### PR TITLE
feat: infinite-scroll news feed with date pagination

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3038,8 +3038,13 @@
 
       main.innerHTML = html;
       hydrateAgentIdentities(main);
-      // Kick off infinite scroll below today's curated signals
-      initInfiniteScroll(todayStr);
+      // Set scroll cursor based on the oldest rendered signal's date (Pacific time)
+      // to avoid duplicates when paginating back to those days
+      const oldestSignal = signals[signals.length - 1];
+      const scrollCursor = oldestSignal && oldestSignal.timestamp
+        ? new Date(oldestSignal.timestamp).toLocaleDateString('en-CA', { timeZone: 'America/Los_Angeles' })
+        : todayStr;
+      initInfiniteScroll(scrollCursor);
     }
 
     // ── Render components ──
@@ -3461,19 +3466,38 @@
       main.insertBefore(spinner, sentinel);
 
       let result = null;
+      let fetchError = false;
       try {
         result = await fetchJSON(`/api/front-page?before=${encodeURIComponent(scrollState.nextBefore)}&limit=50`);
-      } catch (_) { /* network error — treat as no more */ }
+        if (result === null) fetchError = true;
+      } catch (_) {
+        fetchError = true;
+      }
 
       // Remove spinner
       if (spinner.parentNode) spinner.parentNode.removeChild(spinner);
+
+      // Transient error — show retry UI instead of ending the feed
+      if (fetchError) {
+        const retry = document.createElement('div');
+        retry.className = 'scroll-terminal';
+        retry.innerHTML = 'Failed to load older signals. <button class="scroll-retry-btn" style="margin-left:8px;cursor:pointer;background:none;border:1px solid var(--rule);border-radius:4px;padding:4px 12px;color:var(--text);font-size:inherit;">Retry</button>';
+        retry.querySelector('.scroll-retry-btn').addEventListener('click', function() {
+          if (retry.parentNode) retry.parentNode.removeChild(retry);
+          scrollState.loading = false;
+          loadNextDay();
+        });
+        main.insertBefore(retry, sentinel);
+        scrollState.loading = false;
+        return;
+      }
 
       const signals = result && result.signals ? result.signals : [];
       const date = result && result.date ? result.date : null;
       const hasMore = result && result.hasMore === true;
 
       if (signals.length === 0 || !date) {
-        // Nothing more — show terminal state and stop
+        // Confirmed end-of-feed — show terminal state and stop
         scrollState.done = true;
         if (scrollState.observer) {
           scrollState.observer.disconnect();

--- a/src/lib/do-client.ts
+++ b/src/lib/do-client.ts
@@ -116,8 +116,11 @@ export async function listFrontPagePage(
     stub,
     `/signals/front-page-page?${params.toString()}`
   );
-  if (!result.ok || !result.data) {
-    return { signals: [], date: null, hasMore: false };
+  if (!result.ok) {
+    throw new Error(result.error ?? "Failed to fetch front-page page");
+  }
+  if (!result.data) {
+    throw new Error("Missing data in front-page page response");
   }
   return result.data;
 }

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -569,15 +569,11 @@ export class NewsDO extends DurableObject<Env> {
     });
 
     // GET /signals/front-page-page — date-paginated curated signals for infinite scroll
-    // Query params: before (YYYY-MM-DD, required), limit (default 50, max 200)
-    // Returns signals from the most recent day strictly before `before`, with hasMore flag.
+    // Query params: before (YYYY-MM-DD Pacific date, required), limit (unused, kept for compat)
+    // Uses 2-step query: (1) find the target Pacific day, (2) fetch ALL signals for that day.
+    // Returns signals from the most recent Pacific day strictly before `before`, with hasMore flag.
     this.router.get("/signals/front-page-page", (c) => {
       const before = c.req.query("before") ?? null;
-      const limitParam = c.req.query("limit");
-      const limit = Math.min(
-        Math.max(1, parseInt(limitParam ?? "50", 10) || 50),
-        200
-      );
 
       if (!before || !/^\d{4}-\d{2}-\d{2}$/.test(before)) {
         return c.json(
@@ -586,10 +582,33 @@ export class NewsDO extends DurableObject<Env> {
         );
       }
 
-      const beforeISO = `${before}T00:00:00.000Z`;
+      // Use Pacific-day boundaries to match brief date semantics
+      const beforeDayStartUTC = getPacificDayStartUTC(before);
 
-      // Fetch approved + brief_included signals strictly before the boundary.
-      // Fetch limit+1 to determine hasMore — we'll slice back to limit after day-filtering.
+      // Step 1: Find the target day — get the most recent signal strictly before the boundary
+      const probeRows = this.ctx.storage.sql
+        .exec(
+          `SELECT s.created_at
+           FROM signals s
+           WHERE s.status IN ('approved', 'brief_included')
+             AND s.created_at < ?1
+           ORDER BY s.created_at DESC
+           LIMIT 1`,
+          beforeDayStartUTC
+        )
+        .toArray();
+
+      if (probeRows.length === 0) {
+        return c.json({ ok: true, data: { signals: [], date: null, hasMore: false } });
+      }
+
+      // Determine the Pacific date of the most recent signal before the boundary
+      const probeTimestamp = (probeRows[0] as Record<string, unknown>).created_at as string;
+      const day = getPacificDate(new Date(probeTimestamp));
+      const dayStartUTC = getPacificDayStartUTC(day);
+      const dayEndUTC = getPacificDayStartUTC(getNextDate(day));
+
+      // Step 2: Fetch ALL signals for that Pacific day (complete day, no limit)
       const rows = this.ctx.storage.sql
         .exec(
           `SELECT s.*, b.name as beat_name, GROUP_CONCAT(st.tag) as tags_csv
@@ -597,29 +616,28 @@ export class NewsDO extends DurableObject<Env> {
            LEFT JOIN beats b ON s.beat_slug = b.slug
            LEFT JOIN signal_tags st ON s.id = st.signal_id
            WHERE s.status IN ('approved', 'brief_included')
-             AND s.created_at < ?1
+             AND s.created_at >= ?1
+             AND s.created_at < ?2
            GROUP BY s.id
-           ORDER BY s.created_at DESC
-           LIMIT ?2`,
-          beforeISO,
-          limit + 1
+           ORDER BY s.created_at DESC`,
+          dayStartUTC,
+          dayEndUTC
         )
         .toArray();
 
-      if (rows.length === 0) {
-        return c.json({ ok: true, data: { signals: [], date: null, hasMore: false } });
-      }
+      const daySignals = rows.map((r) => rowToSignal(r as Record<string, unknown>));
 
-      const allSignals = rows.map((r) => rowToSignal(r as Record<string, unknown>));
-
-      // Determine the day: UTC date of the first (most recent) result
-      const day = allSignals[0].created_at.slice(0, 10);
-
-      // Keep only signals from that day
-      const daySignals = allSignals.filter((s) => s.created_at.slice(0, 10) === day);
-
-      // hasMore = there are signals from days older than `day`
-      const hasMore = allSignals.some((s) => s.created_at.slice(0, 10) < day);
+      // Check hasMore: are there any signals before this day?
+      const olderRows = this.ctx.storage.sql
+        .exec(
+          `SELECT 1 FROM signals
+           WHERE status IN ('approved', 'brief_included')
+             AND created_at < ?1
+           LIMIT 1`,
+          dayStartUTC
+        )
+        .toArray();
+      const hasMore = olderRows.length > 0;
 
       return c.json({ ok: true, data: { signals: daySignals, date: day, hasMore } });
     });

--- a/src/routes/signal-review.ts
+++ b/src/routes/signal-review.ts
@@ -114,6 +114,11 @@ signalReviewRouter.get("/api/front-page", async (c) => {
     if (!/^\d{4}-\d{2}-\d{2}$/.test(before)) {
       return c.json({ error: "Invalid 'before' param (YYYY-MM-DD required)" }, 400);
     }
+    // Validate it parses to a real date (rejects e.g. 2026-99-99)
+    const parsed = new Date(before + "T12:00:00Z");
+    if (isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== before) {
+      return c.json({ error: "Invalid 'before' param (not a real date)" }, 400);
+    }
 
     const result = await listFrontPagePage(c.env, before, limit);
     const transformed = result.signals.map((s) => ({


### PR DESCRIPTION
## Summary

- **Backend (DO):** Add `GET /signals/front-page-page?before=YYYY-MM-DD&limit=N` inside `NewsDO` — queries `approved` + `brief_included` signals strictly before the boundary date, returns one day's worth of signals plus a `hasMore` flag. Route is registered before `GET /signals/:id` to avoid param capture.
- **Backend (Worker):** Extend `GET /api/front-page` to accept `?before=YYYY-MM-DD` — when present, delegates to `listFrontPagePage()` and returns `{ signals, date, hasMore, curated: true }`. Without `?before`, existing behavior is unchanged.
- **Frontend:** Add `IntersectionObserver`-based infinite scroll below today's content: `initInfiniteScroll(date)` attaches a sentinel, `loadNextDay()` fetches one day at a time, `renderDaySection()` renders a newspaper-style date divider + signal mosaic grid using existing render helpers. Loading spinner and terminal "beginning of feed" state included.

## Design decisions

- Today's content path (renderBrief / renderSignalFeed) is completely unchanged
- Infinite scroll only activates below today's content — `initInfiniteScroll` is called at the END of both render paths
- Pending-review state (submitted signals) does NOT init scroll — no date context available
- One day per IntersectionObserver trigger — `nextBefore` advances to the returned `date` after each load
- Empty signals or `hasMore: false` triggers terminal state and disconnects the observer

## Test plan

- [ ] Today's front page loads and renders as before (no regression)
- [ ] Scroll to bottom of page — spinner appears, older day section loads with date header
- [ ] Date divider shows full date (e.g., "Wednesday, March 18, 2026") above previous day's signals
- [ ] Scrolling to the bottom again loads the next older day
- [ ] When no more older signals exist, "You've reached the beginning of the feed." terminal state appears
- [ ] `GET /api/front-page?before=2026-03-19` returns `{ signals, date, hasMore, curated: true }`
- [ ] `GET /api/front-page?before=invalid` returns 400
- [ ] TypeScript: `npx tsc --noEmit` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)