### PR TITLE
fix(leaderboard): gate brief_inclusions on inscription finalization

### DIFF
--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -3613,9 +3613,13 @@ export class NewsDO extends DurableObject<Env> {
              AND created_at > (SELECT ts FROM epoch)
          ) a
          LEFT JOIN (
-           SELECT btc_address, COUNT(*) as inclusion_count
-           FROM brief_signals WHERE created_at > datetime('now', '-30 days') AND retracted_at IS NULL
-           GROUP BY btc_address
+           SELECT bs.btc_address, COUNT(*) as inclusion_count
+           FROM brief_signals bs
+           JOIN briefs br ON bs.brief_date = br.date
+           WHERE bs.created_at > datetime('now', '-30 days')
+             AND bs.retracted_at IS NULL
+             AND br.inscription_id IS NOT NULL
+           GROUP BY bs.btc_address
          ) bi ON a.btc_address = bi.btc_address
          LEFT JOIN (
            SELECT btc_address, COUNT(*) as signal_count


### PR DESCRIPTION
## Summary

- **Inscription gate on brief_inclusions**: The leaderboard `brief_inclusions_30d` subquery now joins `brief_signals` → `briefs` and requires `briefs.inscription_id IS NOT NULL`. Signals only count toward the brief inclusion score after the daily brief has been inscribed on Bitcoin.

## Problem

The leaderboard scoring formula counts `brief_inclusions` as soon as signals are compiled into a brief (~11pm PT), before the brief is inscribed on-chain (~11:30pm PT) and before payments are sent (~1-6am PT). During this window, a correspondent's score temporarily inflates. If a brief compilation fails or signals are dropped, the score would be inaccurate.

As noted in [issue #298 comments](https://github.com/aibtcdev/agent-news/issues/298#issuecomment-4137300807), the `brief_signals` table is written at review time (before inscription), but `earnings` is correctly gated on payment time. This PR closes the gap for `brief_inclusions`.

## Changes

| File | Change |
|------|--------|
| `src/objects/news-do.ts` | Join `brief_signals bs` → `briefs br` in the `bi` subquery of `queryLeaderboard()`, add `AND br.inscription_id IS NOT NULL` |

## What this does NOT change

Per the [issue #298 discussion](https://github.com/aibtcdev/agent-news/issues/298#issuecomment-4139919675):

- **`signal_count` / `days_active`**: These count raw signal submissions regardless of brief inclusion. They measure volume and participation, not editorial confirmation. Gating them on inscription would make the leaderboard appear frozen until 11pm PT daily, which is bad UX per the discussion.
- **`streaks`**: Written at signal submission time. A `confirmed_at` column would be a larger migration best done alongside PR #273 (beat_streaks). This is a follow-up.
- **`earnings`**: Already correctly gated on payment time — no change needed.

## Test plan

- [ ] `npx tsc --noEmit` passes (confirmed locally)
- [ ] Deploy to staging, compile a brief WITHOUT inscribing — verify `brief_inclusions_30d` stays at 0
- [ ] Inscribe the brief — verify `brief_inclusions_30d` reflects the included signals
- [ ] Verify `retracted_at IS NULL` guard still works (retracted signals don't count even after inscription)

Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)