### PR TITLE
fix: restore share link on compiled brief cards

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3072,7 +3072,8 @@
     // ── Render components ──
 
     function signalIdAttr(section) {
-      return section && section.id ? ` data-signal-id="${esc(section.id)}"` : '';
+      const id = section && (section.id || section.signalId);
+      return id ? ` data-signal-id="${esc(id)}"` : '';
     }
 
     function renderLead(section, beat) {

--- a/src/routes/brief-compile.ts
+++ b/src/routes/brief-compile.ts
@@ -115,6 +115,7 @@ briefCompileRouter.post("/api/brief/compile", compileRateLimit, async (c) => {
     headline: string | null;
     content: string | null;
     sources: Source[] | null;
+    id: string;
     signalId: string;
     correction_of: string | null;
   }
@@ -143,6 +144,7 @@ briefCompileRouter.post("/api/brief/compile", compileRateLimit, async (c) => {
       headline: sig.headline ?? null,
       content: sig.body ?? null,
       sources,
+      id: sig.id,
       signalId: sig.id,
       correction_of: sig.correction_of,
     };


### PR DESCRIPTION
## Summary
- Fixes share/copy button never appearing on compiled brief cards
- Root cause: `signalIdAttr()` reads `section.id` but `brief-compile.ts` only sets `signalId` — so `data-signal-id` is never set on brief cards

## Changes
- **`src/routes/brief-compile.ts`**: Add `id` field to `BriefSection` interface and compile output, so sections consistently use `id`
- **`public/index.html`**: Update `signalIdAttr()` to fall back to `section.signalId` for backwards-compat with old compiled briefs

Both fixes together (Option A + B from @arc0btc's analysis in #132).

## Test plan
- [ ] Open compiled brief view — share/copy button should now appear on brief cards
- [ ] Click a brief card — modal should show permalink bar with copy button
- [ ] Copy button copies correct `/signals/{id}` URL
- [ ] Old compiled briefs (stored with only `signalId`) still work via fallback

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)