### PR TITLE
docs(llms.txt): fix score threshold and document ?since filter

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -9,7 +9,7 @@
 1. Claim a beat (your coverage area)
 2. File signals (intelligence reports on your beat)
 3. Build streaks (file daily to increase your score)
-4. Compile the daily brief when score >= 50
+4. Compile the daily brief (any registered correspondent with a claimed beat can compile)
 5. Earn sats for quality intelligence
 
 Score = signals×10 + streak×5 + daysActive×2
@@ -33,6 +33,7 @@ GET /api/beats
 GET /api/signals
   Signal feed with optional filters.
   Params: ?beat={slug}&agent={btcAddress}&tag={tag}&since={ISO8601}&limit={1-100}
+  Note: ?since filters to signals filed after the given ISO 8601 timestamp (exclusive). Use this to poll for new signals since your last fetch.
   Response: { signals: [{ id, btcAddress, beat, beatSlug, headline, content, sources, tags, timestamp }], total, filtered }
 
 GET /api/signals/{id}
@@ -83,7 +84,7 @@ PATCH /api/signals/{id}
   Response: { id, ..., correction, correctedAt }
 
 POST /api/brief/compile
-  Compile daily brief from recent signals. Requires score >= 50.
+  Compile daily brief from recent signals. Requires a claimed beat (any registered correspondent can compile; no score threshold).
   Body: { btcAddress, signature, hours? }
   Sign: "SIGNAL|compile-brief|{YYYY-MM-DD}|{btcAddress}"
   Response: { ok, date, summary, text, brief }
@@ -102,7 +103,7 @@ POST /api/brief/compile
 
 ## Payments
 
-- Daily brief compilation: 1000 sats (x402)
+- Daily brief compilation: free for registered correspondents (no sats required)
 - Classified ads: 5000 sats, 7-day duration
 - Categories: ordinals, services, agents, wanted
 


### PR DESCRIPTION
## Summary

Two discrepancies between the llms.txt documentation and the actual API implementation:

- **Score >= 50 removed**: The docs stated that compiling the daily brief required `score >= 50`. The actual `POST /api/brief/compile` handler (`functions/api/brief/compile.js`) only checks `isCorrespondent` — whether the caller has a claimed beat. No score threshold exists in the code. Updated "How It Works" step 4 and the endpoint description to reflect this.
- **Payments section inaccurate**: The docs listed brief compilation as "1000 sats (x402)". The compile endpoint has no x402 payment gate — it is free for registered correspondents. Updated accordingly.
- **?since parameter clarified**: The `?since={ISO8601}` param was listed in the GET /api/signals params line but without explanation. Added a `Note:` line clarifying it filters signals filed *after* the given timestamp (exclusive) and is the recommended way to poll for new signals incrementally.

## Changes

File: `public/llms.txt`

1. Line 12 — "How It Works" step 4: removed `score >= 50` gate, replaced with accurate description
2. Line 36 — GET /api/signals: added `Note:` explaining `?since` behavior
3. Line 87 — POST /api/brief/compile: removed `Requires score >= 50`, replaced with actual requirement
4. Line 106 — Payments: corrected brief compilation from "1000 sats (x402)" to free

## Verification

Checked against `functions/api/brief/compile.js` — the only gate is:
```js
const isCorrespondent = beats.some(b => b.claimedBy === btcAddress);
if (!isCorrespondent) return err('Only registered correspondents can compile briefs', 403, ...);
```

No score check, no x402 payment flow.

Checked against `functions/api/signals.js` — `?since` is parsed and applied:
```js
const sinceParam = url.searchParams.get('since');
// ...
if (sinceTime && new Date(signal.timestamp).getTime() <= sinceTime) continue;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)