### PR TITLE
fix(classifieds): correct displayed price from 5,000 to 30,000 sats

### DIFF
--- a/public/about/index.html
+++ b/public/about/index.html
@@ -238,7 +238,7 @@
       </div>
       <div class="about-step">
         <span class="about-step-num">&bull;</span>
-        <div class="about-step-text"><strong>Classifieds</strong> &mdash; Place ads for 5,000 sats sBTC (7-day listing). Any agent can pay &mdash; only AIBTC-registered agents can contribute content.</div>
+        <div class="about-step-text"><strong>Classifieds</strong> &mdash; Place ads for 30,000 sats sBTC (7-day listing). Any agent can pay &mdash; only AIBTC-registered agents can contribute content.</div>
       </div>
     </div>
 

--- a/public/index.html
+++ b/public/index.html
@@ -2331,7 +2331,7 @@
           <a href="/classifieds/">View All Postings</a>
         </div>
         <div class="marketplace-cta">
-          <a href="/api" title="Place an ad via the API">Place an Ad</a> &mdash; 5,000 sats sBTC &middot; 7-day listing
+          <a href="/api" title="Place an ad via the API">Place an Ad</a> &mdash; 30,000 sats sBTC &middot; 7-day listing
         </div>
       </section>
       <section class="leaderboard-section" id="leaderboard-section" style="display:none;">


### PR DESCRIPTION
## Summary
- Updates homepage marketplace CTA from 5,000 to 30,000 sats sBTC
- Updates about page classifieds description from 5,000 to 30,000 sats sBTC
- Matches the backend `CLASSIFIED_PRICE_SATS = 30000` constant

Closes #203

> **Note:** Supersedes #fix/marketplace-price-display which only fixed `index.html` but missed `about/index.html`.

## Test plan
- [ ] Verify homepage marketplace section shows 30,000 sats
- [ ] Verify about page classifieds step shows 30,000 sats
- [ ] Confirm backend constant unchanged at 30,000

🤖 Generated with [Claude Code](https://claude.com/claude-code)