### PR TITLE
fix(beats): delete beat_claims before beats to satisfy FK constraint

### DIFF
--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -284,7 +284,8 @@ export class NewsDO extends DurableObject<Env> {
       // Re-run network-focus migration — migration 10 failed silently on production
       // because beat_claims FK constraint blocked DELETE FROM beats. The updated
       // MIGRATION_BEAT_NETWORK_FOCUS_SQL now deletes beat_claims first.
-      if (appliedVersion < 11) {
+      // Only targets DBs already at version 10 to avoid double-execution on fresh DBs.
+      if (appliedVersion === 10) {
         try {
           this.ctx.storage.sql.exec(MIGRATION_BEAT_NETWORK_FOCUS_SQL);
         } catch (e) {

--- a/src/objects/schema.ts
+++ b/src/objects/schema.ts
@@ -411,8 +411,19 @@ export const MIGRATION_BEAT_NETWORK_FOCUS_SQL = `
   UPDATE signals SET beat_slug = 'security'         WHERE beat_slug = 'world-intel';
   UPDATE signals SET beat_slug = 'agent-social'     WHERE beat_slug = 'comics';
 
-  -- ── Phase D: Delete retired beats ──────────────────────────────────
-  -- Remove beat_claims first (FK constraint on beats.slug blocks delete otherwise)
+  -- ── Phase D: Migrate and delete beat_claims, then delete retired beats ─
+  -- Migrate claims for renamed beats to new slugs (preserve memberships)
+  INSERT OR IGNORE INTO beat_claims (beat_slug, btc_address, claimed_at, status)
+    SELECT 'onboarding', btc_address, claimed_at, status
+    FROM beat_claims WHERE beat_slug = 'aibtc-network';
+  INSERT OR IGNORE INTO beat_claims (beat_slug, btc_address, claimed_at, status)
+    SELECT 'governance', btc_address, claimed_at, status
+    FROM beat_claims WHERE beat_slug = 'dao-watch';
+  INSERT OR IGNORE INTO beat_claims (beat_slug, btc_address, claimed_at, status)
+    SELECT 'infrastructure', btc_address, claimed_at, status
+    FROM beat_claims WHERE beat_slug = 'dev-tools';
+
+  -- Delete claims for all retired/renamed beats (FK constraint blocks beat delete)
   DELETE FROM beat_claims WHERE beat_slug IN (
     'bitcoin-macro', 'bitcoin-culture', 'bitcoin-yield',
     'ordinals', 'runes', 'art', 'world-intel', 'comics',


### PR DESCRIPTION
## Summary
- Migration 10 (network-focus beats reduction) failed silently on production because `beat_claims` has a FK on `beats(slug)` — agents had claimed the old beats, blocking the `DELETE FROM beats`
- The error was caught/swallowed but `migration_version` was set to 10 anyway, so it never retried
- Adds `DELETE FROM beat_claims` before `DELETE FROM beats` in the migration SQL
- Bumps migration version to 11 to force the corrected migration to re-run on the production DO

## Test plan
- [x] Schema migration tests pass (5/5) — verifies exactly 10 beats after all migrations
- [x] `wrangler deploy --dry-run` builds cleanly
- [ ] After deploy, verify `https://aibtc.news/api/beats` returns 10 beats (not 20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)