### PR TITLE
feat(disclosure): soft-launch disclosure enforcement messaging

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2719,9 +2719,7 @@
       if (data.tags && data.tags.length) {
         html += `<div class="signal-tags">${data.tags.map(t => `<span class="signal-tag">${esc(t)}</span>`).join('')}</div>`;
       }
-      if (data.disclosure && data.disclosure.trim()) {
-        html += `<div class="signal-disclosure"><span class="signal-disclosure-label">Disclosure</span>${esc(data.disclosure)}</div>`;
-      }
+      html += renderDisclosure(data.disclosure);
       html += `<div class="signal-modal-permalink">
         <code>${esc(url)}</code>
         <button class="signal-modal-copy" onclick="event.stopPropagation();navigator.clipboard.writeText('${esc(url)}').then(()=>{this.textContent='Copied!'});setTimeout(()=>{this.textContent='Copy'},1500)">Copy</button>

--- a/src/routes/signals.ts
+++ b/src/routes/signals.ts
@@ -205,7 +205,8 @@ signalsRouter.post("/api/signals", signalRateLimit, async (c) => {
     btc_address: btc_address as string,
   });
 
-  // Soft-launch disclosure enforcement: warn when disclosure is absent or empty.
+  // Soft-launch disclosure enforcement: warn when disclosure is absent or empty,
+  // including for non-AI signals, to encourage adoption across all correspondents.
   // Do NOT reject the signal — enforcement will be required in a future release.
   const disclosureValue = disclosure as string | undefined;
   const warnings: string[] = [];


### PR DESCRIPTION
## Summary

- **POST /api/signals**: when `disclosure` is absent or empty, the 201 response now includes a `warnings` array explaining what disclosure is, providing an example value, and noting that enforcement will be required in a future release. Signals are never rejected.
- **Frontend (public/index.html)**: disclosure field is now threaded through the sections object and rendered in all signal display paths (renderLead, renderColumn, renderStory, and direct-fetch modal). Hidden in card view, shown in the expanded modal — consistent with sources/tags. New `.signal-disclosure` CSS uses monospace font and faint color to keep it visually subdued.

## Scope

- `src/routes/signals.ts` — warning injection on POST
- `public/index.html` — renderDisclosure helper, CSS, sections threading, modal rendering

## Test plan

- [ ] Submit a signal without `disclosure` — confirm 201 response includes `warnings` array with the guidance message
- [ ] Submit a signal with `disclosure: "Claude claude-sonnet-4-5"` — confirm 201 response has no `warnings` field
- [ ] On the front page, open a signal modal for a signal that has disclosure set — confirm "Disclosure" label and value appear below tags
- [ ] On the front page, open a signal modal for a signal without disclosure — confirm no disclosure block appears
- [ ] Visit `/signals/:id` for a signal with disclosure — confirm disclosure appears in noscript block (OG page)
- [ ] Confirm `npx tsc --noEmit` exits clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)