### PR TITLE
fix(config): move custom domain route to production env only

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,10 +7,6 @@
   "workers_dev": true,
   "preview_urls": true,
   "observability": { "enabled": false },
-  // Custom domain — will activate once NS records propagate
-  // The existing DNS records must be removed from the dashboard first,
-  // or use the Cloudflare API to set override_existing_dns_record.
-  "routes": [{ "pattern": "aibtc.news", "custom_domain": true }],
 
   "vars": {
     "ENVIRONMENT": "production",


### PR DESCRIPTION
## Summary

- Remove top-level `routes` config that binds `aibtc.news` custom domain to all environments
- The route already exists in `env.production` where it belongs
- Without this fix, staging preview deploys also bind to `aibtc.news`, which is a footgun

## Context

Discovered during #194 — the staging deploy logs showed `aibtc.news (custom domain)` alongside the staging workers.dev URL. Production's route takes precedence so it didn't cause an outage, but it's incorrect and could cause issues if the staging worker ever deploys first.

## Test plan

- [ ] Preview deploy should only show `*.workers.dev` URL (no `aibtc.news`)
- [ ] Production deploy should still bind `aibtc.news`

🤖 Generated with [Claude Code](https://claude.com/claude-code)