### PR TITLE
fix(auth): surface clear error for taproot (bc1p) auth attempts

### DIFF
--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -50,7 +50,7 @@ export interface AuthHeaders {
 export interface AuthResult {
   valid: boolean;
   error?: string;
-  code?: "MISSING_AUTH" | "EXPIRED_TIMESTAMP" | "ADDRESS_MISMATCH" | "INVALID_SIGNATURE";
+  code?: "MISSING_AUTH" | "EXPIRED_TIMESTAMP" | "ADDRESS_MISMATCH" | "INVALID_SIGNATURE" | "UNSUPPORTED_ADDRESS_TYPE";
 }
 
 // ── Constants ──
@@ -320,6 +320,14 @@ export function verifyAuth(
       valid: false,
       error: "Missing authentication headers: X-BTC-Address, X-BTC-Signature, X-BTC-Timestamp",
       code: "MISSING_AUTH",
+    };
+  }
+
+  if (authHeaders.address.startsWith("bc1p")) {
+    return {
+      valid: false,
+      error: "P2TR taproot addresses are not supported for BIP-322 auth; use a P2WPKH (bc1q) address",
+      code: "UNSUPPORTED_ADDRESS_TYPE",
     };
   }
 


### PR DESCRIPTION
## Summary

Closes #43

- Added `UNSUPPORTED_ADDRESS_TYPE` to the `AuthResult` error code union
- In `verifyAuth`, check if the address starts with `bc1p` immediately after extracting headers — before timestamp/signature checks — and return a specific error message

**Error returned:**
```json
{
  "valid": false,
  "code": "UNSUPPORTED_ADDRESS_TYPE",
  "error": "P2TR taproot addresses are not supported for BIP-322 auth; use a P2WPKH (bc1q) address"
}
```

## Operational context

This came up in production — taproot wallets are common (Leather defaults to bc1p for some operations), and the previous generic 401 sent agents down a debugging rabbit hole. The new error codes cleanly, and API consumers can branch on `UNSUPPORTED_ADDRESS_TYPE` to redirect users.

## Test plan

- [ ] POST to a write endpoint (e.g. `/api/classifieds`) with a `bc1p` address in `X-BTC-Address` → expect 401 + `UNSUPPORTED_ADDRESS_TYPE` code + descriptive message
- [ ] Same test with a `bc1q` address → verify existing auth flow unchanged
- [ ] Verify TypeScript compiles cleanly (`bun build` or `tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)