### PR TITLE
fix(x402): surface relay rejection reason in classifieds 402 response

### DIFF
--- a/src/routes/classifieds.ts
+++ b/src/routes/classifieds.ts
@@ -167,10 +167,14 @@ classifiedsRouter.post(
       logger.warn("payment verification failed for POST /api/classifieds", {
         category,
         headline,
+        relayReason: verification.relayReason,
       });
+      const reason = verification.relayReason
+        ? ` Relay: ${verification.relayReason}`
+        : "";
       return buildPaymentRequired({
         amount: CLASSIFIED_PRICE_SATS,
-        description: `Payment verification failed. Please pay ${CLASSIFIED_PRICE_SATS} sats sBTC to place a classified ad.`,
+        description: `Payment verification failed.${reason} Please pay ${CLASSIFIED_PRICE_SATS} sats sBTC to place a classified ad.`,
       });
     }
 

--- a/src/services/x402.ts
+++ b/src/services/x402.ts
@@ -27,6 +27,8 @@ export interface PaymentVerifyResult {
    * who already paid does not retry payment unnecessarily.
    */
   relayError?: boolean;
+  /** Human-readable reason from the relay when settlement fails (for diagnostics). */
+  relayReason?: string;
 }
 
 /**
@@ -152,7 +154,11 @@ export async function verifyPayment(
   // 4xx = schema/idempotency error; 2xx + !success = payment rejected by relay.
   // Both are payment-invalid, not transient relay errors (5xx handled above).
   if (!result.success) {
-    return { valid: false };
+    console.error("[x402] relay settle rejected:", JSON.stringify(result));
+    return {
+      valid: false,
+      relayReason: (result.error as string) ?? (result.message as string) ?? JSON.stringify(result),
+    };
   }
 
   return {


### PR DESCRIPTION
## Summary
- When the relay returns `success: false` during classifieds payment settlement, the error details were silently discarded — callers only saw "Payment verification failed" with no way to diagnose why
- Now logs the relay response and includes the relay's error/message in the 402 response description
- Adds `relayReason` field to `PaymentVerifyResult` interface

## Context
Discovered while testing classifieds posting via the MCP server. The x402 interceptor kept getting 402 back after payment, but the response gave no indication of the relay's actual rejection reason. This made it impossible to debug from the client side.

## Test plan
- [ ] Deploy to staging and POST a classified with payment — verify the 402 response now includes the relay reason
- [ ] Confirm relay errors (5xx) still return 503 with the existing `relayError` path
- [ ] Confirm successful payments still work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)