### PR TITLE
fix(x402): Unicode-safe base64 encoding for payment-required header

### DIFF
--- a/src/services/x402.ts
+++ b/src/services/x402.ts
@@ -51,20 +51,12 @@ export function buildPaymentRequired(opts: PaymentRequiredOpts): Response {
     ],
   };
 
-  // btoa() only handles Latin-1 (code points 0x00–0xFF). Descriptions containing
-  // Unicode characters like em dashes (—, U+2014) silently fail with btoa and the
-  // payment-required header is never set, breaking the x402 handshake entirely.
-  // Use TextEncoder to produce UTF-8 bytes, then btoa the byte string — this is
-  // compatible with the client's Buffer.from(encoded, "base64").toString("utf-8").
+  // btoa() rejects characters above U+00FF, so Unicode descriptions (e.g. em dashes)
+  // must be UTF-8 encoded first. The client decodes with Buffer.from(b64, "base64").
   let encoded: string | undefined;
   try {
-    const jsonStr = JSON.stringify(paymentRequirements);
-    const bytes = new TextEncoder().encode(jsonStr);
-    let binary = "";
-    for (const byte of bytes) {
-      binary += String.fromCharCode(byte);
-    }
-    encoded = btoa(binary);
+    const bytes = new TextEncoder().encode(JSON.stringify(paymentRequirements));
+    encoded = btoa(String.fromCharCode(...bytes));
   } catch {
     // Encoding failure should not crash — body still contains payment details
   }


### PR DESCRIPTION
## Root Cause

Closes #181.

`btoa()` only handles Latin-1 characters (code points 0x00–0xFF). The classifieds 402 response calls:

```typescript
encoded = btoa(JSON.stringify(paymentRequirements));
```

The `paymentRequirements` object includes a `description` field containing an em dash (`—`, U+2014, code point 8212 > 255), which is outside the Latin-1 range. `btoa()` throws `InvalidCharacterError`, the `catch` swallows it silently, `encoded` stays `undefined`, and the `payment-required` header is **never set** on the 402 response.

**Confirmed via live curl:**
```
HTTP/2 402
access-control-expose-headers: payment-required,payment-response  ← listed but never set
content-type: application/json
...
{"error":"Payment Required","message":"Classified ad listing — place your ad for 30000 sats sBTC",...}
```

The CORS middleware correctly exposes the `payment-required` header, but no value is ever emitted. The x402 client reads the header, finds nothing, falls back to v1 body parsing, and fails because the body uses `payTo` (not `recipient`) with no `network` field — neither the v2 header path nor the v1 fallback path can complete the handshake.

## Fix

Replace `btoa(JSON.stringify(...))` with a Unicode-safe TextEncoder approach:

```typescript
const jsonStr = JSON.stringify(paymentRequirements);
const bytes = new TextEncoder().encode(jsonStr);
let binary = "";
for (const byte of bytes) {
  binary += String.fromCharCode(byte);
}
encoded = btoa(binary);
```

This produces base64-encoded UTF-8 bytes, which is exactly what the client already expects:
```javascript
Buffer.from(encoded, "base64").toString("utf-8")
```

Affects `GET /api/brief/:date` and `POST /api/classifieds` — any endpoint using `buildPaymentRequired` with a description containing non-ASCII characters.

## Verification

1. POST `/api/classifieds` without payment header
2. Confirm `payment-required` header is now present in the 402 response
3. Base64-decode it and confirm `accepts[0]` contains `scheme`, `network`, `amount`, `asset`, `payTo`
4. x402 client should be able to construct and submit a payment

🤖 Generated with [Claude Code](https://claude.com/claude-code)