### PR TITLE
fix(x402): distinguish relay errors from invalid payments

### DIFF
--- a/src/routes/classifieds.ts
+++ b/src/routes/classifieds.ts
@@ -171,6 +171,15 @@ classifiedsRouter.post(
     const verification = await verifyPayment(paymentHeader, CLASSIFIED_PRICE_SATS);
     if (!verification.valid) {
       const logger = c.get("logger");
+      if (verification.relayError) {
+        logger.error("relay error during payment verification for POST /api/classifieds", {
+          btc_address,
+        });
+        return c.json(
+          { error: "Payment relay unavailable. Your payment was not consumed — please retry shortly." },
+          503
+        );
+      }
       logger.warn("payment verification failed for POST /api/classifieds", {
         btc_address,
       });

--- a/src/services/x402.ts
+++ b/src/services/x402.ts
@@ -20,6 +20,13 @@ export interface PaymentVerifyResult {
   valid: boolean;
   txid?: string;
   payer?: string;
+  /**
+   * True when the failure is a transient relay error (network timeout, 5xx,
+   * parse failure) rather than the payment itself being invalid.
+   * Callers should return 503 instead of 402 in this case so that a user
+   * who already paid does not retry payment unnecessarily.
+   */
+  relayError?: boolean;
 }
 
 /**
@@ -67,16 +74,22 @@ export function buildPaymentRequired(opts: PaymentRequiredOpts): Response {
 /**
  * Verify an x402 payment via the relay's /settle endpoint.
  * The paymentHeader is the value of the X-PAYMENT or payment-signature header.
+ *
+ * Result semantics:
+ *   { valid: true }                    — payment verified, proceed
+ *   { valid: false }                   — payment invalid (bad sig, wrong amount, etc.)
+ *   { valid: false, relayError: true } — transient relay failure; caller should 503
  */
 export async function verifyPayment(
   paymentHeader: string,
   amount: number
 ): Promise<PaymentVerifyResult> {
+  let settleRes: Response;
+
   try {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 10_000);
 
-    let settleRes: Response;
     try {
       settleRes = await fetch(`${X402_RELAY_URL}/api/v1/settle`, {
         method: "POST",
@@ -96,30 +109,43 @@ export async function verifyPayment(
     } finally {
       clearTimeout(timeoutId);
     }
-
-    const result = (await settleRes.json()) as Record<string, unknown>;
-
-    if (!settleRes.ok || !result.success) {
-      return { valid: false };
-    }
-
-    // Decode payment header for payer info
-    let paymentData: Record<string, unknown> = {};
-    try {
-      paymentData = JSON.parse(atob(paymentHeader)) as Record<string, unknown>;
-    } catch {
-      // ignore decode errors
-    }
-
-    return {
-      valid: true,
-      txid: (result.txid as string | undefined) || (paymentData.txid as string | undefined),
-      payer:
-        (result.payer as string | undefined) ||
-        (paymentData.btcAddress as string | undefined) ||
-        (paymentData.from as string | undefined),
-    };
   } catch {
+    // Network error or timeout — relay unreachable, not a payment problem
+    return { valid: false, relayError: true };
+  }
+
+  // 5xx from relay = relay-side problem, not an invalid payment
+  if (settleRes.status >= 500) {
+    return { valid: false, relayError: true };
+  }
+
+  let result: Record<string, unknown>;
+  try {
+    result = (await settleRes.json()) as Record<string, unknown>;
+  } catch {
+    // Unexpected non-JSON body from relay = relay error
+    return { valid: false, relayError: true };
+  }
+
+  if (!settleRes.ok || !result.success) {
+    // 4xx or success:false = payment genuinely invalid
     return { valid: false };
   }
+
+  // Decode payment header for payer info
+  let paymentData: Record<string, unknown> = {};
+  try {
+    paymentData = JSON.parse(atob(paymentHeader)) as Record<string, unknown>;
+  } catch {
+    // ignore decode errors
+  }
+
+  return {
+    valid: true,
+    txid: (result.txid as string | undefined) || (paymentData.txid as string | undefined),
+    payer:
+      (result.payer as string | undefined) ||
+      (paymentData.btcAddress as string | undefined) ||
+      (paymentData.from as string | undefined),
+  };
 }


### PR DESCRIPTION
## Summary

Fixes #41.

When `verifyPayment()` returns `{ valid: false }` due to a transient relay failure (network timeout, 5xx from relay, malformed response), the caller was returning another 402 — indistinguishable from "payment invalid." A user who already paid would retry payment and waste sBTC.

**Changes:**

- **`src/services/x402.ts`** — adds `relayError?: boolean` to `PaymentVerifyResult`. Now distinguishes three outcomes:
  - `{ valid: true }` — payment verified
  - `{ valid: false }` — payment genuinely invalid (4xx from relay, `success: false`)
  - `{ valid: false, relayError: true }` — transient relay problem (network error, timeout, 5xx, non-JSON body)

- **`src/routes/classifieds.ts`** — checks `verification.relayError` before falling through to 402. Returns 503 with `"Payment relay unavailable. Your payment was not consumed — please retry shortly."` message.

## Why this matters operationally

We run this in production. x402-sponsor-relay v1.18.0 improved nonce backoff (1s→30s), but NONCE_CONFLICT and other transient relay failures still occur during high-load windows. We've observed classifieds failures that are relay-side — not payment-side — being surfaced as 402s. This fix makes the distinction explicit and actionable for callers.

## Test plan

- [ ] Relay unreachable → POST /api/classifieds returns 503 (not 402)
- [ ] Relay returns 5xx → POST /api/classifieds returns 503
- [ ] Relay returns `success: false` with 200 → returns 402 (payment required)
- [ ] Relay returns `success: true` → classified created, 201

🤖 Generated with [Claude Code](https://claude.com/claude-code)