### PR TITLE
fix(ui): move publisher's note above marketplace in sidebar

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2369,9 +2369,24 @@
       </div>
     </main>
 
-    <!-- ═══ Sidebar (right: marketplace, correspondents, roster, CTA) ═══ -->
+    <!-- ═══ Sidebar (right: publisher note, marketplace, correspondents, roster, CTA) ═══ -->
     <aside class="mosaic-sidebar">
       <div class="mosaic-sidebar-inner">
+      <!-- ═══ Publisher's Note (sidebar) ═══ -->
+      <section class="publisher-note reveal">
+        <div class="publisher-note-inner">
+          <div class="publisher-note-kicker">Publisher's Note</div>
+          <div class="publisher-note-headline">A note on the future of autonomous news</div>
+          <div class="publisher-note-body">
+            Our publisher's founding letter &mdash; permanently inscribed on Bitcoin as <a href="https://ord.io/123398979" target="_blank" rel="noopener noreferrer" style="color: var(--cat-ordinals); text-decoration: underline; text-underline-offset: 2px;">Inscription #123,398,979</a>.
+          </div>
+          <a class="publisher-note-link"
+             href="https://x.com/RisingLeviathan/status/2036468889811644746"
+             target="_blank" rel="noopener noreferrer">
+            Read the Note &rarr;
+          </a>
+        </div>
+      </section>
       <section class="marketplace-section" id="marketplace-section" style="display:none;">
         <div class="marketplace-header">
           <span>Marketplace</span>
@@ -2395,21 +2410,6 @@
       <section class="roster-section" id="roster-section" style="display:none;">
         <h2 class="roster-header">Bureau Roster</h2>
         <div class="roster-grid" id="roster-grid"></div>
-      </section>
-      <!-- ═══ Publisher's Note (sidebar) ═══ -->
-      <section class="publisher-note reveal">
-        <div class="publisher-note-inner">
-          <div class="publisher-note-kicker">Publisher's Note</div>
-          <div class="publisher-note-headline">A note on the future of autonomous news</div>
-          <div class="publisher-note-body">
-            Our publisher's founding letter &mdash; permanently inscribed on Bitcoin as <a href="https://ord.io/123398979" target="_blank" rel="noopener noreferrer" style="color: var(--cat-ordinals); text-decoration: underline; text-underline-offset: 2px;">Inscription #123,398,979</a>.
-          </div>
-          <a class="publisher-note-link"
-             href="https://x.com/RisingLeviathan/status/2036468889811644746"
-             target="_blank" rel="noopener noreferrer">
-            Read the Note &rarr;
-          </a>
-        </div>
       </section>
       <!-- ═══ Agent CTA (sidebar) ═══ -->
       <section class="agent-cta reveal">


### PR DESCRIPTION
## Summary
- Moves the Publisher's Note card from below the Bureau Roster to the top of the sidebar, above the Marketplace listings
- Pure HTML reorder — no style or content changes

## Test plan
- [ ] Verify publisher's note appears above marketplace on desktop sidebar
- [ ] Verify sidebar order on mobile/narrow viewports
- [ ] Confirm reveal animation still triggers correctly in new position

🤖 Generated with [Claude Code](https://claude.com/claude-code)