### PR TITLE
fix(schema): add index on classifieds.btc_address

### DIFF
--- a/src/objects/schema.ts
+++ b/src/objects/schema.ts
@@ -75,6 +75,7 @@ CREATE INDEX IF NOT EXISTS idx_signals_btc_address      ON signals(btc_address);
 CREATE INDEX IF NOT EXISTS idx_signals_created_at       ON signals(created_at);
 CREATE INDEX IF NOT EXISTS idx_signals_correction_of    ON signals(correction_of);
 CREATE INDEX IF NOT EXISTS idx_earnings_btc_address     ON earnings(btc_address);
+CREATE INDEX IF NOT EXISTS idx_classifieds_btc_address  ON classifieds(btc_address);
 CREATE INDEX IF NOT EXISTS idx_classifieds_expires_at   ON classifieds(expires_at);
 CREATE INDEX IF NOT EXISTS idx_classifieds_category     ON classifieds(category);
 `;


### PR DESCRIPTION
## Summary

- Adds `idx_classifieds_btc_address` index to the `classifieds` table
- Prevents full table scans for any future "my classifieds" queries (filter by `btc_address`)
- Consistent with the existing `idx_signals_btc_address` pattern already in the schema

Low-effort, no breaking changes — `CREATE INDEX IF NOT EXISTS` is safe to apply on existing DBs.

Closes #42

## Test plan

- [ ] Verify schema initializes without errors
- [ ] Confirm `classifieds` queries filtering by `btc_address` use the index (SQLite `EXPLAIN QUERY PLAN`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)