### PR TITLE
fix(mobile): make about page responsive

### DIFF
--- a/public/about/index.html
+++ b/public/about/index.html
@@ -159,8 +159,82 @@
     }
 
     /* ═══ Responsive (page-specific) ═══ */
+    @media (max-width: 768px) {
+      .about-content {
+        padding: var(--space-5) var(--page-padding);
+      }
+
+      .about-section h2 {
+        font-size: var(--text-xl);
+      }
+
+      .about-section p {
+        font-size: 14px;
+      }
+
+      pre {
+        font-size: 11px;
+        padding: var(--space-3);
+      }
+    }
+
     @media (max-width: 640px) {
-      .about-headline { font-size: 24px; }
+      .about-headline {
+        font-size: 22px;
+      }
+
+      .about-pitch {
+        font-size: 13px;
+        margin-bottom: var(--space-5);
+      }
+
+      .about-section {
+        margin-bottom: var(--space-5);
+      }
+
+      .about-section h2 {
+        font-size: var(--text-lg);
+        margin-bottom: var(--space-3);
+      }
+
+      .about-section p {
+        font-size: 13px;
+        line-height: 1.6;
+      }
+
+      .about-step {
+        gap: 10px;
+        margin-bottom: 10px;
+      }
+
+      .about-step-text {
+        font-size: 13px;
+        line-height: 1.5;
+      }
+
+      .about-quote {
+        font-size: 14px;
+        padding: var(--space-3) 0;
+      }
+
+      pre {
+        font-size: 10px;
+        padding: var(--space-2);
+        line-height: 1.6;
+      }
+
+      .about-cta-heading {
+        font-size: var(--text-lg);
+      }
+
+      .about-cta-links {
+        gap: var(--space-2);
+      }
+
+      .about-cta-link {
+        font-size: 11px;
+        padding: var(--space-2) var(--space-3);
+      }
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary
About page had almost no mobile styles — just one headline size override. Content was cropped/overflowing on mobile due to large padding, wide pre blocks, and unshrunk text.

Adds 768px and 640px breakpoints:
- Content padding reduced from 48px to page-padding
- Section headings, body, step text, quote all scaled down
- Scoring formula `<pre>` block fits mobile screens
- CTA links and spacing tightened

## Test plan
- [ ] About page readable on mobile without horizontal scroll
- [ ] Scoring formula pre block doesn't overflow
- [ ] Desktop layout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)