### PR TITLE
feat(config): migrate wrangler.toml to wrangler.jsonc

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,19 @@
+{
+  // Project name — used as the Cloudflare Pages / Workers identifier
+  "name": "signal-dashboard",
+
+  // Directory that Cloudflare Pages will serve as the static site
+  "pages_build_output_dir": "./public",
+
+  // KV namespace bindings — key/value storage used at runtime
+  "kv_namespaces": [
+    {
+      // Name exposed to Worker functions as `env.SIGNAL_KV`
+      "binding": "SIGNAL_KV",
+      // Production namespace ID
+      "id": "a9581bb6ee574b74ae74241433249f47",
+      // Preview (local dev / staging) namespace ID
+      "preview_id": "aa4a0d5dd3e6451fa5d130c3e7d7c715"
+    }
+  ]
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,7 +1,0 @@
-name = "signal-dashboard"
-pages_build_output_dir = "./public"
-
-[[kv_namespaces]]
-binding = "SIGNAL_KV"
-id = "a9581bb6ee574b74ae74241433249f47"
-preview_id = "aa4a0d5dd3e6451fa5d130c3e7d7c715"


### PR DESCRIPTION
## Summary

- Replaces `wrangler.toml` with `wrangler.jsonc` (JSONC = JSON with Comments)
- Adds inline comments documenting each configuration section: project name, Pages build output dir, and KV namespace bindings
- All values are unchanged — this is a format-only migration

## Why

Wrangler supports `wrangler.jsonc` natively. The JSONC format allows comments directly in the config file, making it easier for contributors to understand what each field does without consulting external docs.

Closes #22

## Test plan

- [ ] Run `wrangler pages dev` locally and confirm it picks up `wrangler.jsonc` correctly
- [ ] Confirm KV namespace binding `SIGNAL_KV` is accessible in function handlers
- [ ] Verify no CI failures from the format change

🤖 Generated with [Claude Code](https://claude.com/claude-code)