### PR TITLE
fix(beats): remove explicit BEGIN/COMMIT from cascade delete (fixes #263)

### DIFF
--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -773,34 +773,27 @@ export class NewsDO extends DurableObject<Env> {
         .toArray();
       const signalCount = (signalRows[0] as { cnt: number }).cnt;
 
-      // Cascade delete in a transaction: dependents → signals → beat_claims → beat
-      try {
-        this.ctx.storage.sql.exec("BEGIN");
-        if (signalCount > 0) {
-          this.ctx.storage.sql.exec(
-            "DELETE FROM signal_tags WHERE signal_id IN (SELECT id FROM signals WHERE beat_slug = ?)",
-            slug
-          );
-          this.ctx.storage.sql.exec(
-            "DELETE FROM brief_signals WHERE signal_id IN (SELECT id FROM signals WHERE beat_slug = ?)",
-            slug
-          );
-          this.ctx.storage.sql.exec(
-            "DELETE FROM corrections WHERE signal_id IN (SELECT id FROM signals WHERE beat_slug = ?)",
-            slug
-          );
-          this.ctx.storage.sql.exec("DELETE FROM signals WHERE beat_slug = ?", slug);
-        }
-        this.ctx.storage.sql.exec("DELETE FROM beat_claims WHERE beat_slug = ?", slug);
-        this.ctx.storage.sql.exec("DELETE FROM beats WHERE slug = ?", slug);
-        this.ctx.storage.sql.exec("COMMIT");
-      } catch (e) {
-        this.ctx.storage.sql.exec("ROLLBACK");
-        return c.json(
-          { ok: false, error: "Cascade delete failed" } satisfies DOResult<unknown>,
-          500
+      // Cascade delete: dependents -> signals -> beat_claims -> beat
+      // DO SQLite runs all exec() calls within a single fetch() handler in an
+      // implicit transaction, so explicit BEGIN/COMMIT is not needed (and causes
+      // errors on Cloudflare's DO SQLite implementation).
+      if (signalCount > 0) {
+        this.ctx.storage.sql.exec(
+          "DELETE FROM signal_tags WHERE signal_id IN (SELECT id FROM signals WHERE beat_slug = ?)",
+          slug
         );
+        this.ctx.storage.sql.exec(
+          "DELETE FROM brief_signals WHERE signal_id IN (SELECT id FROM signals WHERE beat_slug = ?)",
+          slug
+        );
+        this.ctx.storage.sql.exec(
+          "DELETE FROM corrections WHERE signal_id IN (SELECT id FROM signals WHERE beat_slug = ?)",
+          slug
+        );
+        this.ctx.storage.sql.exec("DELETE FROM signals WHERE beat_slug = ?", slug);
       }
+      this.ctx.storage.sql.exec("DELETE FROM beat_claims WHERE beat_slug = ?", slug);
+      this.ctx.storage.sql.exec("DELETE FROM beats WHERE slug = ?", slug);
 
       return c.json({ ok: true, data: { slug, deleted: true, signals_deleted: signalCount } });
     });


### PR DESCRIPTION
## Summary

Fixes #263 — `DELETE /api/beats/:slug` returns 500 because explicit `BEGIN`/`COMMIT`/`ROLLBACK` calls are unsupported in Cloudflare Durable Object SQLite.

## Root Cause

DO SQLite wraps each `fetch()` handler in an implicit transaction. The cascade delete handler was using explicit transaction control (`BEGIN`/`COMMIT`/`ROLLBACK`), which conflicts with this behavior and causes the 500 error.

## Fix

Remove `BEGIN`/`COMMIT`/`ROLLBACK` and rely on DO's built-in implicit transaction atomicity. This is consistent with the pattern already used in the signal-insert handler (line ~1275):

```typescript
// Atomicity: DO SQLite runs all exec() calls within a single fetch()
// handler in an implicit transaction — no explicit BEGIN/COMMIT needed.
```

## Changes

- `src/objects/news-do.ts`: Remove explicit transaction control from `DELETE /beats/:slug` handler
- All cascade delete statements remain in the same order (dependents → signals → beat_claims → beat)
- Zero behavioral change beyond fixing the 500 error

Closes #263