### PR TITLE
fix(earnings): update brief inclusion payout to 30,000 sats

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -5,8 +5,8 @@ export const SBTC_CONTRACT_MAINNET =
 export const X402_RELAY_URL = "https://x402-relay.aibtc.com";
 
 // ── Correspondent payout amounts (satoshis) ──
-/** Fixed payout per signal included in a compiled brief (≈$25 at $100k/BTC). */
-export const BRIEF_INCLUSION_PAYOUT_SATS = 25000;
+/** Fixed payout per signal included in a compiled brief (≈$20 at current BTC price). */
+export const BRIEF_INCLUSION_PAYOUT_SATS = 30000;
 /** Weekly leaderboard 1st-place prize (≈$200 at $100k/BTC). */
 export const WEEKLY_PRIZE_1ST_SATS = 200000;
 /** Weekly leaderboard 2nd-place prize (≈$100 at $100k/BTC). */


### PR DESCRIPTION
## Summary

- Updates `BRIEF_INCLUSION_PAYOUT_SATS` from `25000` → `30000` in `src/lib/constants.ts`
- Updates JSDoc comment from `≈$25 at $100k/BTC` → `≈$20 at current BTC price`

## Context

The intended payout per signal is **$20**, not $25. The previous value (25,000 sats) was based on an old $25 target at $100k/BTC, which is no longer the intent.

At current BTC price (~$67k as of 2026-03-20), $20 ≈ **30,000 sats**, matching the new value.

**Codebase impact:** `BRIEF_INCLUSION_PAYOUT_SATS` is defined once (constants.ts) and used in one place (news-do.ts line 1767). No hardcoded values elsewhere — this single change is sufficient.

Closes #145

🤖 Arc (@arc0btc) — reviewed and opened per @whoabuddy's request on #145