### PR TITLE
Free briefs, open compilation, compile-brief status action

### DIFF
--- a/functions/api/brief/[date]/index.js
+++ b/functions/api/brief/[date]/index.js
@@ -1,6 +1,10 @@
 // GET /api/brief/:date — Read a specific brief by date
-// Gated behind x402 (1000 sats sBTC). Without payment → preview only.
+// When BRIEFS_FREE is true, returns full brief without payment.
+// When false, gated behind x402 (1000 sats sBTC).
 // Date format: YYYY-MM-DD
+
+// ── Free-brief toggle (set false to re-enable x402 paywall) ──
+const BRIEFS_FREE = true;
 
 import {
   CORS, json, err, options, methodNotAllowed,
@@ -39,7 +43,30 @@ export async function onRequest(context) {
     );
   }
 
-  // ── x402 gate ──
+  // ── Free-brief bypass ──
+  if (BRIEFS_FREE) {
+    if (format === 'text') {
+      return new Response(brief.text, {
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Content-Type': 'text/plain; charset=utf-8',
+          'Cache-Control': 'no-store',
+        },
+      });
+    }
+    return new Response(JSON.stringify({
+      date,
+      compiledAt: brief.compiledAt,
+      inscription: brief.inscription || null,
+      ...brief.json,
+      text: brief.text,
+    }), {
+      status: 200,
+      headers: { ...CORS, 'Content-Type': 'application/json' },
+    });
+  }
+
+  // ── x402 gate (active when BRIEFS_FREE = false) ──
   const paymentSig = context.request.headers.get('payment-signature');
 
   if (!paymentSig) {

--- a/public/index.html
+++ b/public/index.html
@@ -1502,34 +1502,7 @@
 
       const brief = briefRes.status === 'fulfilled' ? briefRes.value : null;
 
-      if (brief && brief.preview) {
-        // Brief exists but is behind paywall — show preview summary + signal feed
-        if (brief.summary) {
-          el('stat-correspondents').textContent = brief.summary.correspondents || 0;
-          el('stat-beats').textContent = brief.summary.beats || 0;
-          el('stat-signals').textContent = brief.summary.signals || 0;
-          el('summary-line').style.display = '';
-        }
-        setDate(brief.date);
-        await renderSignalFeed();
-        // Add paywall banner below summary
-        const summaryEl = el('summary-line');
-        if (summaryEl && !document.getElementById('paywall-banner')) {
-          const banner = document.createElement('div');
-          banner.id = 'paywall-banner';
-          banner.className = 'paywall-banner';
-          banner.innerHTML = '<strong>Full Daily Brief Available</strong><span class="paywall-price">1,000 sats sBTC</span><span class="paywall-protocol">via x402</span>';
-          summaryEl.parentNode.insertBefore(banner, summaryEl.nextSibling);
-
-          // Preview beat pills
-          if (brief.beats && brief.beats.length > 0) {
-            const beatsDiv = document.createElement('div');
-            beatsDiv.className = 'preview-beats';
-            beatsDiv.innerHTML = brief.beats.map(b => `<span class="preview-beat-pill">${esc(b)}</span>`).join('');
-            banner.parentNode.insertBefore(beatsDiv, banner.nextSibling);
-          }
-        }
-      } else if (brief && brief.sections && brief.sections.length > 0) {
+      if (brief && brief.sections && brief.sections.length > 0) {
         renderBrief(brief);
       } else {
         // No brief — render raw signal feed
@@ -1614,8 +1587,7 @@
     async function fetchJSON(url) {
       try {
         const res = await fetch(url);
-        // Also parse 402 responses (x402 previews)
-        if (!res.ok && res.status !== 402) return null;
+        if (!res.ok) return null;
         return await res.json();
       } catch { return null; }
     }
@@ -1956,16 +1928,7 @@
       </div>`;
 
       const brief = await fetchJSON(`/api/brief/${date}?format=json`);
-      if (brief && brief.preview) {
-        let archivePaywall = '<div class="paywall-banner"><strong>Brief Available</strong><span class="paywall-price">1,000 sats sBTC</span><span class="paywall-protocol">via x402</span></div>';
-        if (brief.beats && brief.beats.length > 0) {
-          archivePaywall += '<div class="preview-beats">' + brief.beats.map(b => `<span class="preview-beat-pill">${esc(b)}</span>`).join('') + '</div>';
-        }
-        main.innerHTML = archivePaywall;
-        document.querySelectorAll('.archive-pill').forEach(p =>
-          p.classList.toggle('active', p.dataset.date === date)
-        );
-      } else if (brief && brief.sections && brief.sections.length > 0) {
+      if (brief && brief.sections && brief.sections.length > 0) {
         renderBrief(brief);
         document.querySelectorAll('.archive-pill').forEach(p =>
           p.classList.toggle('active', p.dataset.date === date)


### PR DESCRIPTION
## Summary

- **Remove score gate** from `/api/brief/compile` — any registered correspondent can now compile briefs (was: score >= 50 required)
- **Enforce 3-signal minimum** — hard floor rejects with 400 if fewer than 3 signals in the lookback window (no fallback to "most recent 10")
- **Free briefs** via `BRIEFS_FREE = true` flag on both `/api/brief` and `/api/brief/:date` — bypasses x402 paywall, returns full brief at 200. All x402 code preserved behind the flag for easy re-enablement
- **`compile-brief` status action** — `/api/status/:address` now suggests compilation when: agent has a beat, no brief exists for today, and >= 3 signals filed in the last 24h
- **Frontend cleanup** — removed paywall banner branches and 402 special-casing from `fetchJSON`

## Test plan

- [ ] `POST /api/brief/compile` with < 3 signals in window → expect 400
- [ ] `POST /api/brief/compile` with 3+ signals, any correspondent → expect 201
- [ ] `GET /api/brief` without payment header → expect 200 with full brief (not 402 preview)
- [ ] `GET /api/brief/:date` without payment header → expect 200 with full brief
- [ ] `GET /api/status/:address` for correspondent with no brief today + 3 signals → expect `compile-brief` action
- [ ] `GET /api/status/:address` when brief already exists today → no `compile-brief` action
- [ ] Frontend loads brief without paywall banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)