### PR TITLE
feat: add tsconfig.json and CI workflow (fixes #5, #6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npx tsc --noEmit

--- a/functions/api/brief/compile.js
+++ b/functions/api/brief/compile.js
@@ -133,7 +133,7 @@ export async function onRequest(context) {
 
   // Sort signals within each beat by timestamp descending
   for (const beatSignals of Object.values(signalsByBeat)) {
-    beatSignals.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+    beatSignals.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
   }
 
   // Build structured report

--- a/functions/api/report.js
+++ b/functions/api/report.js
@@ -99,7 +99,7 @@ export async function onRequest(context) {
       const beatName = beatData ? beatData.name : beatKey;
 
       // Sort signals within beat by timestamp descending
-      beatSignals.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+      beatSignals.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
 
       for (const signal of beatSignals) {
         const streak = streakMap[signal.btcAddress] || { current: 0 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,37 @@
+{
+  "name": "agent-news",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "agent-news",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20250224.0",
+        "typescript": "^5.7.3"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260301.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260301.1.tgz",
+      "integrity": "sha512-klKnECMb5A4GtVF0P5NH6rCjtyjqIEKJaz6kEtx9YPHhfFO2HUEarO+MI4F8WPchgeZqpGlEpDhRapzrOTw51Q==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "agent-news",
+  "version": "1.0.0",
+  "private": true,
+  "description": "AIBTC News — AI Agent Intelligence Network (Cloudflare Pages)",
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250224.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "strict": false,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "allowJs": true,
+    "checkJs": true
+  },
+  "include": ["functions/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

- Add `tsconfig.json` configured for Cloudflare Workers JavaScript type-checking (`allowJs: true`, `checkJs: true`, `strict: false` as a safe baseline, `@cloudflare/workers-types` included)
- Add `package.json` with `typescript` and `@cloudflare/workers-types` as devDependencies (needed for `npm ci` in CI)
- Add `.github/workflows/ci.yml` running `npm ci` and `npx tsc --noEmit` on every push/PR to `main`
- Fix two latent type errors in `functions/api/brief/compile.js` and `functions/api/report.js`: `Date` subtraction in `.sort()` callbacks now calls `.getTime()` so arithmetic operates on numbers

Closes #5, closes #6.

## Why `strict: false`

The codebase is untyped JavaScript. Enabling `strict: true` immediately produces 100+ implicit-`any` errors across all handlers (the `context`, `kv`, and all function parameters). Rather than flooding the repo with noise or requiring JSDoc annotations on every function, this PR starts with `strict: false` so the CI gate passes cleanly today. Stricter flags (`noImplicitAny`, `strictNullChecks`, etc.) can be turned on incrementally as types are added.

## Test plan

- [x] `npm ci` installs cleanly (2 packages, 0 vulnerabilities)
- [x] `npx tsc --noEmit` exits 0 with the tsconfig in this PR
- [x] CI workflow triggers on push to `main` and on PRs targeting `main`
- [x] No changes to runtime logic — only config files added and `.getTime()` fixes applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)