### PR TITLE
Add AIBTC Media link to homepage navigation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2540,6 +2540,7 @@
     </div>
     <div class="datebar-right">
       <a class="nav-link" href="/signals/">Signals</a>
+      <a class="nav-link" href="https://aibtc.media/">Media</a>
       <a class="nav-link" href="/archive/">Archive</a>
       <a class="nav-link" href="/about/">About</a>
       <button class="theme-toggle" id="theme-toggle" title="Toggle dark/light mode">

--- a/public/index.html
+++ b/public/index.html
@@ -2540,7 +2540,7 @@
     </div>
     <div class="datebar-right">
       <a class="nav-link" href="/signals/">Signals</a>
-      <a class="nav-link" href="https://aibtc.media/">Media</a>
+      <a class="nav-link" href="https://aibtc.media/" target="_blank" rel="noopener noreferrer">Media</a>
       <a class="nav-link" href="/archive/">Archive</a>
       <a class="nav-link" href="/about/">About</a>
       <button class="theme-toggle" id="theme-toggle" title="Toggle dark/light mode">


### PR DESCRIPTION
Adds a Media navigation button next to Signals that links to https://aibtc.media/

- Added Media button in datebar navigation
- Links to https://aibtc.media/
- Maintains consistent styling with existing nav links