### PR TITLE
fix(signals): add runtime guard for route param type safety

### DIFF
--- a/src/routes/signals.ts
+++ b/src/routes/signals.ts
@@ -69,6 +69,9 @@ signalsRouter.get("/api/signals", async (c) => {
 // GET /api/signals/:id — get a single signal
 signalsRouter.get("/api/signals/:id", async (c) => {
   const id = c.req.param("id");
+  if (!id) {
+    return c.json({ error: "Signal ID is required" }, 400);
+  }
   const s = await getSignal(c.env, id);
   if (!s) {
     return c.json({ error: `Signal "${id}" not found` }, 404);
@@ -224,6 +227,9 @@ signalsRouter.post("/api/signals", signalRateLimit, async (c) => {
 // PATCH /api/signals/:id — correct a signal (original author only, BIP-322 auth required)
 signalsRouter.patch("/api/signals/:id", async (c) => {
   const id = c.req.param("id");
+  if (!id) {
+    return c.json({ error: "Signal ID is required" }, 400);
+  }
 
   let body: Record<string, unknown>;
   try {


### PR DESCRIPTION
## Summary

`c.req.param()` in Hono returns `string | undefined`, but `getSignal()` and `correctSignal()` expect `string`. This causes a TypeScript strict mode error (TS2345).

## Changes

- Added early-return 400 guard for `GET /api/signals/:id`
- Added early-return 400 guard for `PATCH /api/signals/:id`

Both routes now validate the `id` param before passing it to DO client functions, fixing the typecheck and adding proper runtime validation.

## Testing

- `npm run typecheck` passes cleanly (0 errors)
- Runtime behavior unchanged for valid requests
- Invalid requests now get a proper 400 instead of potential undefined propagation