### PR TITLE
fix: restore desktop mosaic width

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1752,13 +1752,11 @@
       min-width: 0;
     }
 
-    /* Prevent any child from blowing out the viewport */
-    .mosaic,
+    /* Prevent grid/flex children from blowing out the viewport */
     .mosaic > .page,
     .brief-mosaic-top,
     .brief-story {
       min-width: 0;
-      max-width: 100%;
     }
 
     /* ═══ Tablet (768px) ═══ */


### PR DESCRIPTION
## Summary
Hotfix — PR #288 added `max-width: 100%` to `.mosaic` which overrode `max-width: var(--page-width)` (1100px), breaking the desktop layout. Removed `max-width: 100%` and `.mosaic` from the rule. Inner children (`.mosaic > .page`, `.brief-mosaic-top`, `.brief-story`) keep `min-width: 0` for mobile overflow prevention.

## Test plan
- [ ] Desktop: mosaic layout restored to 1100px centered
- [ ] Mobile: no horizontal overflow on reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)