### PR TITLE
style: fix tab indentation in agent-resolver.ts

### DIFF
--- a/src/services/agent-resolver.ts
+++ b/src/services/agent-resolver.ts
@@ -16,8 +16,8 @@ const BULK_PAGE_SIZE = 100; // max allowed by aibtc.com
 const BULK_MAX_PAGES = 3; // safety cap: 300 agents max
 
 export interface AgentInfo {
-	name: string | null;
-	btcAddress: string | null; // canonical segwit address from aibtc.com
+  name: string | null;
+  btcAddress: string | null; // canonical segwit address from aibtc.com
 }
 
 /**
@@ -25,62 +25,62 @@ export interface AgentInfo {
  * Returns { name, btcAddress } where btcAddress is the segwit address from aibtc.com.
  */
 export async function resolveAgentName(
-	kv: KVNamespace,
-	btcAddress: string,
+  kv: KVNamespace,
+  btcAddress: string,
 ): Promise<AgentInfo> {
-	const cacheKey = `${CACHE_KEY_PREFIX}${btcAddress}`;
+  const cacheKey = `${CACHE_KEY_PREFIX}${btcAddress}`;
 
-	// Check KV cache first
-	const cached = await kv.get(cacheKey);
-	if (cached !== null) {
-		// New JSON format
-		if (cached.startsWith("{")) {
-			return JSON.parse(cached) as AgentInfo;
-		}
-		// Legacy plain-string format: migrate by treating it as name-only
-		return { name: cached || null, btcAddress: null };
-	}
+  // Check KV cache first
+  const cached = await kv.get(cacheKey);
+  if (cached !== null) {
+    // New JSON format
+    if (cached.startsWith("{")) {
+      return JSON.parse(cached) as AgentInfo;
+    }
+    // Legacy plain-string format: migrate by treating it as name-only
+    return { name: cached || null, btcAddress: null };
+  }
 
-	// Cache miss — fetch from external API with 5-second timeout
-	try {
-		const res = await fetch(
-			`${AGENT_API_BASE}/${encodeURIComponent(btcAddress)}`,
-			{
-				headers: { Accept: "application/json" },
-				signal: AbortSignal.timeout(5000),
-			},
-		);
+  // Cache miss — fetch from external API with 5-second timeout
+  try {
+    const res = await fetch(
+      `${AGENT_API_BASE}/${encodeURIComponent(btcAddress)}`,
+      {
+        headers: { Accept: "application/json" },
+        signal: AbortSignal.timeout(5000),
+      },
+    );
 
-		if (res.ok) {
-			const data = (await res.json()) as Record<string, unknown>;
-			const agent = data?.agent as Record<string, unknown> | undefined;
-			const displayName =
-				(agent?.displayName as string | undefined) ||
-				(agent?.name as string | undefined) ||
-				null;
-			const canonicalBtc =
-				(agent?.btcAddress as string | undefined) || null;
+    if (res.ok) {
+      const data = (await res.json()) as Record<string, unknown>;
+      const agent = data?.agent as Record<string, unknown> | undefined;
+      const displayName =
+        (agent?.displayName as string | undefined) ||
+        (agent?.name as string | undefined) ||
+        null;
+      const canonicalBtc =
+        (agent?.btcAddress as string | undefined) || null;
 
-			const info: AgentInfo = { name: displayName, btcAddress: canonicalBtc };
+      const info: AgentInfo = { name: displayName, btcAddress: canonicalBtc };
 
-			// Cache result as JSON (empty name signals "no name" to avoid repeated fetches)
-			await kv.put(cacheKey, JSON.stringify(info), {
-				expirationTtl: CACHE_TTL_SECONDS,
-			});
+      // Cache result as JSON (empty name signals "no name" to avoid repeated fetches)
+      await kv.put(cacheKey, JSON.stringify(info), {
+        expirationTtl: CACHE_TTL_SECONDS,
+      });
 
-			return info;
-		}
-	} catch {
-		// Network error — don't cache, use fallback
-	}
+      return info;
+    }
+  } catch {
+    // Network error — don't cache, use fallback
+  }
 
-	return { name: null, btcAddress: null };
+  return { name: null, btcAddress: null };
 }
 
 interface BulkFetchResult {
-	agents: Map<string, AgentInfo>;
-	/** True only when all pages were fetched successfully (no errors, no truncation). */
-	complete: boolean;
+  agents: Map<string, AgentInfo>;
+  /** True only when all pages were fetched successfully (no errors, no truncation). */
+  complete: boolean;
 }
 
 /**
@@ -90,54 +90,54 @@ interface BulkFetchResult {
  * Much faster than individual lookups: ~0.3s per 100 agents vs ~42s per individual call.
  */
 async function fetchBulkAgents(): Promise<BulkFetchResult> {
-	const allAgents = new Map<string, AgentInfo>();
-	let offset = 0;
-	let complete = false;
+  const allAgents = new Map<string, AgentInfo>();
+  let offset = 0;
+  let complete = false;
 
-	for (let page = 0; page < BULK_MAX_PAGES; page++) {
-		try {
-			const res = await fetch(
-				`${AGENT_API_BASE}?limit=${BULK_PAGE_SIZE}&offset=${offset}`,
-				{
-					headers: { Accept: "application/json" },
-					signal: AbortSignal.timeout(10000),
-				},
-			);
+  for (let page = 0; page < BULK_MAX_PAGES; page++) {
+    try {
+      const res = await fetch(
+        `${AGENT_API_BASE}?limit=${BULK_PAGE_SIZE}&offset=${offset}`,
+        {
+          headers: { Accept: "application/json" },
+          signal: AbortSignal.timeout(10000),
+        },
+      );
 
-			if (!res.ok) break;
+      if (!res.ok) break;
 
-			const data = (await res.json()) as {
-				agents: Array<Record<string, unknown>>;
-				pagination?: { hasMore?: boolean };
-			};
+      const data = (await res.json()) as {
+        agents: Array<Record<string, unknown>>;
+        pagination?: { hasMore?: boolean };
+      };
 
-			for (const agent of data.agents) {
-				const btcAddr = agent.btcAddress as string | undefined;
-				if (!btcAddr) continue;
+      for (const agent of data.agents) {
+        const btcAddr = agent.btcAddress as string | undefined;
+        if (!btcAddr) continue;
 
-				const displayName =
-					(agent.displayName as string | undefined) ||
-					(agent.name as string | undefined) ||
-					null;
+        const displayName =
+          (agent.displayName as string | undefined) ||
+          (agent.name as string | undefined) ||
+          null;
 
-				allAgents.set(btcAddr, {
-					name: displayName,
-					btcAddress: btcAddr,
-				});
-			}
+        allAgents.set(btcAddr, {
+          name: displayName,
+          btcAddress: btcAddr,
+        });
+      }
 
-			if (!data.pagination?.hasMore) {
-				complete = true;
-				break;
-			}
-			offset += BULK_PAGE_SIZE;
-		} catch {
-			// Network error on this page — return what we have so far
-			break;
-		}
-	}
+      if (!data.pagination?.hasMore) {
+        complete = true;
+        break;
+      }
+      offset += BULK_PAGE_SIZE;
+    } catch {
+      // Network error on this page — return what we have so far
+      break;
+    }
+  }
 
-	return { agents: allAgents, complete };
+  return { agents: allAgents, complete };
 }
 
 /**
@@ -151,77 +151,77 @@ async function fetchBulkAgents(): Promise<BulkFetchResult> {
  * 4. Return a Map<address, AgentInfo> for all requested addresses
  */
 export async function resolveAgentNames(
-	kv: KVNamespace,
-	addresses: string[],
+  kv: KVNamespace,
+  addresses: string[],
 ): Promise<Map<string, AgentInfo>> {
-	const unique = [...new Set(addresses)];
-	const infoMap = new Map<string, AgentInfo>();
-	const uncached: string[] = [];
+  const unique = [...new Set(addresses)];
+  const infoMap = new Map<string, AgentInfo>();
+  const uncached: string[] = [];
 
-	// Step 1: Check KV cache for all addresses in parallel
-	const cacheResults = await Promise.allSettled(
-		unique.map(async (addr) => {
-			const cached = await kv.get(`${CACHE_KEY_PREFIX}${addr}`);
-			return { addr, cached };
-		}),
-	);
+  // Step 1: Check KV cache for all addresses in parallel
+  const cacheResults = await Promise.allSettled(
+    unique.map(async (addr) => {
+      const cached = await kv.get(`${CACHE_KEY_PREFIX}${addr}`);
+      return { addr, cached };
+    }),
+  );
 
-	for (const result of cacheResults) {
-		if (result.status !== "fulfilled") continue;
-		const { addr, cached } = result.value;
+  for (const result of cacheResults) {
+    if (result.status !== "fulfilled") continue;
+    const { addr, cached } = result.value;
 
-		if (cached !== null) {
-			if (cached.startsWith("{")) {
-				infoMap.set(addr, JSON.parse(cached) as AgentInfo);
-			} else {
-				infoMap.set(addr, { name: cached || null, btcAddress: null });
-			}
-		} else {
-			uncached.push(addr);
-		}
-	}
+    if (cached !== null) {
+      if (cached.startsWith("{")) {
+        infoMap.set(addr, JSON.parse(cached) as AgentInfo);
+      } else {
+        infoMap.set(addr, { name: cached || null, btcAddress: null });
+      }
+    } else {
+      uncached.push(addr);
+    }
+  }
 
-	// Step 2: If all addresses were cached, return immediately
-	if (uncached.length === 0) return infoMap;
+  // Step 2: If all addresses were cached, return immediately
+  if (uncached.length === 0) return infoMap;
 
-	// Step 3: Fetch bulk agent list and match against uncached addresses
-	const { agents: bulkAgents, complete } = await fetchBulkAgents();
-	const uncachedSet = new Set(uncached);
+  // Step 3: Fetch bulk agent list and match against uncached addresses
+  const { agents: bulkAgents, complete } = await fetchBulkAgents();
+  const uncachedSet = new Set(uncached);
 
-	// Step 4: Populate KV cache for ALL fetched agents (pre-warm) and resolve our addresses
-	const kvWrites: Promise<void>[] = [];
+  // Step 4: Populate KV cache for ALL fetched agents (pre-warm) and resolve our addresses
+  const kvWrites: Promise<void>[] = [];
 
-	for (const [btcAddr, info] of bulkAgents) {
-		const cacheKey = `${CACHE_KEY_PREFIX}${btcAddr}`;
-		kvWrites.push(
-			kv.put(cacheKey, JSON.stringify(info), {
-				expirationTtl: CACHE_TTL_SECONDS,
-			}),
-		);
+  for (const [btcAddr, info] of bulkAgents) {
+    const cacheKey = `${CACHE_KEY_PREFIX}${btcAddr}`;
+    kvWrites.push(
+      kv.put(cacheKey, JSON.stringify(info), {
+        expirationTtl: CACHE_TTL_SECONDS,
+      }),
+    );
 
-		if (uncachedSet.has(btcAddr)) {
-			infoMap.set(btcAddr, info);
-			uncachedSet.delete(btcAddr);
-		}
-	}
+    if (uncachedSet.has(btcAddr)) {
+      infoMap.set(btcAddr, info);
+      uncachedSet.delete(btcAddr);
+    }
+  }
 
-	// Only negative-cache addresses as "not found" when the bulk fetch completed fully.
-	// A partial fetch (network error, pagination cap) might have missed real agents,
-	// and we don't want to incorrectly cache them as absent for 24 hours.
-	if (complete) {
-		for (const addr of uncachedSet) {
-			const info: AgentInfo = { name: null, btcAddress: null };
-			infoMap.set(addr, info);
-			kvWrites.push(
-				kv.put(`${CACHE_KEY_PREFIX}${addr}`, JSON.stringify(info), {
-					expirationTtl: CACHE_TTL_SECONDS,
-				}),
-			);
-		}
-	}
+  // Only negative-cache addresses as "not found" when the bulk fetch completed fully.
+  // A partial fetch (network error, pagination cap) might have missed real agents,
+  // and we don't want to incorrectly cache them as absent for 24 hours.
+  if (complete) {
+    for (const addr of uncachedSet) {
+      const info: AgentInfo = { name: null, btcAddress: null };
+      infoMap.set(addr, info);
+      kvWrites.push(
+        kv.put(`${CACHE_KEY_PREFIX}${addr}`, JSON.stringify(info), {
+          expirationTtl: CACHE_TTL_SECONDS,
+        }),
+      );
+    }
+  }
 
-	// Fire KV writes in parallel and wait for all of them to settle
-	await Promise.allSettled(kvWrites);
+  // Fire KV writes in parallel and wait for all of them to settle
+  await Promise.allSettled(kvWrites);
 
-	return infoMap;
+  return infoMap;
 }


### PR DESCRIPTION
## Summary
- Convert tabs to 2-space indentation in `agent-resolver.ts` to match codebase convention
- Pure whitespace change (174 lines), no logic modifications
- Supersedes #170 which was branched before the bulk resolution rewrite landed

## Test plan
- [x] `tsc --noEmit` passes
- [x] 133/133 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)