### PR TITLE
fix(brief): promote BRIEFS_FREE from hardcoded constant to env var

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -50,4 +50,3 @@ export const BEAT_EXPIRY_DAYS = 14;
 // ── Brief paywall ──
 export const BRIEF_PRICE_SATS = 1000;
 export const CORRESPONDENT_SHARE = 0.7;
-export const BRIEFS_FREE = true;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -48,6 +48,8 @@ export interface Env {
   ENVIRONMENT?: string;
   // Shared secret for POST /api/internal/migrate endpoints (set via wrangler secret put)
   MIGRATION_KEY?: string;
+  // Set to "false" to enable x402 paywall for past briefs (default: "true" = free access)
+  BRIEFS_FREE?: string;
 }
 
 /**

--- a/src/routes/brief.ts
+++ b/src/routes/brief.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import type { Env, AppVariables } from "../lib/types";
 import { getLatestBrief, getBriefByDate, listBriefDates, recordEarning } from "../lib/do-client";
-import { BRIEFS_FREE, BRIEF_PRICE_SATS, CORRESPONDENT_SHARE } from "../lib/constants";
+import { BRIEF_PRICE_SATS, CORRESPONDENT_SHARE } from "../lib/constants";
 import { buildPaymentRequired, verifyPayment } from "../services/x402";
 
 const briefRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>();
@@ -74,7 +74,8 @@ briefRouter.get("/api/brief/:date", async (c) => {
   }
 
   // x402 paywall for past briefs (when not free)
-  if (!BRIEFS_FREE) {
+  const briefsFree = c.env.BRIEFS_FREE !== "false";
+  if (!briefsFree) {
     const paymentHeader =
       c.req.header("X-PAYMENT") ?? c.req.header("payment-signature");
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -13,7 +13,9 @@
   "routes": [{ "pattern": "aibtc.news", "custom_domain": true }],
 
   "vars": {
-    "ENVIRONMENT": "production"
+    "ENVIRONMENT": "production",
+    // Set to "false" to enable x402 paywall for past briefs; any other value (or omit) = free access
+    "BRIEFS_FREE": "true"
   },
 
   // KV namespace — rate limiting and agent cache


### PR DESCRIPTION
Fixes #44.

## What

`BRIEFS_FREE` was hardcoded as `true` in `constants.ts` with no way to toggle the brief paywall without a code change. This PR promotes it to a proper Cloudflare Worker env var.

## Changes

- **`src/lib/constants.ts`** — Remove `BRIEFS_FREE` (was always `true`, never read from env)
- **`src/lib/types.ts`** — Add `BRIEFS_FREE?: string` to `Env` interface to match wrangler binding
- **`src/routes/brief.ts`** — Read `c.env.BRIEFS_FREE` at request time; default is free (`!== "false"`)
- **`wrangler.jsonc`** — Document `BRIEFS_FREE: "true"` in `vars` with a usage comment

## Behavior

| `BRIEFS_FREE` env value | Effect |
|------------------------|--------|
| `"true"` (default) | Briefs are free — no x402 paywall |
| omitted | Same as `"true"` — free access |
| `"false"` | x402 paywall active for past briefs |

To enable the paywall: set `BRIEFS_FREE = "false"` in your Cloudflare dashboard or via `wrangler vars put BRIEFS_FREE false`.

## Operational context

Running this in prod — the sensor that monitors brief compilation has been watching this toggle. The hardcoded `true` was fine for launch, but now that the classifieds x402 flow is proven, being able to flip the brief paywall without a deploy is table stakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)