### PR TITLE
refactor: replace error substring matching with structured error codes (fixes #150)

### DIFF
--- a/src/lib/do-client.ts
+++ b/src/lib/do-client.ts
@@ -1,4 +1,4 @@
-import type { Env, Beat, Signal, SignalStatus, Source, Brief, Classified, ClassifiedStatus, Streak, Earning, Correction, ReferralCredit, BriefSignal, CompiledBriefData, DOResult, PayoutRecord, WeeklyPayoutResult } from "./types";
+import type { Env, Beat, Signal, SignalStatus, Source, Brief, Classified, ClassifiedStatus, Streak, Earning, Correction, ReferralCredit, BriefSignal, CompiledBriefData, DOResult, DOErrorStatus, PayoutRecord, WeeklyPayoutResult } from "./types";
 import { CLASSIFIED_BRIEF_SLOTS } from "./constants";
 
 /** Singleton DO stub ID — single instance manages all news data */
@@ -17,7 +17,11 @@ async function doFetch<T>(
   init?: RequestInit
 ): Promise<DOResult<T>> {
   const res = await stub.fetch(`https://do${path}`, init);
-  return (await res.json()) as DOResult<T>;
+  const data = (await res.json()) as DOResult<T>;
+  if (!data.ok) {
+    return { ...data, status: res.status as DOErrorStatus };
+  }
+  return data;
 }
 
 // ---------------------------------------------------------------------------
@@ -164,7 +168,11 @@ export async function createSignal(
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(signal),
   });
-  return (await res.json()) as CreateSignalResult;
+  const data = (await res.json()) as CreateSignalResult;
+  if (!data.ok) {
+    return { ...data, status: res.status as DOErrorStatus };
+  }
+  return data;
 }
 
 export interface CorrectionInput {
@@ -556,8 +564,8 @@ export async function getConfig(env: Env, key: string): Promise<ConfigEntry | nu
   const stub = getStub(env);
   const result = await doFetch<ConfigEntry>(stub, `/config/${encodeURIComponent(key)}`);
   if (result.ok) return result.data ?? null;
-  // "not set" is a normal 404 — return null
-  if (result.error?.includes("not set")) return null;
+  // 404 is a normal "not set" — return null
+  if (result.status === 404) return null;
   // Any other error (DO crash, 500) — throw so callers can fail closed
   throw new Error(result.error ?? "Failed to fetch config");
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -260,10 +260,15 @@ export interface CompiledBriefData {
 /**
  * Generic result type for Durable Object operations
  */
+/** HTTP error status codes returned by DO handlers */
+export type DOErrorStatus = 400 | 401 | 403 | 404 | 409 | 429 | 500;
+
 export interface DOResult<T> {
   ok: boolean;
   data?: T;
   error?: string;
+  /** HTTP status hint from DO, present on error paths */
+  status?: DOErrorStatus;
 }
 
 /**

--- a/src/routes/beats.ts
+++ b/src/routes/beats.ts
@@ -107,8 +107,7 @@ beatsRouter.post("/api/beats", beatRateLimit, async (c) => {
   });
 
   if (!result.ok) {
-    const status = result.error?.includes("already exists") ? 409 : 400;
-    return c.json({ error: result.error }, status);
+    return c.json({ error: result.error }, result.status ?? 400);
   }
 
   const logger = c.get("logger");
@@ -177,8 +176,7 @@ beatsRouter.patch("/api/beats/:slug", beatRateLimit, async (c) => {
   const result = await updateBeat(c.env, slug, body);
 
   if (!result.ok) {
-    const status = result.error?.includes("not found") ? 404 : 400;
-    return c.json({ error: result.error }, status);
+    return c.json({ error: result.error }, result.status ?? 400);
   }
 
   return c.json(result.data);

--- a/src/routes/classified-review.ts
+++ b/src/routes/classified-review.ts
@@ -72,10 +72,7 @@ classifiedReviewRouter.patch("/api/classifieds/:id/review", reviewRateLimit, asy
   });
 
   if (!result.ok) {
-    const httpStatus = result.error?.includes("not found") ? 404
-      : result.error?.includes("Publisher") ? 403
-      : 400;
-    return c.json({ error: result.error }, httpStatus);
+    return c.json({ error: result.error }, result.status ?? 400);
   }
 
   const logger = c.get("logger");
@@ -129,10 +126,7 @@ classifiedReviewRouter.patch("/api/classifieds/:id/refund", reviewRateLimit, asy
   });
 
   if (!result.ok) {
-    const httpStatus = result.error?.includes("not found") ? 404
-      : result.error?.includes("Publisher") ? 403
-      : 400;
-    return c.json({ error: result.error }, httpStatus);
+    return c.json({ error: result.error }, result.status ?? 400);
   }
 
   const logger = c.get("logger");

--- a/src/routes/corrections.ts
+++ b/src/routes/corrections.ts
@@ -71,10 +71,7 @@ correctionsRouter.post("/api/signals/:id/corrections", correctionRateLimit, asyn
   });
 
   if (!result.ok) {
-    const status = result.error?.includes("not found") ? 404
-      : result.error?.includes("own signal") ? 400
-      : 400;
-    return c.json({ error: result.error }, status);
+    return c.json({ error: result.error }, result.status ?? 400);
   }
 
   const logger = c.get("logger");
@@ -138,10 +135,7 @@ correctionsRouter.patch("/api/signals/:id/corrections/:correctionId", async (c) 
   });
 
   if (!result.ok) {
-    const httpStatus = result.error?.includes("not found") ? 404
-      : result.error?.includes("Publisher") ? 403
-      : 400;
-    return c.json({ error: result.error }, httpStatus);
+    return c.json({ error: result.error }, result.status ?? 400);
   }
 
   return c.json(result.data);

--- a/src/routes/earnings.ts
+++ b/src/routes/earnings.ts
@@ -89,10 +89,7 @@ earningsRouter.patch("/api/earnings/:id", async (c) => {
   });
 
   if (!result.ok) {
-    const httpStatus = result.error?.includes("not found") ? 404
-      : result.error?.includes("Publisher") ? 403
-      : 400;
-    return c.json({ error: result.error }, httpStatus);
+    return c.json({ error: result.error }, result.status ?? 400);
   }
 
   const logger = c.get("logger");

--- a/src/routes/referrals.ts
+++ b/src/routes/referrals.ts
@@ -56,10 +56,7 @@ referralsRouter.post("/api/referrals", referralRateLimit, async (c) => {
   const result = await registerReferral(c.env, btc_address as string, recruit_address as string);
 
   if (!result.ok) {
-    const status = result.error?.includes("yourself") ? 400
-      : result.error?.includes("already") ? 409
-      : 400;
-    return c.json({ error: result.error }, status);
+    return c.json({ error: result.error }, result.status ?? 400);
   }
 
   const logger = c.get("logger");

--- a/src/routes/signal-review.ts
+++ b/src/routes/signal-review.ts
@@ -68,10 +68,7 @@ signalReviewRouter.patch("/api/signals/:id/review", reviewRateLimit, async (c) =
   });
 
   if (!result.ok) {
-    const httpStatus = result.error?.includes("not found") ? 404
-      : result.error?.includes("Publisher") ? 403
-      : 400;
-    return c.json({ error: result.error }, httpStatus);
+    return c.json({ error: result.error }, result.status ?? 400);
   }
 
   const logger = c.get("logger");

--- a/src/routes/signals.ts
+++ b/src/routes/signals.ts
@@ -193,8 +193,7 @@ signalsRouter.post("/api/signals", signalRateLimit, async (c) => {
         429
       );
     }
-    const status = result.error?.includes("not found") ? 404 : 400;
-    return c.json({ error: result.error }, status);
+    return c.json({ error: result.error }, result.status ?? 400);
   }
 
   const logger = c.get("logger");
@@ -292,12 +291,7 @@ signalsRouter.patch("/api/signals/:id", async (c) => {
   });
 
   if (!result.ok) {
-    const status = result.error?.includes("not found")
-      ? 404
-      : result.error?.includes("Only the original author")
-      ? 403
-      : 400;
-    return c.json({ error: result.error }, status);
+    return c.json({ error: result.error }, result.status ?? 400);
   }
 
   return c.json(result.data);


### PR DESCRIPTION
## Summary

- Adds `DOErrorStatus` type and `status` field to `DOResult<T>` in `src/lib/types.ts`
- Updates `doFetch` in `src/lib/do-client.ts` to propagate `res.status` from the DO HTTP response on error paths
- Replaces all 10 instances of fragile `result.error?.includes(...)` substring matching across 7 route files with `result.status ?? 400`
- Also fixes the `createSignal` custom fetch path (bypasses `doFetch`) to propagate status
- Also fixes `getConfig` to use `result.status === 404` instead of matching `"not set"` string

## Context

Per issue #150 and @arc0btc's analysis: the DO already sets correct HTTP status codes on every error response, but `doFetch` was discarding `res.status`. Routes then tried to reconstruct it by substring-matching error messages — which breaks silently when DO error messages change.

The fix is a one-line change at the `doFetch` level (`status: res.status as DOErrorStatus`) that benefits every route consuming `DOResult`.

## Files changed (9)

| File | Change |
|------|--------|
| `src/lib/types.ts` | Add `DOErrorStatus` type, add `status` field to `DOResult<T>` |
| `src/lib/do-client.ts` | Propagate `res.status` in `doFetch` and `createSignal`; fix `getConfig` |
| `src/routes/beats.ts` | 2 instances → `result.status ?? 400` |
| `src/routes/classified-review.ts` | 2 instances → `result.status ?? 400` |
| `src/routes/corrections.ts` | 2 instances → `result.status ?? 400` |
| `src/routes/earnings.ts` | 1 instance → `result.status ?? 400` |
| `src/routes/referrals.ts` | 1 instance → `result.status ?? 400` |
| `src/routes/signal-review.ts` | 1 instance → `result.status ?? 400` |
| `src/routes/signals.ts` | 2 instances → `result.status ?? 400` |

## Test plan

- [x] `tsc --noEmit` passes clean (0 errors)
- [ ] Verify DO error responses carry correct HTTP status codes through to API callers
- [ ] Confirm 404 on "not found", 403 on publisher auth errors, 409 on duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)