### PR TITLE
fix(agents): use display_name from correspondents to prevent truncated address

### DIFF
--- a/public/agents/index.html
+++ b/public/agents/index.html
@@ -337,7 +337,18 @@
       return;
     }
 
-    // Resolve agent names/avatars
+    // Pre-populate cache from server-resolved names to avoid redundant /api/agents calls.
+    // The correspondents API already resolves display_name server-side; use it directly.
+    for (const correspondent of correspondents) {
+      if (correspondent.display_name) {
+        agentCache.set(correspondent.address, {
+          name: correspondent.display_name,
+          avatar: correspondent.avatar,
+        });
+      }
+    }
+
+    // Resolve remaining agents (those where server-side resolution timed out)
     const addresses = correspondents.map(c => c.address).filter(Boolean);
     await resolveAgentsBatch(addresses);
 
@@ -349,7 +360,9 @@
 
     for (let i = 0; i < correspondents.length; i++) {
       const c = correspondents[i];
-      const agent = agentCache.get(c.address) || { name: c.addressShort, avatar: '' };
+      // Prefer server-resolved display_name over the cache fallback (which may be a
+      // truncated address when /api/agents returned null for an unwarmed KV cache).
+      const agent = agentCache.get(c.address) || { name: c.display_name || c.addressShort, avatar: c.avatar || '' };
       const beatNames = (c.beats || []).map(b => '<span class="beat-pill">' + esc(b.name) + '</span>').join(' ');
       const profileUrl = 'https://aibtc.com/agents/' + encodeURIComponent(c.address);
 


### PR DESCRIPTION
## Problem

On the `/agents/` correspondents page, some agent names intermittently display as truncated BTC addresses (e.g., `bc1qqaxq…s4vxpp`) instead of their registered names. Closes #320. Related to #319.

## Root Cause

The `/api/correspondents` endpoint already resolves agent names server-side (with a 3s timeout) and returns `display_name` and `avatar` in each row. The frontend was ignoring this data and making a **separate** `/api/agents?addresses=...` call for name resolution.

When `/api/agents` encounters a cold KV cache **and** `aibtc.com` is slow to respond, it returns `name: null`. The `resolveAgentsBatch` function then stores `truncAddr(addr)` in the client-side cache:

```js
// Before: stores truncated address when profile.name is null
agentCache.set(addr, {
  name: profile.name || truncAddr(addr),  // truncAddr(addr) when name is null
  ...
});
```

The rendering then reads from that cache and shows the truncated address. The `display_name` that was already correctly resolved by the correspondents API was never consulted.

## Fix

Two-part fix:

**1. Pre-populate `agentCache` from the correspondents response** before calling `resolveAgentsBatch`. This short-circuits the `/api/agents` call for agents already resolved server-side, eliminating the redundant network round-trip:

```js
for (const correspondent of correspondents) {
  if (correspondent.display_name) {
    agentCache.set(correspondent.address, {
      name: correspondent.display_name,
      avatar: correspondent.avatar,
    });
  }
}
```

**2. Fix the rendering fallback** to use `c.display_name` before falling back to the truncated address:

```js
// After: server-resolved name is used even when cache misses
const agent = agentCache.get(c.address) || { name: c.display_name || c.addressShort, avatar: c.avatar || '' };
```

## Impact

- Agents with server-side resolved names now display correctly on first load
- Only agents where the server-side 3s timeout fired still go through `/api/agents` (cold KV cache edge case)
- Fewer `/api/agents` calls also reduces page load time (helps #319)
- No backend changes required

## Test Plan

- [ ] Load `/agents/` page — all agents with registered names should show their name, not a truncated address
- [ ] Verify the #1 ranked agent shows their registered name
- [ ] Check Network tab: `/api/agents` should only be called for agents not in the correspondents response (if any)
- [ ] Verify cold-cache behavior: even on first load, `display_name` from `/api/correspondents` is used if the server resolved it within the 3s window

🤖 Generated with [Claude Code](https://claude.ai/claude-code)