### PR TITLE
Add tsconfig.json for JS type checking

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "forceConsistentCasingInFileNames": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true
+  },
+  "include": ["functions/**/*.js"],
+  "exclude": ["node_modules", ".wrangler"]
+}


### PR DESCRIPTION
## Summary
- Adds `tsconfig.json` at root to enable TypeScript-powered type checking on existing JS files
- IDE-only config (`noEmit: true`) — no build step changes, Wrangler continues deploying `.js` directly
- `allowJs` + `checkJs` enables gradual type safety without renaming files

Closes #20

## Details
- `strict: true` catches implicit any, null/undefined, missing returns
- `lib: ["ES2022"]` matches Workers runtime (no DOM APIs)
- `moduleResolution: "bundler"` per Cloudflare convention
- Developers can run `npx tsc --noEmit` locally to validate

## Test plan
- [x] Verify config is valid JSON
- [x] No build step affected (Wrangler deploys .js directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)