### PR TITLE
fix(schema): remove index crash blocking DO constructor

### DIFF
--- a/src/objects/schema.ts
+++ b/src/objects/schema.ts
@@ -119,7 +119,6 @@ CREATE INDEX IF NOT EXISTS idx_earnings_btc_address     ON earnings(btc_address)
 CREATE INDEX IF NOT EXISTS idx_classifieds_btc_address  ON classifieds(btc_address);
 CREATE INDEX IF NOT EXISTS idx_classifieds_expires_at   ON classifieds(expires_at);
 CREATE INDEX IF NOT EXISTS idx_classifieds_category     ON classifieds(category);
-CREATE INDEX IF NOT EXISTS idx_signals_status           ON signals(status);
 CREATE INDEX IF NOT EXISTS idx_brief_signals_address    ON brief_signals(btc_address);
 CREATE INDEX IF NOT EXISTS idx_brief_signals_date       ON brief_signals(brief_date);
 CREATE INDEX IF NOT EXISTS idx_corrections_signal       ON corrections(signal_id);


### PR DESCRIPTION
## Summary

- **Production is down** — every API endpoint returns 500, landing page is blank, archive is empty
- Root cause: `SCHEMA_SQL` creates `idx_signals_status` on `signals(status)`, but on the existing production DO the `status` column doesn't exist yet (it's added by `MIGRATION_PHASE0_SQL`)
- Since `sql.exec()` runs the entire `SCHEMA_SQL` as one batch, the index creation crashes the DO constructor before the migration ever runs
- Fix: remove the duplicate index from `SCHEMA_SQL` — it's already in `MIGRATION_PHASE0_SQL` where it runs after the column is added

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] All 114 tests pass
- [ ] After merge + deploy, verify `https://aibtc.news/api/beats` returns data instead of 500
- [ ] Verify landing page loads with signal feed
- [ ] Verify archive page shows brief history

🤖 Generated with [Claude Code](https://claude.com/claude-code)