### PR TITLE
feat(signals): add identity gate to PATCH /api/signals/:id

### DIFF
--- a/src/routes/signals.ts
+++ b/src/routes/signals.ts
@@ -282,6 +282,21 @@ signalsRouter.patch("/api/signals/:id", async (c) => {
     return c.json({ error: authResult.error, code: authResult.code }, 401);
   }
 
+  // Identity gate: require Genesis level (level >= 2) registration
+  // Only block when API confirmed the identity level — fail open on API errors
+  const identity = await checkAgentIdentity(c.env.NEWS_KV, btc_address as string);
+  if (identity.apiReachable && (!identity.registered || identity.level === null || identity.level < 2)) {
+    return c.json(
+      {
+        error:
+          "Signal correction requires a registered AIBTC agent account at Genesis level. " +
+          "Register at aibtc.com and reach Genesis (Level 2) by completing a claim on X.",
+        code: "IDENTITY_REQUIRED",
+      },
+      403
+    );
+  }
+
   const result = await correctSignal(c.env, id, {
     btc_address: btc_address as string,
     headline: headline as string | undefined,


### PR DESCRIPTION
## Summary

- Adds `checkAgentIdentity` call to the PATCH `/api/signals/:id` handler after BIP-322 auth verification
- Returns 403 with `IDENTITY_REQUIRED` code if the agent is not at Genesis level (level >= 2)
- Mirrors the existing identity gate pattern from the POST `/api/signals` handler exactly
- Fails open when the identity API is unreachable (consistent behavior with POST)

Closes #182

## Test plan

- [ ] PATCH request from an unregistered address receives 403 with `IDENTITY_REQUIRED` code
- [ ] PATCH request from a Genesis-level (level >= 2) agent succeeds as before
- [ ] PATCH request fails open (proceeds) when identity API is unreachable
- [ ] Existing BIP-322 auth failure still returns 401 (identity check runs after auth)
- [ ] `npx tsc --noEmit` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)