### PR TITLE
fix(identity): correct Clarity string-ascii encoding and add payout idempotency

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -142,3 +142,8 @@ export const BRIEF_INSCRIBE_RATE_LIMIT = {
 
 // ── Config keys ──
 export const CONFIG_PUBLISHER_ADDRESS = "publisher_btc_address" as const;
+
+// ── ERC-8004 identity registry ──
+export const ERC8004_REGISTRY_CONTRACT =
+  "SP1NMR7MY0TJ1QA7WQBZ6504KC79PZNTRQH4YGFJD.identity-registry-v2" as const;
+export const ERC8004_CACHE_TTL_SECONDS = 3600; // 1 hour

--- a/src/middleware/identity-gate.ts
+++ b/src/middleware/identity-gate.ts
@@ -1,0 +1,56 @@
+/**
+ * ERC-8004 identity gate middleware.
+ *
+ * When enabled (config key `erc8004_gate_enabled` = "true"), requires
+ * signal submitters to have a registered ERC-8004 identity NFT with
+ * a matching BTC address in the identity registry.
+ *
+ * Disabled by default — must be explicitly enabled via config after
+ * verifying the on-chain registry has sufficient active registrations.
+ *
+ * Pass-through assumption: when `X-BTC-Address` header is absent and
+ * the gate is enabled, the request is passed through to the downstream
+ * handler. This is safe because BIP-322 auth always requires the header
+ * to be present — submissions without it will be rejected by `verifyAuth`.
+ */
+
+import type { Context, Next } from "hono";
+import type { Env, AppVariables } from "../lib/types";
+import { getConfig } from "../lib/do-client";
+import { resolveIdentity } from "../services/identity";
+
+const CONFIG_GATE_ENABLED = "erc8004_gate_enabled";
+
+export async function identityGate(
+  c: Context<{ Bindings: Env; Variables: AppVariables }>,
+  next: Next
+): Promise<Response | void> {
+  const gateConfig = await getConfig(c.env, CONFIG_GATE_ENABLED);
+  if (!gateConfig || gateConfig.value !== "true") {
+    // Gate disabled — allow all submissions through
+    return next();
+  }
+
+  const btcAddress = c.req.header("X-BTC-Address");
+  if (!btcAddress) {
+    // No address header present — pass through to downstream BIP-322 auth check
+    return next();
+  }
+
+  const identity = await resolveIdentity(c.env.NEWS_KV, btcAddress);
+
+  if (!identity || !identity.verified) {
+    return c.json(
+      {
+        error:
+          "Signal submission requires a registered agent identity (ERC-8004 NFT) with a matching Bitcoin address.",
+        hint: "Register at aibtc.com and add your BTC address to your agent profile.",
+        docs: "https://aibtc.com/docs/identity",
+        btcAddress,
+      },
+      403
+    );
+  }
+
+  return next();
+}

--- a/src/routes/earnings.ts
+++ b/src/routes/earnings.ts
@@ -1,17 +1,107 @@
 /**
- * Earnings route — correspondent earning history.
+ * Earnings route — correspondent earning history and payout recording.
  *
- * GET   /api/earnings/:address — list earnings for a BTC address
- * PATCH /api/earnings/:id      — Publisher records sBTC txid after sending payout
+ * POST  /api/payouts/record     — Publisher records brief inclusion earnings (idempotent)
+ * GET   /api/earnings/:address  — list earnings for a BTC address
+ * PATCH /api/earnings/:id       — Publisher records sBTC txid after sending payout
  */
 
 import { Hono } from "hono";
 import type { Env, AppVariables, Earning } from "../lib/types";
 import { validateBtcAddress } from "../lib/validators";
-import { listEarnings, updateEarning } from "../lib/do-client";
+import {
+  listEarnings,
+  updateEarning,
+  getBriefSignals,
+  recordBriefInclusionPayouts,
+  getConfig,
+} from "../lib/do-client";
 import { verifyAuth } from "../services/auth";
+import { CONFIG_PUBLISHER_ADDRESS } from "../lib/constants";
 
 const earningsRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>();
+
+// POST /api/payouts/record — Publisher records brief inclusion earnings (Publisher-only, idempotent)
+// Calls POST /payouts/brief-inclusion in the DO, which uses INSERT OR IGNORE — safe to retry.
+earningsRouter.post("/api/payouts/record", async (c) => {
+  let body: Record<string, unknown>;
+  try {
+    body = await c.req.json<Record<string, unknown>>();
+  } catch {
+    return c.json({ error: "Invalid JSON body" }, 400);
+  }
+
+  const { btc_address, brief_date } = body;
+
+  if (!btc_address || typeof btc_address !== "string") {
+    return c.json({ error: "Missing required field: btc_address" }, 400);
+  }
+  if (!brief_date || typeof brief_date !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(brief_date)) {
+    return c.json({ error: "Missing or invalid field: brief_date (expected YYYY-MM-DD)" }, 400);
+  }
+
+  if (!validateBtcAddress(btc_address)) {
+    return c.json({ error: "Invalid BTC address format" }, 400);
+  }
+
+  // BIP-322 auth — Publisher must sign the request
+  const authResult = verifyAuth(
+    c.req.raw.headers,
+    btc_address,
+    "POST",
+    "/api/payouts/record"
+  );
+  if (!authResult.valid) {
+    return c.json({ error: authResult.error, code: authResult.code }, 401);
+  }
+
+  // Verify caller is the designated Publisher
+  const publisherConfig = await getConfig(c.env, CONFIG_PUBLISHER_ADDRESS);
+  if (!publisherConfig || publisherConfig.value !== btc_address) {
+    return c.json({ error: "Only the designated Publisher can record payouts" }, 403);
+  }
+
+  // Look up signals included in this brief
+  let briefSignals: unknown[];
+  try {
+    briefSignals = await getBriefSignals(c.env, brief_date);
+  } catch {
+    return c.json({ error: `Failed to fetch brief signals for ${brief_date}` }, 503);
+  }
+
+  if (briefSignals.length === 0) {
+    return c.json({ error: `No signals found in brief for ${brief_date}` }, 404);
+  }
+
+  // Extract signal IDs and call the idempotent DO payout endpoint
+  const signalIds = briefSignals
+    .map((s) => (s as Record<string, unknown>).signal_id as string)
+    .filter(Boolean);
+
+  const result = await recordBriefInclusionPayouts(c.env, brief_date, signalIds);
+
+  if (!result.ok) {
+    return c.json({ error: result.error ?? "Failed to record payouts" }, 500);
+  }
+
+  const logger = c.get("logger");
+  logger.info("brief payouts recorded", {
+    brief_date,
+    paid: result.data?.paid,
+    skipped: result.data?.skipped,
+    publisher: btc_address,
+  });
+
+  return c.json(
+    {
+      ok: true,
+      brief_date,
+      paid: result.data?.paid ?? 0,
+      skipped: result.data?.skipped ?? 0,
+    },
+    201
+  );
+});
 
 // GET /api/earnings/:address — earning history for a correspondent
 earningsRouter.get("/api/earnings/:address", async (c) => {

--- a/src/routes/signals.ts
+++ b/src/routes/signals.ts
@@ -18,6 +18,7 @@ import {
 } from "../lib/do-client";
 import { verifyAuth } from "../services/auth";
 import { checkAgentIdentity } from "../services/identity-gate";
+import { identityGate } from "../middleware/identity-gate";
 
 const signalsRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>();
 
@@ -94,7 +95,7 @@ signalsRouter.get("/api/signals/:id", async (c) => {
 });
 
 // POST /api/signals — submit a new signal (rate limited, BIP-322 auth required)
-signalsRouter.post("/api/signals", signalRateLimit, async (c) => {
+signalsRouter.post("/api/signals", signalRateLimit, identityGate, async (c) => {
   let body: Record<string, unknown>;
   try {
     body = await c.req.json<Record<string, unknown>>();

--- a/src/services/identity.ts
+++ b/src/services/identity.ts
@@ -1,0 +1,113 @@
+/**
+ * ERC-8004 identity verification service.
+ *
+ * Resolves BTC addresses to ERC-8004 agent identities by querying the
+ * identity-registry-v2 contract on Stacks mainnet via Hiro call-read-only API.
+ * Results are cached in KV with a configurable TTL.
+ */
+
+import { ERC8004_REGISTRY_CONTRACT, ERC8004_CACHE_TTL_SECONDS } from "../lib/constants";
+
+const [REGISTRY_ADDRESS, REGISTRY_NAME] = ERC8004_REGISTRY_CONTRACT.split(".");
+
+export interface AgentIdentity {
+  agentId: number;
+  btcAddress: string;
+  verified: boolean;
+  cachedAt: string;
+}
+
+/**
+ * Check if a BTC address has a registered ERC-8004 identity.
+ * Uses KV cache to avoid per-request contract calls.
+ *
+ * Returns the agent identity if verified, null if not registered or on API error.
+ */
+export async function resolveIdentity(
+  kv: KVNamespace,
+  btcAddress: string
+): Promise<AgentIdentity | null> {
+  const cacheKey = `erc8004:${btcAddress}`;
+
+  // Check cache first
+  const cached = await kv.get(cacheKey, "json");
+  if (cached) {
+    return cached as AgentIdentity;
+  }
+
+  // Query the identity registry via Hiro call-read-only API.
+  // get-agent-by-wallet takes a (string-ascii 62) argument.
+  try {
+    // Clarity string-ascii CV encoding:
+    //   type_id  = 0x0d (1 byte)
+    //   length   = 4-byte big-endian length of the string
+    //   payload  = UTF-8 bytes of the string
+    const bytes = Array.from(new TextEncoder().encode(btcAddress));
+    const lenHex = bytes.length.toString(16).padStart(8, "0"); // 4-byte BE length
+    const payloadHex = bytes.map((b) => b.toString(16).padStart(2, "0")).join("");
+    const clarityArg = `0x0d${lenHex}${payloadHex}`;
+
+    const response = await fetch(
+      `https://api.hiro.so/v2/contracts/call-read/${REGISTRY_ADDRESS}/${REGISTRY_NAME}/get-agent-by-wallet`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sender: REGISTRY_ADDRESS,
+          arguments: [clarityArg],
+        }),
+      }
+    );
+
+    if (!response.ok) {
+      // Contract call failed — don't cache, allow retry
+      return null;
+    }
+
+    const data = (await response.json()) as { okay: boolean; result: string };
+
+    if (!data.okay || !data.result || data.result.startsWith("0x09")) {
+      // (none) response — agent not found. Cache negatives with shorter TTL.
+      const negativeResult: AgentIdentity = {
+        agentId: 0,
+        btcAddress,
+        verified: false,
+        cachedAt: new Date().toISOString(),
+      };
+      await kv.put(cacheKey, JSON.stringify(negativeResult), {
+        expirationTtl: Math.floor(ERC8004_CACHE_TTL_SECONDS / 4), // 15 min
+      });
+      return null;
+    }
+
+    // Parse (some ...) response — extract agent ID from optional uint.
+    // Clarity optional uint: 0x0a (some) + 0x01 (uint type) + 16-byte big-endian uint.
+    const agentId = parseInt(data.result.slice(6, 38), 16) || 0;
+
+    const identity: AgentIdentity = {
+      agentId,
+      btcAddress,
+      verified: true,
+      cachedAt: new Date().toISOString(),
+    };
+
+    await kv.put(cacheKey, JSON.stringify(identity), {
+      expirationTtl: ERC8004_CACHE_TTL_SECONDS,
+    });
+
+    return identity;
+  } catch {
+    // Network error — don't cache, allow retry
+    return null;
+  }
+}
+
+/**
+ * Invalidate the cached identity for a BTC address.
+ */
+export async function invalidateIdentityCache(
+  kv: KVNamespace,
+  btcAddress: string
+): Promise<void> {
+  await kv.delete(`erc8004:${btcAddress}`);
+}


### PR DESCRIPTION
## Summary

Fixes two blocking bugs from issue #113 that would cause the ERC-8004 identity gate to block all agents when enabled:

- **Clarity string-ascii encoding** (`src/services/identity.ts`): The `get-agent-by-wallet` call was missing the required 4-byte big-endian length prefix. Format is `0x0d` + 4-byte BE length + UTF-8 payload. Without this, `resolveIdentity()` returned null on every call.
- **Payout idempotency** (`src/routes/earnings.ts`): `POST /api/payouts/record` now routes through `recordBriefInclusionPayouts()` → DO's `POST /payouts/brief-inclusion`, which uses `INSERT OR IGNORE` with the existing `idx_earnings_reason_ref` unique index. Repeated calls for the same `brief_date` skip already-recorded rows.

Also adds:
- `src/middleware/identity-gate.ts`: ERC-8004 gate wired into `POST /api/signals`, disabled by default via `erc8004_gate_enabled` config key. Documents the missing-header pass-through assumption (safe: BIP-322 auth always requires the header).
- ERC-8004 registry constants in `src/lib/constants.ts`.

Gate remains disabled until on-chain registry has sufficient active registrations.

## Test plan

- [ ] `POST /api/signals` with gate disabled (`erc8004_gate_enabled` unset) — no identity check, existing tests unaffected
- [ ] `POST /api/signals` with gate enabled + unregistered address → 403 with hint
- [ ] `POST /api/signals` with gate enabled + no `X-BTC-Address` header → passes to BIP-322 auth
- [ ] `POST /api/payouts/record` called twice for same `brief_date` → second call returns `paid: 0, skipped: N` (no duplicates)
- [ ] TypeScript typecheck: `bunx tsc --noEmit` passes

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)