### PR TITLE
fix(beats): remove duplicate agentic-trading slug

### DIFF
--- a/src/__tests__/schema-migration.test.ts
+++ b/src/__tests__/schema-migration.test.ts
@@ -64,5 +64,6 @@ describe("DO constructor: schema initialization", () => {
     expect(slugs).not.toContain("btc-macro");
     expect(slugs).not.toContain("agent-commerce");
     expect(slugs).not.toContain("protocol-infra");
+    expect(slugs).not.toContain("agentic-trading");
   });
 });

--- a/src/objects/schema.ts
+++ b/src/objects/schema.ts
@@ -233,11 +233,20 @@ export const MIGRATION_BEAT_RESTRUCTURE_SQL = `
     AND EXISTS (SELECT 1 FROM beats WHERE slug = 'protocol-infra')
     AND (SELECT created_by FROM beats WHERE slug = 'protocol-infra') != 'system';
 
+  -- agentic-trading claim carries to agent-trading (rename)
+  UPDATE beats SET
+    created_by = (SELECT created_by FROM beats WHERE slug = 'agentic-trading'),
+    created_at = (SELECT created_at FROM beats WHERE slug = 'agentic-trading')
+  WHERE slug = 'agent-trading'
+    AND EXISTS (SELECT 1 FROM beats WHERE slug = 'agentic-trading')
+    AND (SELECT created_by FROM beats WHERE slug = 'agentic-trading') != 'system';
+
   -- ── Phase C: Remap signals.beat_slug ───────────────────────────────────
   -- Renames: old slug → new slug
   UPDATE signals SET beat_slug = 'bitcoin-macro' WHERE beat_slug = 'btc-macro';
   UPDATE signals SET beat_slug = 'agent-economy' WHERE beat_slug = 'agent-commerce';
   UPDATE signals SET beat_slug = 'aibtc-network' WHERE beat_slug = 'network-ops';
+  UPDATE signals SET beat_slug = 'agent-trading' WHERE beat_slug = 'agentic-trading';
   -- Merges: multiple old slugs → single new slug
   UPDATE signals SET beat_slug = 'ordinals' WHERE beat_slug IN ('ordinals-business', 'ordinals-culture');
   UPDATE signals SET beat_slug = 'dev-tools' WHERE beat_slug = 'protocol-infra';
@@ -246,5 +255,5 @@ export const MIGRATION_BEAT_RESTRUCTURE_SQL = `
   UPDATE signals SET beat_slug = 'bitcoin-macro' WHERE beat_slug = 'fee-weather';
 
   -- ── Phase D: Delete old beats (all signals remapped above) ─────────────
-  DELETE FROM beats WHERE slug IN ('btc-macro', 'agent-commerce', 'network-ops', 'ordinals-business', 'ordinals-culture', 'protocol-infra', 'defi-yields', 'fee-weather');
+  DELETE FROM beats WHERE slug IN ('btc-macro', 'agent-commerce', 'network-ops', 'ordinals-business', 'ordinals-culture', 'protocol-infra', 'defi-yields', 'fee-weather', 'agentic-trading');
 `;


### PR DESCRIPTION
## Summary

- The `MIGRATION_BEAT_RESTRUCTURE_SQL` (PR #106) missed the `agentic-trading` → `agent-trading` rename
- Production has both slugs alive — `GET /api/beats` returns 18 instead of 17
- Ionic Anvil confirmed this via MCP tools on 2026-03-18 ([gist comment](https://gist.github.com/cedarxyz/53d08487b7bd3ce990e6b8f1f9bf1af1?permalink_comment_id=6038814#gistcomment-6038814))

## Changes

Three additions to `MIGRATION_BEAT_RESTRUCTURE_SQL` in `src/objects/schema.ts`:

1. **Phase B** — Preserve correspondent claim from `agentic-trading` → `agent-trading` (same pattern as other renames)
2. **Phase C** — Remap signals: `UPDATE signals SET beat_slug = 'agent-trading' WHERE beat_slug = 'agentic-trading'`
3. **Phase D** — Add `'agentic-trading'` to the DELETE list

Test assertion added: `agentic-trading` must not appear in `GET /api/beats` response.

All SQL is idempotent — safe to re-run on already-migrated DBs (UPDATE where no rows match = no-op, DELETE where slug doesn't exist = no-op).

## Test plan

- [x] All 119 existing tests pass (`npx vitest run`)
- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [x] New test assertion verifies `agentic-trading` excluded from beat list
- [ ] After deploy: `GET /api/beats` returns exactly 17 beats
- [ ] After deploy: no signals orphaned under `agentic-trading` slug

Closes the duplicate-slug portion of the Phase 0 checklist (§13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)