### PR TITLE
fix(rate-limits): raise publisher limits and consolidate constants

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -37,22 +37,6 @@ export function isClassifiedCategory(s: string): s is ClassifiedCategory {
   return (CLASSIFIED_CATEGORIES as readonly string[]).includes(s);
 }
 
-// ── Rate limit defaults (per-hour windows) ──
-export const SIGNAL_RATE_LIMIT = {
-  maxRequests: 10,
-  windowSeconds: 3600,
-} as const;
-
-export const CLASSIFIED_RATE_LIMIT = {
-  maxRequests: 5,
-  windowSeconds: 3600,
-} as const;
-
-export const BEAT_RATE_LIMIT = {
-  maxRequests: 5,
-  windowSeconds: 3600,
-} as const;
-
 // ── Signal cooldown ──
 export const SIGNAL_COOLDOWN_HOURS = 1;
 
@@ -75,22 +59,47 @@ export const SIGNAL_STATUSES = [
   "brief_included",
 ] as const;
 
-// ── Publisher review rate limit ──
-export const REVIEW_RATE_LIMIT = {
-  maxRequests: 60,
-  windowSeconds: 3600,
+// ── Rate limits ──
+// Agent-facing routes (many callers, tighter windows)
+export const SIGNAL_RATE_LIMIT = {
+  maxRequests: 10,
+  windowSeconds: 3600, // 1 hour
 } as const;
 
-// ── Correction rate limit ──
+export const BEAT_RATE_LIMIT = {
+  maxRequests: 10,
+  windowSeconds: 3600, // 1 hour
+} as const;
+
+export const CLASSIFIED_RATE_LIMIT = {
+  maxRequests: 5,
+  windowSeconds: 3600, // 1 hour
+} as const;
+
 export const CORRECTION_RATE_LIMIT = {
   maxRequests: 3,
-  windowSeconds: 86400, // 3 per day
+  windowSeconds: 86400, // 24 hours
 } as const;
 
-// ── Referral rate limit ──
 export const REFERRAL_RATE_LIMIT = {
   maxRequests: 1,
-  windowSeconds: 604800, // 1 per week
+  windowSeconds: 604800, // 7 days
+} as const;
+
+// Publisher-only routes (single operator, generous limits)
+export const REVIEW_RATE_LIMIT = {
+  maxRequests: 200,
+  windowSeconds: 3600, // 1 hour
+} as const;
+
+export const BRIEF_COMPILE_RATE_LIMIT = {
+  maxRequests: 10,
+  windowSeconds: 3600, // 1 hour
+} as const;
+
+export const BRIEF_INSCRIBE_RATE_LIMIT = {
+  maxRequests: 10,
+  windowSeconds: 3600, // 1 hour
 } as const;
 
 // ── Config keys ──

--- a/src/middleware/rate-limit.ts
+++ b/src/middleware/rate-limit.ts
@@ -58,6 +58,7 @@ export function createRateLimitMiddleware(opts: RateLimitOptions) {
         max: opts.maxRequests,
         retry_after: retryAfter,
       });
+      c.header("Retry-After", String(retryAfter));
       return c.json(
         { error: `Rate limited. Try again in ${retryAfter}s` },
         429

--- a/src/routes/beats.ts
+++ b/src/routes/beats.ts
@@ -10,8 +10,7 @@ const beatsRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>();
 
 const beatRateLimit = createRateLimitMiddleware({
   key: "beats",
-  maxRequests: BEAT_RATE_LIMIT.maxRequests,
-  windowSeconds: BEAT_RATE_LIMIT.windowSeconds,
+  ...BEAT_RATE_LIMIT,
 });
 
 // GET /api/beats — list all beats

--- a/src/routes/brief-compile.ts
+++ b/src/routes/brief-compile.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import type { Env, AppVariables, Source } from "../lib/types";
 import { createRateLimitMiddleware } from "../middleware/rate-limit";
 import { compileBriefData, saveBrief, recordBriefSignals, recordBriefInclusionPayouts, getConfig } from "../lib/do-client";
-import { CONFIG_PUBLISHER_ADDRESS } from "../lib/constants";
+import { CONFIG_PUBLISHER_ADDRESS, BRIEF_COMPILE_RATE_LIMIT } from "../lib/constants";
 import { resolveAgentNames } from "../services/agent-resolver";
 import { getPacificDate, formatPacificShort } from "../lib/helpers";
 import { validateBtcAddress } from "../lib/validators";
@@ -12,8 +12,7 @@ const briefCompileRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>(
 
 const compileRateLimit = createRateLimitMiddleware({
   key: "brief-compile",
-  maxRequests: 3,
-  windowSeconds: 3600,
+  ...BRIEF_COMPILE_RATE_LIMIT,
 });
 
 const MIN_SIGNALS = 3;

--- a/src/routes/brief-inscribe.ts
+++ b/src/routes/brief-inscribe.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import type { Env, AppVariables } from "../lib/types";
 import { createRateLimitMiddleware } from "../middleware/rate-limit";
+import { BRIEF_INSCRIBE_RATE_LIMIT } from "../lib/constants";
 import { getBriefByDate, updateBrief } from "../lib/do-client";
 import { validateBtcAddress, validateSignatureFormat } from "../lib/validators";
 import { verifyAuth } from "../services/auth";
@@ -9,8 +10,7 @@ const briefInscribeRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>
 
 const inscribeRateLimit = createRateLimitMiddleware({
   key: "brief-inscribe",
-  maxRequests: 5,
-  windowSeconds: 3600,
+  ...BRIEF_INSCRIBE_RATE_LIMIT,
 });
 
 /** Validate inscription ID: {64-char txid}i{index} or numeric ordinal number */

--- a/src/routes/classifieds.ts
+++ b/src/routes/classifieds.ts
@@ -32,8 +32,7 @@ const classifiedsRouter = new Hono<{
 
 const classifiedRateLimit = createRateLimitMiddleware({
   key: "classifieds",
-  maxRequests: CLASSIFIED_RATE_LIMIT.maxRequests,
-  windowSeconds: CLASSIFIED_RATE_LIMIT.windowSeconds,
+  ...CLASSIFIED_RATE_LIMIT,
 });
 
 // GET /api/classifieds/rotation — random selection of up to 3 active listings for brief inclusion

--- a/src/routes/corrections.ts
+++ b/src/routes/corrections.ts
@@ -18,8 +18,7 @@ const correctionsRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>()
 
 const correctionRateLimit = createRateLimitMiddleware({
   key: "corrections",
-  maxRequests: CORRECTION_RATE_LIMIT.maxRequests,
-  windowSeconds: CORRECTION_RATE_LIMIT.windowSeconds,
+  ...CORRECTION_RATE_LIMIT,
 });
 
 // POST /api/signals/:id/corrections — file a correction

--- a/src/routes/referrals.ts
+++ b/src/routes/referrals.ts
@@ -16,8 +16,7 @@ const referralsRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>();
 
 const referralRateLimit = createRateLimitMiddleware({
   key: "referrals",
-  maxRequests: REFERRAL_RATE_LIMIT.maxRequests,
-  windowSeconds: REFERRAL_RATE_LIMIT.windowSeconds,
+  ...REFERRAL_RATE_LIMIT,
 });
 
 // POST /api/referrals — register a referral

--- a/src/routes/signal-review.ts
+++ b/src/routes/signal-review.ts
@@ -17,8 +17,7 @@ const signalReviewRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>(
 
 const reviewRateLimit = createRateLimitMiddleware({
   key: "signal-review",
-  maxRequests: REVIEW_RATE_LIMIT.maxRequests,
-  windowSeconds: REVIEW_RATE_LIMIT.windowSeconds,
+  ...REVIEW_RATE_LIMIT,
 });
 
 // PATCH /api/signals/:id/review — Publisher reviews a signal (BIP-322 auth required)

--- a/src/routes/signals.ts
+++ b/src/routes/signals.ts
@@ -23,8 +23,7 @@ const signalsRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>();
 
 const signalRateLimit = createRateLimitMiddleware({
   key: "signals",
-  maxRequests: SIGNAL_RATE_LIMIT.maxRequests,
-  windowSeconds: SIGNAL_RATE_LIMIT.windowSeconds,
+  ...SIGNAL_RATE_LIMIT,
 });
 
 // GET /api/signals — list signals with optional filters


### PR DESCRIPTION
## Summary
- **Raised publisher-only rate limits** — review 60→200/hr, brief-compile 3→10/hr, brief-inscribe 5→10/hr (publisher was getting rate-limited reviewing 50 beats in a session)
- **Bumped beat creation limit** — 5→10/hr to align with signal submission
- **Added `Retry-After` header** to 429 responses per RFC 6585
- **Eliminated inline magic numbers** — brief-compile and brief-inscribe now import from `constants.ts` like all other routes
- **Consolidated all rate limit constants** into a single section with consistent grouping (agent-facing vs publisher-only) and duration comments
- **Simplified route middleware** — all 8 routes use `{ key, ...CONSTANT }` spread pattern instead of manually destructuring fields

## Test plan
- [ ] `npx tsc --noEmit` passes (verified locally)
- [ ] Verify publisher can review 50+ signals without hitting 429
- [ ] Verify 429 responses include `Retry-After` header
- [ ] Verify agent-facing limits unchanged (signals 10/hr, classifieds 5/hr, corrections 3/day, referrals 1/week)

🤖 Generated with [Claude Code](https://claude.com/claude-code)