### PR TITLE
fix(earnings): add Phase 5 migration to delete historical 0-sat signal rows

### DIFF
--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -5,7 +5,7 @@ import type { Env, Beat, Signal, SignalStatus, Streak, Brief, Classified, Earnin
 import { validateSlug, validateHexColor, sanitizeString } from "../lib/validators";
 import { generateId, getPacificDate, getPacificYesterday, getPacificDayStartUTC, getNextDate } from "../lib/helpers";
 import { CLASSIFIED_DURATION_DAYS, CLASSIFIED_BRIEF_SLOTS, CLASSIFIED_BRIEF_MAX_CHARS, SIGNAL_COOLDOWN_HOURS, BEAT_EXPIRY_DAYS, MAX_SIGNALS_PER_DAY, SIGNAL_STATUSES, CONFIG_PUBLISHER_ADDRESS, BRIEF_INCLUSION_PAYOUT_SATS, WEEKLY_PRIZE_1ST_SATS, WEEKLY_PRIZE_2ND_SATS, WEEKLY_PRIZE_3RD_SATS } from "../lib/constants";
-import { SCHEMA_SQL, MIGRATION_PHASE0_SQL, MIGRATION_PAYMENTS_SQL, MIGRATION_BEAT_RESTRUCTURE_SQL } from "./schema";
+import { SCHEMA_SQL, MIGRATION_PHASE0_SQL, MIGRATION_PAYMENTS_SQL, MIGRATION_BEAT_RESTRUCTURE_SQL, MIGRATION_CLEANUP_EARNINGS_SQL } from "./schema";
 
 /**
  * Raw SQL row returned by signal SELECT queries.
@@ -117,6 +117,16 @@ export class NewsDO extends DurableObject<Env> {
       } catch (e) {
         // Index already exists — safe to ignore on re-run.
         console.error("Payments migration statement failed (likely already applied):", e);
+      }
+    }
+
+    // Run Phase 5 cleanup migration — removes ~230 phantom 0-sat signal earnings
+    // left by the bug fixed in PR #122. Safe to re-run (DELETE WHERE is idempotent).
+    for (const stmt of MIGRATION_CLEANUP_EARNINGS_SQL) {
+      try {
+        this.ctx.storage.sql.exec(stmt);
+      } catch (e) {
+        console.error("Cleanup earnings migration statement failed:", e);
       }
     }
 

--- a/src/objects/schema.ts
+++ b/src/objects/schema.ts
@@ -257,3 +257,17 @@ export const MIGRATION_BEAT_RESTRUCTURE_SQL = `
   -- ── Phase D: Delete old beats (all signals remapped above) ─────────────
   DELETE FROM beats WHERE slug IN ('btc-macro', 'agent-commerce', 'network-ops', 'ordinals-business', 'ordinals-culture', 'protocol-infra', 'defi-yields', 'fee-weather', 'agentic-trading');
 `;
+
+/**
+ * Cleanup migration — Phase 5.
+ * Deletes historical 0-sat earnings rows created with reason='signal'.
+ * These were a side-effect of a bug fixed in PR #122: every signal submission
+ * inserted a phantom earning row with amount_sats=0 and reason='signal'.
+ * ~230 such rows exist in production. They are safe to delete because:
+ *   - No legitimate 0-sat signal earnings exist (payouts are always > 0)
+ *   - They confuse Publisher agents reading GET /api/earnings/:address
+ * Idempotent: DELETE WHERE is a no-op if rows don't exist.
+ */
+export const MIGRATION_CLEANUP_EARNINGS_SQL = [
+  "DELETE FROM earnings WHERE reason = 'signal' AND amount_sats = 0",
+] as const;


### PR DESCRIPTION
## Summary

Adds a cleanup migration (Phase 5) to delete ~230 historical 0-sat earnings rows that were created with `reason = 'signal'` by the bug fixed in PR #122.

## Changes

- `src/objects/schema.ts`: Adds `MIGRATION_CLEANUP_EARNINGS_SQL` export with the idempotent `DELETE FROM earnings WHERE reason = 'signal' AND amount_sats = 0`
- `src/objects/news-do.ts`: Imports and runs the new migration during DO initialization (after Phase 4 payments migration)

## Why it's safe

- The `DELETE WHERE` clause is idempotent — no-op if rows don't exist
- No legitimate 0-sat signal earnings exist (payouts are always > 0)
- The `reason = 'signal'` + `amount_sats = 0` filter is precise — no other rows match
- Runs during DO constructor startup, same as all other migrations

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)