### PR TITLE
chore: migrate wrangler.toml to wrangler.jsonc (closes #7)

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,16 @@
+{
+  // Cloudflare Pages project name
+  "name": "signal-dashboard",
+
+  // Build output directory served by Cloudflare Pages
+  "pages_build_output_dir": "./public",
+
+  // KV namespace bindings
+  "kv_namespaces": [
+    {
+      "binding": "SIGNAL_KV",
+      "id": "a9581bb6ee574b74ae74241433249f47",
+      "preview_id": "aa4a0d5dd3e6451fa5d130c3e7d7c715"
+    }
+  ]
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,7 +1,0 @@
-name = "signal-dashboard"
-pages_build_output_dir = "./public"
-
-[[kv_namespaces]]
-binding = "SIGNAL_KV"
-id = "a9581bb6ee574b74ae74241433249f47"
-preview_id = "aa4a0d5dd3e6451fa5d130c3e7d7c715"


### PR DESCRIPTION
## Summary
- Converts `wrangler.toml` to `wrangler.jsonc` (AIBTC ecosystem standard)
- Adds inline comments documenting each configuration section
- No functional changes -- equivalent configuration in JSON format

## Notes
- Checked main branch source code: only `SIGNAL_KV` binding is used (no Durable Objects or service bindings on main)
- The v2 branch already has its own `wrangler.jsonc` with a different architecture (Workers + DO + service bindings), so this PR only covers the current Pages config on main
- No CI workflows or scripts reference `wrangler.toml`, so no other files needed updating

## Test plan
- [ ] Verify `wrangler pages dev` works with the new config
- [ ] Verify KV bindings are correctly mapped

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)