### PR TITLE
fix(x402): increase settle timeout and handle pending status

### DIFF
--- a/src/routes/brief.ts
+++ b/src/routes/brief.ts
@@ -105,7 +105,16 @@ briefRouter.get("/api/brief/:date", async (c) => {
 
     const verification = await verifyPayment(paymentHeader, BRIEF_PRICE_SATS);
     if (!verification.valid) {
-      return c.json({ error: "Payment verification failed" }, 402);
+      if (verification.relayError) {
+        return c.json(
+          { error: "Payment relay unavailable. Your payment was not consumed — please retry shortly." },
+          503
+        );
+      }
+      const reason = verification.relayReason
+        ? ` Relay: ${verification.relayReason}`
+        : "";
+      return c.json({ error: `Payment verification failed.${reason}` }, 402);
     }
 
     // Record earnings split: correspondent share + treasury remainder

--- a/src/services/x402.ts
+++ b/src/services/x402.ts
@@ -109,7 +109,7 @@ export async function verifyPayment(
 
   try {
     const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 10_000);
+    const timeoutId = setTimeout(() => controller.abort(), 30_000);
 
     try {
       settleRes = await fetch(`${X402_RELAY_URL}/settle`, {
@@ -154,6 +154,16 @@ export async function verifyPayment(
   // 4xx = schema/idempotency error; 2xx + !success = payment rejected by relay.
   // Both are payment-invalid, not transient relay errors (5xx handled above).
   if (!result.success) {
+    // Treat "pending" status as valid — the tx was broadcast successfully and
+    // confirmation is async.  The relay just hasn't seen it confirm yet.
+    if (result.status === "pending") {
+      return {
+        valid: true,
+        txid: result.transaction as string | undefined,
+        payer: result.payer as string | undefined,
+      };
+    }
+
     console.error("[x402] relay settle rejected:", JSON.stringify(result));
     return {
       valid: false,


### PR DESCRIPTION
## Summary
- Bump relay settle timeout from 10s to 30s to accommodate sponsored settlement flow
- Treat relay `status: "pending"` responses as valid (tx broadcast succeeded, confirmation is async)
- Align `GET /api/brief/:date` error handling with classifieds — return 503 for relay errors instead of generic 402, and surface relay rejection reason

Closes #217

## Test plan
- [ ] POST classified with x402 payment — verify no 503 when relay takes >10s but <30s
- [ ] Verify pending relay responses are accepted as valid payments
- [ ] GET /api/brief/:date with payment when relay is down — should return 503 not 402
- [ ] GET /api/brief/:date with invalid payment — should return 402 with relay reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)