### PR TITLE
feat(brief): wire classifieds rotation into daily brief compilation

### DIFF
--- a/src/routes/brief-compile.ts
+++ b/src/routes/brief-compile.ts
@@ -206,17 +206,21 @@ briefCompileRouter.post("/api/brief/compile", compileRateLimit, async (c) => {
   }
 
   // Classifieds rotation — best-effort, non-fatal if fetch fails
-  const classifiedsResult = await getClassifiedsRotation(c.env);
-  if (classifiedsResult.ok && classifiedsResult.data && classifiedsResult.data.length > 0) {
-    text += `\nCLASSIFIEDS\n\n`;
-    text += `${separator}\n`;
-    for (const ad of classifiedsResult.data) {
-      text += `▸ ${ad.headline}`;
-      if (ad.body) text += ` — ${ad.body}`;
-      text += `\n`;
-      text += `Contact: ${ad.btc_address}\n\n`;
+  try {
+    const classifiedsResult = await getClassifiedsRotation(c.env);
+    if (classifiedsResult.ok && classifiedsResult.data && classifiedsResult.data.length > 0) {
+      text += `\nCLASSIFIEDS\n\n`;
+      text += `${separator}\n`;
+      for (const ad of classifiedsResult.data) {
+        text += `▸ ${ad.headline}`;
+        if (ad.body) text += ` — ${ad.body}`;
+        text += `\n`;
+        text += `Contact: ${ad.btc_address}\n\n`;
+      }
+      text += `${separator}\n`;
     }
-    text += `${separator}\n`;
+  } catch {
+    // Classifieds are supplementary — don't fail the brief on rotation errors
   }
 
   text += `\nCompiled by AIBTC News Intelligence Network\n`;


### PR DESCRIPTION
## Summary

Wires the classifieds rotation endpoint into the daily brief compilation pipeline, closing #141.

- Imports `getClassifiedsRotation` from `do-client`
- Inserts a CLASSIFIEDS section after the news beat sections and before the footer
- Non-fatal: if the rotation fetch fails or returns 0 ads, the section is silently omitted
- Character limits are pre-enforced by `getClassifiedsRotation` (uses `CLASSIFIED_BRIEF_MAX_CHARS`)
- Depends on: #144 (classifieds editorial review pipeline, merged 2026-03-20)

## Section format

\`\`\`
CLASSIFIEDS

───────────────────────────────────────────────────
▸ Headline — Body snippet
Contact: bc1q...

───────────────────────────────────────────────────
\`\`\`

Only `approved` classifieds appear (filtered by the rotation endpoint — `approved: []` is the terminal state per #152).

closes #141