### PR TITLE
fix: add defensive JSON parsing to prevent 500 errors

### DIFF
--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -37,7 +37,7 @@ function rowToSignal(row: Record<string, unknown>): Signal {
     btc_address: raw.btc_address,
     headline: raw.headline,
     body: raw.body,
-    sources: JSON.parse(raw.sources || "[]"),
+    sources: (() => { try { return JSON.parse(raw.sources || "[]"); } catch (e) { console.error("Failed to parse signal sources:", e); return []; } })(),
     tags: raw.tags_csv ? raw.tags_csv.split(",") : [],
     created_at: raw.created_at,
     updated_at: raw.updated_at,
@@ -595,7 +595,13 @@ export class NewsDO extends DurableObject<Env> {
       const now = new Date();
       const nowIso = now.toISOString();
       const newId = generateId();
-      const sourcesJson = JSON.stringify(sources ?? JSON.parse(original.sources as string));
+      let fallbackSources: unknown = [];
+      try {
+        fallbackSources = JSON.parse(original.sources as string);
+      } catch (e) {
+        console.error(`Failed to parse sources for original signal ${originalId}:`, e);
+      }
+      const sourcesJson = JSON.stringify(sources ?? fallbackSources);
       const sanitizedBody = signalBody
         ? sanitizeString(signalBody, 1000)
         : (original.body as string | null) ?? null;

--- a/src/routes/brief-compile.ts
+++ b/src/routes/brief-compile.ts
@@ -113,7 +113,8 @@ briefCompileRouter.post("/api/brief/compile", compileRateLimit, async (c) => {
     let sources: Source[] | null = null;
     try {
       sources = JSON.parse(sig.sources) as Source[];
-    } catch {
+    } catch (e) {
+      console.error(`Failed to parse sources for signal ${sig.id}:`, e);
       sources = null;
     }
 

--- a/src/routes/brief.ts
+++ b/src/routes/brief.ts
@@ -31,7 +31,14 @@ briefRouter.get("/api/brief", async (c) => {
     });
   }
 
-  const jsonData = brief.json_data ? (JSON.parse(brief.json_data) as Record<string, unknown>) : {};
+  let jsonData: Record<string, unknown> = {};
+  if (brief.json_data) {
+    try {
+      jsonData = JSON.parse(brief.json_data) as Record<string, unknown>;
+    } catch (e) {
+      console.error(`Failed to parse json_data for latest brief:`, e);
+    }
+  }
 
   return c.json({
     date: brief.date,
@@ -102,7 +109,14 @@ briefRouter.get("/api/brief/:date", async (c) => {
     });
   }
 
-  const jsonData = brief.json_data ? (JSON.parse(brief.json_data) as Record<string, unknown>) : {};
+  let jsonData: Record<string, unknown> = {};
+  if (brief.json_data) {
+    try {
+      jsonData = JSON.parse(brief.json_data) as Record<string, unknown>;
+    } catch (e) {
+      console.error(`Failed to parse json_data for brief ${date}:`, e);
+    }
+  }
 
   return c.json({
     date: brief.date,


### PR DESCRIPTION
## Summary
- Wraps bare `JSON.parse()` calls in try-catch to prevent 500 errors from corrupted stored data
- Adds error logging for silent parse failures in brief-compile.ts
- Adds defensive parsing in news-do.ts for signal source data
- Prevents user-facing errors when `json_data` or `sources` fields contain invalid JSON

## Changes
- `src/routes/brief.ts`: wrap `JSON.parse(brief.json_data)` in try-catch with `{}` fallback (both endpoints)
- `src/routes/brief-compile.ts`: add `console.error` logging when `JSON.parse(sig.sources)` fails
- `src/objects/news-do.ts`: wrap bare `JSON.parse(raw.sources)` and `JSON.parse(original.sources)` in try-catch with `[]` fallback

## Test plan
- [ ] Verify briefs with valid json_data still render correctly
- [ ] Verify briefs with corrupted/null json_data gracefully degrade instead of 500
- [ ] Verify signals with corrupted sources field don't crash compilation
- [ ] Verify corrections of signals with corrupted sources still succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)