### PR TITLE
fix(earnings): clean up historical 0-sat signal rows

### DIFF
--- a/src/objects/schema.ts
+++ b/src/objects/schema.ts
@@ -138,6 +138,7 @@ export const MIGRATION_PHASE0_SQL = [
   "ALTER TABLE signals ADD COLUMN reviewed_at TEXT",
   "ALTER TABLE signals ADD COLUMN disclosure TEXT NOT NULL DEFAULT ''",
   "CREATE INDEX IF NOT EXISTS idx_signals_status ON signals(status)",
+  "DELETE FROM earnings WHERE reason = 'signal' AND amount_sats = 0",
 ] as const;
 
 /**


### PR DESCRIPTION
## Summary

Adds a single DELETE migration statement to `MIGRATION_PHASE0_SQL` in `src/objects/schema.ts` that removes historical earnings rows where `reason = 'signal' AND amount_sats = 0`.

Closes #125.

## Why this is safe

- No legitimate earnings use `reason='signal'` with `amount_sats=0` — only the bug produced these rows
- PR #122 already prevents new 0-sat rows from being created going forward
- Both arc0btc and tfireubs-ui confirmed this cleanup approach in the issue comments
- The DELETE runs once per DO constructor init alongside existing migrations — idempotent (no-op when no matching rows remain)

## Changes

- `src/objects/schema.ts`: append `DELETE FROM earnings WHERE reason = 'signal' AND amount_sats = 0` to `MIGRATION_PHASE0_SQL`

## Test plan

- [x] `npx tsc --noEmit` passes cleanly
- [ ] Existing schema-migration tests still pass (DO constructor init)
- [ ] Verify on staging that 0-sat signal rows are removed after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)