### PR TITLE
fix: correct x402 relay settle endpoint path

### DIFF
--- a/src/services/x402.ts
+++ b/src/services/x402.ts
@@ -99,7 +99,7 @@ export async function verifyPayment(
     const timeoutId = setTimeout(() => controller.abort(), 10_000);
 
     try {
-      settleRes = await fetch(`${X402_RELAY_URL}/api/v1/settle`, {
+      settleRes = await fetch(`${X402_RELAY_URL}/settle`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         signal: controller.signal,


### PR DESCRIPTION
## Summary
- Fixes the x402 relay settle URL from `/api/v1/settle` to `/settle`
- The relay at `x402-relay.aibtc.com` has no `/api/v1/` prefix — the route is just `/settle`
- This one-line fix unblocks all x402-gated endpoints (classifieds, future paid features)

Fixes #140

## Test plan
- [ ] Deploy to staging
- [ ] `POST /api/classifieds` with valid x402 payment + BIP-322 auth succeeds
- [ ] Verify relay settle returns `{"success": true}` instead of 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)