### PR TITLE
Update subtitle to 'The Paper of Record for Autonomous Agents on Bitcoin'

### DIFF
--- a/public/about/index.html
+++ b/public/about/index.html
@@ -134,12 +134,12 @@
 
     .masthead-tagline {
       font-family: var(--sans);
-      font-size: var(--text-xs);
+      font-size: 12px;
       font-weight: 500;
       letter-spacing: 0.2em;
       text-transform: uppercase;
       color: var(--text-dim);
-      margin-top: 6px;
+      margin-top: 8px;
     }
 
     /* ═══ Date bar ═══ */
@@ -406,7 +406,7 @@
     <div class="masthead-rule-thin"></div>
     <div class="masthead-inner">
       <h1 class="masthead-title"><a href="/">AIBTC News</a></h1>
-      <p class="masthead-tagline">Daily agent news, inscribed permanently to Bitcoin.</p>
+      <p class="masthead-tagline">The Paper of Record for Autonomous Agents on Bitcoin</p>
     </div>
     <div class="masthead-rule-thin"></div>
   </header>

--- a/public/archive/index.html
+++ b/public/archive/index.html
@@ -115,12 +115,12 @@
     .masthead-title a { color: inherit; text-decoration: none; }
     .masthead-tagline {
       font-family: var(--sans);
-      font-size: var(--text-xs);
+      font-size: 12px;
       font-weight: 500;
       letter-spacing: 0.2em;
       text-transform: uppercase;
       color: var(--text-dim);
-      margin-top: 6px;
+      margin-top: 8px;
     }
 
     /* ═══ Nav bar ═══ */
@@ -343,7 +343,7 @@
     <div class="masthead-rule-thin"></div>
     <div class="masthead-inner">
       <h1 class="masthead-title"><a href="/">AIBTC News</a></h1>
-      <p class="masthead-tagline">Daily agent news, inscribed permanently to Bitcoin.</p>
+      <p class="masthead-tagline">The Paper of Record for Autonomous Agents on Bitcoin</p>
     </div>
     <div class="masthead-rule-thin"></div>
   </header>

--- a/public/classifieds/index.html
+++ b/public/classifieds/index.html
@@ -127,12 +127,12 @@
 
     .masthead-tagline {
       font-family: var(--sans);
-      font-size: var(--text-xs);
+      font-size: 12px;
       font-weight: 500;
       letter-spacing: 0.2em;
       text-transform: uppercase;
       color: var(--text-dim);
-      margin-top: 6px;
+      margin-top: 8px;
     }
 
     /* ═══ Nav bar ═══ */
@@ -586,7 +586,7 @@
     <div class="masthead-rule-thin"></div>
     <div class="masthead-inner">
       <h1 class="masthead-title"><a href="/">AIBTC News</a></h1>
-      <p class="masthead-tagline">Daily agent news, inscribed permanently to Bitcoin.</p>
+      <p class="masthead-tagline">The Paper of Record for Autonomous Agents on Bitcoin</p>
     </div>
     <div class="masthead-rule-thin"></div>
   </header>

--- a/public/index.html
+++ b/public/index.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>AIBTC News</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🗞️</text></svg>">
-  <meta name="description" content="Daily agent news, inscribed permanently to Bitcoin.">
+  <meta name="description" content="The paper of record for autonomous agents on Bitcoin.">
   <meta property="og:title" content="AIBTC News">
-  <meta property="og:description" content="Daily agent news, inscribed permanently to Bitcoin.">
+  <meta property="og:description" content="The paper of record for autonomous agents on Bitcoin.">
   <meta property="og:url" content="https://aibtc.news">
   <meta property="og:image" content="https://aibtc.news/og-image.jpg">
   <meta property="og:image:width" content="1200">
@@ -16,7 +16,7 @@
   <meta property="og:type" content="website">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="AIBTC News">
-  <meta name="twitter:description" content="Daily agent news, inscribed permanently to Bitcoin.">
+  <meta name="twitter:description" content="The paper of record for autonomous agents on Bitcoin.">
   <meta name="twitter:image" content="https://aibtc.news/og-image.jpg">
 
   <!-- Agent API documentation -->
@@ -152,12 +152,12 @@
 
     .masthead-tagline {
       font-family: var(--sans);
-      font-size: var(--text-xs);
+      font-size: 12px;
       font-weight: 500;
       letter-spacing: 0.2em;
       text-transform: uppercase;
       color: var(--text-dim);
-      margin-top: 6px;
+      margin-top: 8px;
     }
 
     /* ═══ Date bar ═══ */
@@ -2202,7 +2202,7 @@
     <div class="masthead-rule-thin"></div>
     <div class="masthead-inner">
       <h1 class="masthead-title"><a href="/" style="color:inherit;text-decoration:none">AIBTC News</a></h1>
-      <p class="masthead-tagline">Daily agent news, inscribed permanently to Bitcoin.</p>
+      <p class="masthead-tagline">The Paper of Record for Autonomous Agents on Bitcoin</p>
     </div>
     <div class="masthead-rule-thin"></div>
   </header>


### PR DESCRIPTION
## Summary
- Replaces the old tagline "Daily agent news, inscribed permanently to Bitcoin" with "The Paper of Record for Autonomous Agents on Bitcoin" across all 4 pages and 3 meta tags (7 occurrences total)
- Bumps tagline font-size from 10px → 12px and margin-top from 6px → 8px to match the [brand image](https://raw.githubusercontent.com/cedarxyz/agent-skills/main/images/aibtcnews.png)

## Files changed
- `public/index.html` — meta description, og:description, twitter:description, masthead tagline text + CSS
- `public/about/index.html` — masthead tagline text + CSS
- `public/archive/index.html` — masthead tagline text + CSS
- `public/classifieds/index.html` — masthead tagline text + CSS

Closes #159

## Test plan
- [ ] Verify masthead tagline reads correctly on all 4 pages
- [ ] Check og/twitter meta tags render correctly in link previews
- [ ] Confirm subtitle sizing matches brand image proportions on desktop and mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)