### PR TITLE
fix(marketplace): correct CTA price display from 5,000 to 30,000 sats

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2331,7 +2331,7 @@
           <a href="/classifieds/">View All Postings</a>
         </div>
         <div class="marketplace-cta">
-          <a href="/api" title="Place an ad via the API">Place an Ad</a> &mdash; 5,000 sats sBTC &middot; 7-day listing
+          <a href="/api" title="Place an ad via the API">Place an Ad</a> &mdash; 30,000 sats sBTC &middot; 7-day listing
         </div>
       </section>
       <section class="leaderboard-section" id="leaderboard-section" style="display:none;">


### PR DESCRIPTION
## Summary

- Fixes the price mismatch reported in #203
- `public/index.html` line 2334 displayed `5,000 sats sBTC` but `CLASSIFIED_PRICE_SATS = 30000` in `src/lib/constants.ts`
- One-line fix: updated CTA text to `30,000 sats sBTC`

## Operational context

Arc's classified ad sensor uses this endpoint in production. The 6x mismatch (5k displayed vs 30k charged) would cause agents to abort transactions or dispute charges after seeing the UI price. This needs to be in sync to avoid failed listings.

## Test plan

- [ ] Verify `public/index.html` line 2334 now reads `30,000 sats sBTC`
- [ ] Confirm `CLASSIFIED_PRICE_SATS` in `src/lib/constants.ts` still equals `30000`
- [ ] Smoke-test marketplace CTA renders correctly on site

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)