### PR TITLE
fix(payments): correct payout constants to match spec

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -6,13 +6,13 @@ export const X402_RELAY_URL = "https://x402-relay.aibtc.com";
 
 // ── Correspondent payout amounts (satoshis) ──
 /** Fixed payout per signal included in a compiled brief (≈$25 at $100k/BTC). */
-export const BRIEF_INCLUSION_PAYOUT_SATS = 2500;
+export const BRIEF_INCLUSION_PAYOUT_SATS = 25000;
 /** Weekly leaderboard 1st-place prize (≈$200 at $100k/BTC). */
-export const WEEKLY_PRIZE_1ST_SATS = 20000;
+export const WEEKLY_PRIZE_1ST_SATS = 200000;
 /** Weekly leaderboard 2nd-place prize (≈$100 at $100k/BTC). */
-export const WEEKLY_PRIZE_2ND_SATS = 10000;
+export const WEEKLY_PRIZE_2ND_SATS = 100000;
 /** Weekly leaderboard 3rd-place prize (≈$50 at $100k/BTC). */
-export const WEEKLY_PRIZE_3RD_SATS = 5000;
+export const WEEKLY_PRIZE_3RD_SATS = 50000;
 
 export const CLASSIFIED_PRICE_SATS = 5000;
 export const CLASSIFIED_DURATION_DAYS = 7;


### PR DESCRIPTION
## Summary
- Updates four correspondent payout constants in `src/lib/constants.ts` to match the dollar targets documented in inline comments (at $100K/BTC pricing basis)
- `BRIEF_INCLUSION_PAYOUT_SATS`: 2,500 → 25,000 ($25)
- `WEEKLY_PRIZE_1ST_SATS`: 20,000 → 200,000 ($200)
- `WEEKLY_PRIZE_2ND_SATS`: 10,000 → 100,000 ($100)
- `WEEKLY_PRIZE_3RD_SATS`: 5,000 → 50,000 ($50)

## Test plan
- [ ] Verify constants match the dollar values in comments
- [ ] TypeScript build passes
- [ ] No other references to old values

🤖 Generated with [Claude Code](https://claude.com/claude-code)