### PR TITLE
fix: scope leaderboard scoring to signals filed after last reset

### DIFF
--- a/src/__tests__/scoring-math.test.ts
+++ b/src/__tests__/scoring-math.test.ts
@@ -89,6 +89,13 @@ type SeedPayload = {
     last_signal_date: string;
     total_signals: number;
   }>;
+  leaderboard_snapshots?: Array<{
+    id: string;
+    snapshot_type: string;
+    week?: string | null;
+    snapshot_data?: string;
+    created_at: string;
+  }>;
 };
 
 async function seed(payload: SeedPayload): Promise<void> {
@@ -155,6 +162,10 @@ const ADDR_TWIN_RB = "bc1qtwinrecb0000000000000000000000000000000";  // twin B r
 const ADDR_ALL     = "bc1qallcomponent0000000000000000000000000000"; // all-components combined
 const ADDR_ALL_SIG = "bc1qallcompsig000000000000000000000000000000"; // signal for ALL's correction
 const ADDR_ALL_REC = "bc1qallcomprec000000000000000000000000000000"; // recruit for ALL's referral
+
+// Reset epoch test addresses
+const ADDR_RESET_PRE  = "bc1qresetpre0000000000000000000000000000000"; // signals before reset
+const ADDR_RESET_POST = "bc1qresetpost000000000000000000000000000000"; // signals after reset
 
 // Tie-breaking test addresses — 44 chars each, unique prefix "tb" to avoid collisions.
 // For each scenario the "loser" address sorts BEFORE the "winner" alphabetically ('l' < 'w'),
@@ -450,8 +461,8 @@ describe("edge case: 30-day boundary — signal just outside window not counted"
 
     const leaderboard = await getLeaderboard();
     const entry = findEntry(leaderboard, ADDR_BND_OUT);
-    // The address appears in FROM (signals WHERE correction_of IS NULL has no time filter)
-    // but signal_count and days_active use the 30-day window
+    // The address appears in FROM because the epoch defaults to 1970 (no reset),
+    // but signal_count and days_active use the 30-day rolling window.
     expect(entry).toBeDefined();
     expect(entry!.breakdown.signalCount).toBe(0);
     expect(entry!.breakdown.daysActive).toBe(0);
@@ -674,5 +685,49 @@ describe("combined: all scoring components sum to the correct total", () => {
     // = 198
     expect(entry!.score).toBe(expectedScore);
     expect(expectedScore).toBe(198);
+  });
+});
+
+// ── Reset epoch tests ─────────────────────────────────────────────────────────
+// These MUST run last because seeding a launch_reset snapshot sets the scoring
+// epoch for all subsequent queries in this shared DO instance.
+
+describe("reset epoch: signals before reset are excluded from scoring", () => {
+  it("pre-reset signals produce score=0; post-reset signals score normally", async () => {
+    // Timeline:
+    //   10 days ago: ADDR_RESET_PRE files a signal (before the reset)
+    //    8 days ago: launch_reset snapshot created (the scoring epoch)
+    //    3 days ago: ADDR_RESET_POST files a signal (after the reset)
+    const preResetTs = recentTs(10);
+    const resetTs = recentTs(8);
+    const postResetTs = recentTs(3);
+
+    await seed({
+      signals: [
+        // Pre-reset signal — should be excluded from scoring
+        { id: "reset-pre-sig-001", beat_slug: "bitcoin-macro", btc_address: ADDR_RESET_PRE, headline: "Pre-reset signal", created_at: preResetTs },
+        // Post-reset signal — should be counted
+        { id: "reset-post-sig-001", beat_slug: "bitcoin-macro", btc_address: ADDR_RESET_POST, headline: "Post-reset signal", created_at: postResetTs },
+      ],
+      leaderboard_snapshots: [
+        { id: "reset-snapshot-001", snapshot_type: "launch_reset", snapshot_data: "[]", created_at: resetTs },
+      ],
+    });
+
+    const leaderboard = await getLeaderboard();
+
+    // Pre-reset scout should not appear on the leaderboard at all
+    const preEntry = findEntry(leaderboard, ADDR_RESET_PRE);
+    expect(preEntry).toBeUndefined();
+
+    // Post-reset scout should appear with normal scoring
+    const postEntry = findEntry(leaderboard, ADDR_RESET_POST);
+    expect(postEntry).toBeDefined();
+    expect(postEntry!.breakdown.signalCount).toBe(1);
+    expect(postEntry!.breakdown.daysActive).toBe(1);
+    const expectedScore =
+      1 * SCORING_WEIGHTS.signal_count +
+      1 * SCORING_WEIGHTS.days_active;
+    expect(postEntry!.score).toBe(expectedScore);
   });
 });

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -3003,6 +3003,7 @@ export class NewsDO extends DurableObject<Env> {
         corrections: 0,
         referral_credits: 0,
         streaks: 0,
+        leaderboard_snapshots: 0,
       };
 
       // Seed signals
@@ -3120,6 +3121,27 @@ export class NewsDO extends DurableObject<Env> {
         }
       }
 
+      // Seed leaderboard_snapshots (used to test scoring epoch after reset)
+      if (Array.isArray(body.leaderboard_snapshots)) {
+        for (const row of body.leaderboard_snapshots as Array<Record<string, unknown>>) {
+          try {
+            this.ctx.storage.sql.exec(
+              `INSERT OR IGNORE INTO leaderboard_snapshots
+               (id, snapshot_type, week, snapshot_data, created_at)
+               VALUES (?, ?, ?, ?, ?)`,
+              row.id as string,
+              (row.snapshot_type as string) ?? "launch_reset",
+              (row.week as string | null) ?? null,
+              (row.snapshot_data as string) ?? "[]",
+              row.created_at as string
+            );
+            inserted.leaderboard_snapshots++;
+          } catch {
+            // Skip invalid rows silently
+          }
+        }
+      }
+
       return c.json({ ok: true, data: { inserted } });
     });
 
@@ -3164,9 +3186,24 @@ export class NewsDO extends DurableObject<Env> {
    */
   private queryLeaderboard(limit: number): Array<Record<string, unknown>> {
     // SQL literals mirror SCORING_WEIGHTS; tests assert exact scores to enforce sync.
+    //
+    // The `epoch` CTE derives the scoring epoch from the most recent launch_reset
+    // snapshot. Signals filed before the epoch are excluded from signal_count and
+    // days_active so that a leaderboard reset zeroes all scores even though the
+    // signals table is intentionally preserved for historical record. Tables that
+    // are fully cleared on reset (brief_signals, streaks, corrections,
+    // referral_credits, earnings) do not need epoch filtering.
     return this.ctx.storage.sql
       .exec(
-        `SELECT
+        `WITH epoch AS (
+           SELECT COALESCE(
+             (SELECT created_at FROM leaderboard_snapshots
+              WHERE snapshot_type = 'launch_reset'
+              ORDER BY created_at DESC LIMIT 1),
+             '1970-01-01T00:00:00.000Z'
+           ) AS ts
+         )
+         SELECT
            a.btc_address,
            COALESCE(bi.inclusion_count, 0) as brief_inclusions_30d,
            COALESCE(sc.signal_count, 0) as signal_count_30d,
@@ -3181,7 +3218,11 @@ export class NewsDO extends DurableObject<Env> {
             + COALESCE(da.days_active, 0) * 2     /* SCORING_WEIGHTS.days_active */
             + COALESCE(cr.correction_count, 0) * 15  /* SCORING_WEIGHTS.approved_corrections */
             + COALESCE(rf.referral_count, 0) * 25) as score  /* SCORING_WEIGHTS.referral_credits */
-         FROM (SELECT DISTINCT btc_address FROM signals WHERE correction_of IS NULL) a
+         FROM (
+           SELECT DISTINCT btc_address FROM signals
+           WHERE correction_of IS NULL
+             AND created_at > (SELECT ts FROM epoch)
+         ) a
          LEFT JOIN (
            SELECT btc_address, COUNT(*) as inclusion_count
            FROM brief_signals WHERE created_at > datetime('now', '-30 days')
@@ -3189,13 +3230,19 @@ export class NewsDO extends DurableObject<Env> {
          ) bi ON a.btc_address = bi.btc_address
          LEFT JOIN (
            SELECT btc_address, COUNT(*) as signal_count
-           FROM signals WHERE correction_of IS NULL AND created_at > datetime('now', '-30 days')
+           FROM signals
+           WHERE correction_of IS NULL
+             AND created_at > datetime('now', '-30 days')
+             AND created_at > (SELECT ts FROM epoch)
            GROUP BY btc_address
          ) sc ON a.btc_address = sc.btc_address
          LEFT JOIN streaks st ON a.btc_address = st.btc_address
          LEFT JOIN (
            SELECT btc_address, COUNT(DISTINCT date(created_at)) as days_active
-           FROM signals WHERE correction_of IS NULL AND created_at > datetime('now', '-30 days')
+           FROM signals
+           WHERE correction_of IS NULL
+             AND created_at > datetime('now', '-30 days')
+             AND created_at > (SELECT ts FROM epoch)
            GROUP BY btc_address
          ) da ON a.btc_address = da.btc_address
          LEFT JOIN (


### PR DESCRIPTION
## Summary

- Adds a `epoch` CTE to `queryLeaderboard()` that derives the scoring epoch from the most recent `launch_reset` snapshot timestamp
- Filters the three `signals` subqueries (FROM clause, `signal_count_30d`, `days_active_30d`) to exclude signals filed before the epoch
- Tables already cleared on reset (`brief_signals`, `streaks`, `corrections`, `referral_credits`, `earnings`) are unaffected
- The `first_signal_at` tenure tie-breaker remains unfiltered (all-time by design)
- Adds `leaderboard_snapshots` seeding to the test-seed endpoint
- Adds an integration test verifying pre-reset signals produce no score while post-reset signals score normally

**Post-reset behavior:** After a reset, `GET /api/leaderboard` returns an empty list (`total: 0`) until correspondents file new signals. This is correct — correspondents with only pre-reset activity have no post-reset scoring data.

Closes #234

## Test plan

- [x] All 175 existing tests pass (no regressions)
- [x] New "reset epoch" test verifies pre-reset scout is excluded from leaderboard
- [x] New test verifies post-reset scout scores normally
- [ ] Manual verification: call `POST /api/leaderboard/reset`, then `GET /api/leaderboard` — returns empty leaderboard until new signals are filed

🤖 Generated with [Claude Code](https://claude.com/claude-code)