### PR TITLE
feat(front-page): add submitted-signal fallback with pending review banner

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2827,7 +2827,79 @@
       }
 
       if (signals.length === 0) {
-        main.innerHTML = emptyBriefHTML(todayStr);
+        // Secondary fallback: show submitted signals with "pending review" indicator
+        let submittedSignals = [];
+        try {
+          const now = Date.now();
+          const cutoff = new Date(now - 48 * 60 * 60 * 1000).toISOString();
+          const submittedData = await fetchJSON(`/api/signals?status=submitted&limit=7`);
+          submittedSignals = (submittedData && Array.isArray(submittedData.signals))
+            ? submittedData.signals.filter(s => s.timestamp && s.timestamp > cutoff)
+            : [];
+        } catch (_) { /* fallback to empty state if this fetch fails */ }
+
+        if (submittedSignals.length === 0) {
+          main.innerHTML = emptyBriefHTML(todayStr);
+          renderRoster(beats, correspondentsList);
+          return;
+        }
+
+        // Render submitted signals with a pending-review banner
+        const pendingBanner = `
+          <div class="pending-review-banner fade-in" style="background:rgba(255,193,7,0.12);border-left:4px solid #ffc107;padding:10px 16px;margin-bottom:16px;border-radius:4px;">
+            <strong>&#x23F3; Pending Editorial Review</strong>
+            <span style="color:var(--text-muted,#888);font-size:0.9em;margin-left:8px;">These signals have been submitted and are awaiting curation. Curated signals will appear here once reviewed.</span>
+          </div>`;
+
+        const agents = new Set(submittedSignals.map(s => s.btcAddress));
+        const beatSlugs = new Set(submittedSignals.map(s => s.beatSlug || s.beat));
+        if (el('stat-correspondents')) el('stat-correspondents').textContent = agents.size;
+        if (el('stat-beats')) el('stat-beats').textContent = beatSlugs.size;
+        if (el('stat-signals')) el('stat-signals').textContent = submittedSignals.length;
+        if (el('summary-line')) el('summary-line').style.display = '';
+
+        const beatMap = {};
+        for (const b of beats) beatMap[b.slug] = b;
+
+        const submittedSections = submittedSignals.map(s => ({
+          beat: s.beat,
+          beatSlug: s.beatSlug || s.beat,
+          correspondent: s.btcAddress,
+          correspondentShort: truncAddr(s.btcAddress),
+          timestamp: s.timestamp,
+          headline: s.headline || null,
+          content: s.content,
+          sources: s.sources || null,
+          tags: s.tags || null,
+          streak: 0,
+          correction: null,
+          correctedAt: null,
+        }));
+
+        const grouped = groupByBeat(submittedSections);
+        const allItems = [];
+        for (const [key, group] of Object.entries(grouped)) {
+          for (const section of group.sections) {
+            allItems.push({ section, beat: beatMap[section.beatSlug] || beatMap[key] });
+          }
+        }
+
+        let submittedHtml;
+        if (allItems.length >= 2) {
+          submittedHtml = '<div class="has-mosaic"><div class="brief-mosaic-top">';
+          const leadToggle = '<button class="story-expand-toggle" onclick="openSignalModal(this)">Read more &#9658;</button>';
+          submittedHtml += `<div class="brief-story brief-lead" onclick="openSignalModal(this)">${renderLead(allItems[0].section, allItems[0].beat)}${leadToggle}</div>`;
+          for (let i = 1; i < allItems.length; i++) {
+            const toggle = '<button class="story-expand-toggle" onclick="openSignalModal(this)">Read more &#9658;</button>';
+            submittedHtml += `<div class="brief-story brief-card" onclick="openSignalModal(this)">${renderColumn(allItems[i].section, allItems[i].beat)}${toggle}</div>`;
+          }
+          submittedHtml += '</div></div>';
+        } else {
+          submittedHtml = renderLead(allItems[0].section, allItems[0].beat);
+        }
+
+        main.innerHTML = pendingBanner + submittedHtml;
+        hydrateAgentIdentities(main);
         renderRoster(beats, correspondentsList);
         return;
       }


### PR DESCRIPTION
## Summary

Implements the submitted-signal fallback from issue #112.

**Before:** When no curated signals exist for today, the front page showed a static "No Brief Compiled" message.

**After:** Before falling back to the empty state, the front page now:
1. Fetches `/api/signals?status=submitted&limit=7`
2. Filters to signals submitted within the last 48 hours
3. Renders them with a distinct amber "Pending Editorial Review" banner
4. Only shows "No Brief Compiled" if there are also no recent submitted signals

This gives visitors something to read while signals queue for review, and gives agents immediate visual confirmation that their submitted signal was received.

## Test plan
- [ ] With no curated brief and no submitted signals: shows "No Brief Compiled" (unchanged)
- [ ] With no curated brief but submitted signals: shows pending banner + submitted signals
- [ ] With curated signals: shows curated signals normally (unchanged)
- [ ] Error in submitted-signal fetch is silent (try/catch) — falls through to empty state

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)