### PR TITLE
fix: em dash avatar prefix, async font, mobile overflow

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,7 +25,9 @@
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;0,700;0,800;1,400&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;0,700;0,800;1,400&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap">
+  <link rel="stylesheet" media="print" onload="this.media='all'" href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;0,700;0,800;1,400&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap">
+  <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;0,700;0,800;1,400&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap"></noscript>
 
   <style>
     *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
@@ -1740,8 +1742,23 @@
     .lead-content,
     .story-content,
     .brief-text-content,
-    .column-content {
+    .column-content,
+    .brief-text-headline,
+    .lead-headline,
+    .story-headline,
+    .column-headline,
+    .brief-text-attr {
       overflow-wrap: anywhere;
+      min-width: 0;
+    }
+
+    /* Prevent any child from blowing out the viewport */
+    .mosaic,
+    .mosaic > .page,
+    .brief-mosaic-top,
+    .brief-story {
+      min-width: 0;
+      max-width: 100%;
     }
 
     /* ═══ Tablet (768px) ═══ */
@@ -2941,6 +2958,8 @@
 
       // Helper: resolve agent identity in attribution line
       function resolveAttr(line) {
+        // Strip leading em dash (— or \u2014) so it doesn't show as "__" before the avatar
+        line = line.replace(/^[\u2014—]\s*/, '');
         let attrHTML = esc(line);
         let matched = false;
         // Try matching by truncated address first


### PR DESCRIPTION
## Summary
- **Em dash before avatar**: Attribution lines from the brief text start with `— ` (em dash) which rendered as `__` before the agent avatar. Now stripped during `resolveAttr()` processing.
- **Font loading reverted**: Google Fonts switched back to async loading (`preload` + `media="print" onload`) from the blocking `<link rel="stylesheet">` introduced in #285. Restores the original non-blocking font load behavior.
- **Mobile viewport overflow**: Content inside the mosaic grid was overflowing the viewport width on mobile, causing the browser to zoom out and shift content left. Fixed by adding `min-width: 0` and `max-width: 100%` to the mosaic/page/brief container chain (standard CSS grid/flex overflow prevention), and `overflow-wrap: anywhere` to all headline and attribution elements.

## Root cause (overflow)
CSS grid/flex children default to `min-width: auto`, which means they won't shrink below their content's intrinsic width. When a headline or body text line was slightly wider than the viewport, the grid child expanded beyond the screen edge, triggering mobile Safari to widen the viewport. Pinch-zooming out then revealed the extra width as a gap on the right.

## Test plan
- [ ] Reload homepage on mobile — no horizontal overflow or zoom shift
- [ ] Agent avatars show without `__` prefix on today's brief
- [ ] Font loads asynchronously (brief flash of fallback font is expected)
- [ ] Headlines and long text wrap correctly on narrow screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)