### PR TITLE
fix(signals): add Retry-After header and structured body to daily cap 429 (closes #267)

### DIFF
--- a/src/lib/do-client.ts
+++ b/src/lib/do-client.ts
@@ -204,7 +204,14 @@ export interface CooldownInfo {
   waitMinutes: number;
 }
 
-export type CreateSignalResult = DOResult<Signal> & { cooldown?: CooldownInfo };
+export interface DailyLimitInfo {
+  limit: number;
+  filed_today: number;
+  reset_at: string;
+  retry_after: number;
+}
+
+export type CreateSignalResult = DOResult<Signal> & { cooldown?: CooldownInfo; daily_limit?: DailyLimitInfo };
 
 export async function createSignal(
   env: Env,

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -1193,13 +1193,24 @@ export class NewsDO extends DurableObject<Env> {
         .toArray();
       const dailyCount = (dailyCountRows[0] as Record<string, unknown>).count as number;
       if (dailyCount >= MAX_SIGNALS_PER_DAY) {
-        return c.json(
+        // Compute seconds until the next Pacific-day reset
+        const tomorrowStart = getPacificDayStartUTC(getNextDate(today));
+        const retryAfterSecs = Math.ceil((new Date(tomorrowStart).getTime() - now.getTime()) / 1000);
+        const res = c.json(
           {
             ok: false,
-            error: `Daily limit reached — maximum ${MAX_SIGNALS_PER_DAY} signals per day. Try again tomorrow.`,
-          } satisfies DOResult<Signal>,
+            error: `Daily limit reached — maximum ${MAX_SIGNALS_PER_DAY} signals per day. Resets at midnight Pacific.`,
+            daily_limit: {
+              limit: MAX_SIGNALS_PER_DAY,
+              filed_today: dailyCount,
+              reset_at: tomorrowStart,
+              retry_after: retryAfterSecs,
+            },
+          } as unknown as DOResult<Signal>,
           429
         );
+        res.headers.set("Retry-After", String(retryAfterSecs));
+        return res;
       }
 
       const signalId = generateId();

--- a/src/routes/signals.ts
+++ b/src/routes/signals.ts
@@ -207,6 +207,14 @@ signalsRouter.post("/api/signals", signalRateLimit, async (c) => {
   });
 
   if (!result.ok) {
+    if (result.daily_limit) {
+      const res = c.json(
+        { error: result.error, daily_limit: result.daily_limit },
+        429
+      );
+      res.headers.set("Retry-After", String(result.daily_limit.retry_after));
+      return res;
+    }
     if (result.cooldown) {
       return c.json(
         { error: result.error, cooldown: result.cooldown },


### PR DESCRIPTION
## Problem

When an agent hits the daily signal cap, the 429 response body was opaque — just an error string. Agents couldn't programmatically determine when to retry without reimplementing the Pacific-midnight reset logic themselves.

## Changes

**`src/objects/news-do.ts`**
- Compute `retryAfterSecs` (seconds until next Pacific-midnight reset) when daily cap is hit
- Add `Retry-After` header to the 429 response
- Include structured `daily_limit` object in the body: `{ limit, filed_today, reset_at, retry_after }`

**`src/lib/do-client.ts`**
- Add `DailyLimitInfo` interface
- Extend `CreateSignalResult` with `daily_limit?: DailyLimitInfo`

**`src/routes/signals.ts`**
- Surface `daily_limit` in the Worker-layer 429 response
- Set `Retry-After` header at the Worker layer as well (DO headers pass through via `stub.fetch`, but the Worker response is what the caller actually receives)

## Example Response

```
HTTP/1.1 429 Too Many Requests
Retry-After: 14400

{
  "ok": false,
  "error": "Daily limit reached — maximum 6 signals per day. Resets at midnight Pacific.",
  "daily_limit": {
    "limit": 6,
    "filed_today": 6,
    "reset_at": "2026-03-26T08:00:00.000Z",
    "retry_after": 14400
  }
}
```

## Test Plan
- [ ] File 6 signals in a day; 7th attempt returns 429 with `Retry-After` header and `daily_limit` body
- [ ] `reset_at` in body matches midnight Pacific for the current day
- [ ] `retry_after` header value matches `daily_limit.retry_after`
- [ ] Cooldown 429 path unchanged (still returns `cooldown` not `daily_limit`)

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)