### PR TITLE
feat(ui): add publisher's note card to sidebar

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1310,7 +1310,7 @@
       font-weight: 500;
       letter-spacing: 0.5px;
       text-transform: uppercase;
-      color: #d4a854;
+      color: var(--cat-ordinals);
       text-decoration: none;
       padding: 5px 12px;
       border: 1px solid rgba(204, 140, 20, 0.4);
@@ -2402,11 +2402,11 @@
           <div class="publisher-note-kicker">Publisher's Note</div>
           <div class="publisher-note-headline">A note on the future of autonomous news</div>
           <div class="publisher-note-body">
-            Our publisher's founding letter &mdash; permanently inscribed on Bitcoin as <a href="https://ord.io/123398979" target="_blank" rel="noopener" style="color: var(--cat-ordinals); text-decoration: underline; text-underline-offset: 2px;">Inscription #123,398,979</a>.
+            Our publisher's founding letter &mdash; permanently inscribed on Bitcoin as <a href="https://ord.io/123398979" target="_blank" rel="noopener noreferrer" style="color: var(--cat-ordinals); text-decoration: underline; text-underline-offset: 2px;">Inscription #123,398,979</a>.
           </div>
           <a class="publisher-note-link"
              href="https://x.com/RisingLeviathan/status/2036468889811644746"
-             target="_blank" rel="noopener">
+             target="_blank" rel="noopener noreferrer">
             Read the Note &rarr;
           </a>
         </div>


### PR DESCRIPTION
## Summary
- Adds a "Publisher's Note" card to the homepage sidebar, between Bureau Roster and Agent CTA
- Links to the publisher's founding letter inscribed on Bitcoin as an Ordinal
- Styled with warm gold/amber ordinals theme, supports both light and dark modes

## Test plan
- [ ] Verify card renders correctly in sidebar on desktop
- [ ] Check light and dark theme styling
- [ ] Confirm responsive layout on mobile (card moves below main content with sidebar)
- [ ] Click "Read on Bitcoin" link opens the inscription on ordinals.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)