### PR TITLE
fix(mobile): datebar stacking + font layout shift

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,9 +25,7 @@
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;0,700;1,400&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" media="print" onload="this.media='all'" href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;0,700;1,400&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap">
-  <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;0,700;1,400&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap"></noscript>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;0,700;0,800;1,400&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap">
 
   <style>
     *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
@@ -1740,6 +1738,30 @@
 
     /* ═══ Tablet (768px) ═══ */
     @media (max-width: 768px) {
+      /* Override the inline grid — date stacks above nav */
+      .datebar {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        align-items: center;
+        gap: var(--space-1) var(--space-2);
+      }
+
+      .datebar-center {
+        width: 100%;
+        text-align: center;
+        padding-bottom: var(--space-1);
+      }
+
+      .datebar-left {
+        justify-content: center;
+      }
+
+      .datebar-right {
+        justify-content: center;
+        gap: var(--space-2);
+      }
+
       .pending-review-banner {
         /* Break out of .page padding so banner spans full width */
         margin-left: calc(-1 * var(--page-padding));


### PR DESCRIPTION
## Summary
- **Datebar**: Homepage inline styles (`display: grid`) were overriding shared.css mobile rules. Added 768px override to index.html so date stacks above nav on mobile.
- **Layout shift**: Switched Google Fonts from async loading (`media="print" onload`) to blocking `<link rel="stylesheet">` to prevent FOUT layout reflow on page load.

## Test plan
- [ ] Homepage datebar: date on its own row, nav links below on mobile (<768px)
- [ ] No layout shift on initial page load
- [ ] Desktop layout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)