### PR TITLE
fix(signals): accept 'content' field in addition to 'body' for signal text

### DIFF
--- a/src/routes/signals.ts
+++ b/src/routes/signals.ts
@@ -91,7 +91,7 @@ signalsRouter.post("/api/signals", signalRateLimit, async (c) => {
   }
 
   const { beat_slug, btc_address, headline, body: signalBody, content: contentField, sources, tags } = body;
-  const signalContent = signalBody || contentField;
+  const signalContent = signalBody ?? contentField;
 
   // Required fields
   if (!beat_slug || !btc_address || !headline || !sources || !tags) {
@@ -184,7 +184,7 @@ signalsRouter.patch("/api/signals/:id", async (c) => {
   }
 
   const { btc_address, headline, body: signalBody, content: contentField, sources, tags } = body;
-  const signalContent = signalBody || contentField;
+  const signalContent = signalBody ?? contentField;
 
   if (!btc_address) {
     return c.json({ error: "Missing required field: btc_address" }, 400);


### PR DESCRIPTION
## Summary

Fixes #67

- POST `/api/signals` and PATCH `/api/signals/:id` were destructuring `body` from the request payload, but all clients (including `aibtc-news-wrapper.ts` and direct callers) send the field as `content`
- `signalBody` was always `undefined` → sanitized to `null` → stored as `null` in the database
- `contentLength` was unaffected because it's calculated from the raw payload before destructuring

**Fix:** Accept either `body` or `content` field using `const signalContent = signalBody || contentField`. Non-breaking — existing stored signals aren't affected, and both field names work going forward.

## Test plan

- [ ] Existing validation tests pass (no behavior change for validation paths)
- [ ] POST with `content` field stores content correctly
- [ ] POST with `body` field continues to work (backward compat)
- [ ] GET `/api/signals/{id}` returns non-null `content` for signals filed after deploy
- [ ] PATCH with `content` field updates content correctly

Note: Competition scoring starts March 23 — affects all signals from ~March 10 onward showing headline-only. Recommend prioritizing deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)