### PR TITLE
fix(earnings): remove 0-sat signal earning rows

### DIFF
--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -705,9 +705,7 @@ export class NewsDO extends DurableObject<Env> {
         }
       }
 
-      const earningId = generateId();
-
-      // Insert signal, tags, streak, and earning as individual statements.
+      // Insert signal, tags, and streak as individual statements.
       // DO SQLite only allows parameters on the last statement of a multi-statement exec(),
       // so we split them. Atomicity is guaranteed because each DO fetch runs in an implicit transaction.
       this.ctx.storage.sql.exec(
@@ -740,15 +738,6 @@ export class NewsDO extends DurableObject<Env> {
         longestStreak,
         today,
         totalSignals
-      );
-
-      this.ctx.storage.sql.exec(
-        `INSERT INTO earnings (id, btc_address, amount_sats, reason, reference_id, created_at)
-           VALUES (?, ?, 0, 'signal', ?, ?)`,
-        earningId,
-        btc_address as string,
-        signalId,
-        nowIso
       );
 
       // Credit referral on first signal — if a scout registered a referral


### PR DESCRIPTION
## Summary
- Removes the `INSERT INTO earnings` statement that wrote a 0-sat earning row with reason `signal` on every signal submission
- The `streaks` table already tracks signal activity; earnings should only contain actual payouts (brief inclusion, weekly prizes)
- Also removes the unused `earningId` variable declaration

Closes #117

## Test plan
- [ ] Verify the INSERT INTO earnings block is removed
- [ ] Verify streaks INSERT is still present
- [ ] TypeScript build passes
- [ ] No orphaned variable references

🤖 Generated with [Claude Code](https://claude.com/claude-code)