### PR TITLE
refactor(classifieds): drop contact field

### DIFF
--- a/src/lib/do-client.ts
+++ b/src/lib/do-client.ts
@@ -297,7 +297,6 @@ export interface CreateClassifiedInput {
   category: string;
   headline: string;
   body?: string | null;
-  contact?: string | null;
   payment_txid?: string | null;
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -171,7 +171,6 @@ export interface Classified {
   readonly category: string;
   readonly headline: string;
   readonly body: string | null;
-  readonly contact: string | null;
   readonly payment_txid: string | null;
   readonly created_at: string;
   readonly expires_at: string;

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -5,7 +5,7 @@ import type { Env, Beat, Signal, SignalStatus, Streak, Brief, Classified, Earnin
 import { validateSlug, validateHexColor, sanitizeString } from "../lib/validators";
 import { generateId, getPacificDate, getPacificYesterday, getPacificDayStartUTC, getNextDate } from "../lib/helpers";
 import { CLASSIFIED_DURATION_DAYS, CLASSIFIED_BRIEF_SLOTS, CLASSIFIED_BRIEF_MAX_CHARS, SIGNAL_COOLDOWN_HOURS, BEAT_EXPIRY_DAYS, MAX_SIGNALS_PER_DAY, SIGNAL_STATUSES, CONFIG_PUBLISHER_ADDRESS, BRIEF_INCLUSION_PAYOUT_SATS, WEEKLY_PRIZE_1ST_SATS, WEEKLY_PRIZE_2ND_SATS, WEEKLY_PRIZE_3RD_SATS } from "../lib/constants";
-import { SCHEMA_SQL, MIGRATION_PHASE0_SQL, MIGRATION_PAYMENTS_SQL, MIGRATION_BEAT_RESTRUCTURE_SQL, MIGRATION_SBTC_TRACKING_SQL } from "./schema";
+import { SCHEMA_SQL, MIGRATION_PHASE0_SQL, MIGRATION_PAYMENTS_SQL, MIGRATION_BEAT_RESTRUCTURE_SQL, MIGRATION_SBTC_TRACKING_SQL, MIGRATION_CLASSIFIEDS_CLEANUP_SQL } from "./schema";
 
 /**
  * Raw SQL row returned by signal SELECT queries.
@@ -129,6 +129,19 @@ export class NewsDO extends DurableObject<Env> {
         const msg = e instanceof Error ? e.message : String(e);
         if (!msg.includes("duplicate column")) {
           console.error("sBTC tracking migration statement failed:", e);
+        }
+      }
+    }
+
+    // Run classifieds cleanup migration — drops contact column (btc_address serves as contact).
+    for (const stmt of MIGRATION_CLASSIFIEDS_CLEANUP_SQL) {
+      try {
+        this.ctx.storage.sql.exec(stmt);
+      } catch (e) {
+        // Column may not exist (new instances) or already dropped — safe to ignore.
+        const msg = e instanceof Error ? e.message : String(e);
+        if (!msg.includes("no such column") && !msg.includes("no column")) {
+          console.error("Classifieds cleanup migration statement failed:", e);
         }
       }
     }
@@ -1201,8 +1214,7 @@ export class NewsDO extends DurableObject<Env> {
         .filter((row) => {
           const charCount =
             (row.headline?.length ?? 0) +
-            (row.body?.length ?? 0) +
-            (row.contact?.length ?? 0);
+            (row.body?.length ?? 0);
           return charCount <= maxChars;
         })
         .slice(0, CLASSIFIED_BRIEF_SLOTS);
@@ -1240,7 +1252,7 @@ export class NewsDO extends DurableObject<Env> {
         );
       }
 
-      const { btc_address, category, headline, body: adBody, contact, payment_txid } = body;
+      const { btc_address, category, headline, body: adBody, payment_txid } = body;
 
       if (!btc_address || !category || !headline) {
         return c.json(
@@ -1261,14 +1273,13 @@ export class NewsDO extends DurableObject<Env> {
       expiresAt.setDate(expiresAt.getDate() + CLASSIFIED_DURATION_DAYS);
 
       this.ctx.storage.sql.exec(
-        `INSERT INTO classifieds (id, btc_address, category, headline, body, contact, payment_txid, created_at, expires_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO classifieds (id, btc_address, category, headline, body, payment_txid, created_at, expires_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
         id,
         btc_address as string,
         category as string,
         sanitizeString(headline, 100),
         adBody ? sanitizeString(adBody, 500) : null,
-        contact ? sanitizeString(contact, 200) : null,
         payment_txid ? (payment_txid as string) : null,
         nowIso,
         expiresAt.toISOString()

--- a/src/objects/schema.ts
+++ b/src/objects/schema.ts
@@ -74,7 +74,6 @@ CREATE TABLE IF NOT EXISTS classifieds (
   category     TEXT NOT NULL,
   headline     TEXT NOT NULL,
   body         TEXT,
-  contact      TEXT,
   payment_txid TEXT,
   created_at   TEXT NOT NULL,
   expires_at   TEXT NOT NULL
@@ -149,6 +148,14 @@ export const MIGRATION_PHASE0_SQL = [
  */
 export const MIGRATION_SBTC_TRACKING_SQL = [
   "ALTER TABLE earnings ADD COLUMN payout_txid TEXT",
+] as const;
+
+/**
+ * Classifieds cleanup migration.
+ * Drops the contact column — btc_address already serves as the agent-native contact method.
+ */
+export const MIGRATION_CLASSIFIEDS_CLEANUP_SQL = [
+  "ALTER TABLE classifieds DROP COLUMN contact",
 ] as const;
 
 /**

--- a/src/routes/classifieds.ts
+++ b/src/routes/classifieds.ts
@@ -64,7 +64,6 @@ classifiedsRouter.get("/api/classifieds", async (c) => {
     body: cl.body,
     category: cl.category,
     placedBy: cl.btc_address,
-    contact: cl.contact,
     paymentTxid: cl.payment_txid,
     createdAt: cl.created_at,
     expiresAt: cl.expires_at,
@@ -89,7 +88,6 @@ classifiedsRouter.get("/api/classifieds/:id", async (c) => {
     body: cl.body,
     category: cl.category,
     placedBy: cl.btc_address,
-    contact: cl.contact,
     paymentTxid: cl.payment_txid,
     createdAt: cl.created_at,
     expiresAt: cl.expires_at,
@@ -133,7 +131,6 @@ classifiedsRouter.post(
       category,
       headline,
       body: adBody,
-      contact,
     } = body;
 
     // Required fields
@@ -212,7 +209,6 @@ classifiedsRouter.post(
       category: category as string,
       headline: sanitizeString(headline, 100),
       body: adBody ? sanitizeString(adBody, 500) : null,
-      contact: contact ? sanitizeString(contact, 200) : null,
       payment_txid: verification.txid ?? null,
     });
 


### PR DESCRIPTION
## Summary

- Removes `contact TEXT` column from the `classifieds` table — `btc_address` already serves as the agent-native contact method
- Adds `MIGRATION_CLASSIFIEDS_CLEANUP_SQL` (`ALTER TABLE classifieds DROP COLUMN contact`) wired into the DO constructor for existing instances
- Cleans up all references across types, do-client, classifieds route, and news-do INSERT

## Files changed

- `schema.ts` — column removed from SCHEMA_SQL; `MIGRATION_CLASSIFIEDS_CLEANUP_SQL` added
- `news-do.ts` — migration wired into constructor; INSERT updated; char-count filter simplified
- `types.ts` — `Classified.contact` field removed
- `do-client.ts` — `CreateClassifiedInput.contact` field removed
- `classifieds.ts` — body destructure, response transforms, and `createClassified` call updated

## Test plan

- [ ] `npm run typecheck` passes (verified clean)
- [ ] POST /api/classifieds no longer accepts or stores `contact`
- [ ] GET /api/classifieds and GET /api/classifieds/:id response no longer includes `contact`
- [ ] Existing DO instances: migration drops column on first startup after deploy
- [ ] New DO instances: column never created (not in SCHEMA_SQL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)