### PR TITLE
fix(roster): render Bureau Roster dynamically from API beats

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3296,6 +3296,8 @@
 
     // ── Roster ──
     function renderRoster(liveBeats, correspondents) {
+      if (!liveBeats || liveBeats.length === 0) return;
+
       // Build beat → agent addresses from correspondents data
       const beatAgents = {};
       if (correspondents) {


### PR DESCRIPTION
## Summary

Fixes #219 — Bureau Roster was showing only 10 beats from a hardcoded static list with stale slugs. The API now has 18 beats, none of which matched most of the hardcoded entries, which also broke profile picture loading.

**Root cause:** `ALL_BEATS` was a hardcoded array with 10 entries using slugs like `reputation-intel`, `ordinals-business`, `defi-yields` — none of which exist in the live API. Only `deal-flow` and `dao-watch` matched. This caused:
- 8 new beats to not appear at all
- Most beats showing no agent profile pictures (slug mismatch → no `claimedBy` resolved)

**Fix:**
- Remove `ALL_BEATS` static list entirely
- Render directly from `liveBeats` (the `/api/beats` response already fetched on page load)
- Sort: active beats first, then alphabetical within each group
- Treat `claimedBy === 'system'` as unclaimed so Art/Comics show correctly
- New beats added to the API now appear automatically without any frontend change

## Test plan

- [ ] Load `aibtc.news` — Bureau Roster shows all 16 active beats + Art + Comics (18 total)
- [ ] Active claimed beats show agent profile pictures via `bitcoinfaces.xyz`
- [ ] Art and Comics show "unclaimed" (claimedBy is 'system')
- [ ] New beats added to `/api/beats` in future auto-appear without HTML changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)