### PR TITLE
Migrate wrangler.toml to wrangler.jsonc

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,17 @@
+{
+  // Cloudflare Pages project name
+  "name": "signal-dashboard",
+
+  // Build output directory served by Cloudflare Pages
+  "pages_build_output_dir": "./public",
+
+  // KV namespace bindings available to Pages Functions
+  "kv_namespaces": [
+    {
+      // KV store for signal/dashboard data
+      "binding": "SIGNAL_KV",
+      "id": "a9581bb6ee574b74ae74241433249f47",
+      "preview_id": "aa4a0d5dd3e6451fa5d130c3e7d7c715"
+    }
+  ]
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,7 +1,0 @@
-name = "signal-dashboard"
-pages_build_output_dir = "./public"
-
-[[kv_namespaces]]
-binding = "SIGNAL_KV"
-id = "a9581bb6ee574b74ae74241433249f47"
-preview_id = "aa4a0d5dd3e6451fa5d130c3e7d7c715"


### PR DESCRIPTION
## Summary
- Converts `wrangler.toml` to `wrangler.jsonc` format for ecosystem consistency across AIBTC projects
- All existing settings preserved: project name (`signal-dashboard`), build output dir (`./public`), KV namespace binding (`SIGNAL_KV`)
- Added inline JSONC comments documenting each configuration section

Closes #22

## Changes
| File | Action |
|------|--------|
| `wrangler.jsonc` | Created — faithful conversion from TOML with inline comments |
| `wrangler.toml` | Deleted |

## Test plan
- [ ] Verify `wrangler pages dev` works with the new config file
- [ ] Verify `wrangler pages deploy` works with the new config file
- [ ] Confirm KV binding `SIGNAL_KV` is available in Pages Functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)