### PR TITLE
refactor: switch from Pacific timezone to UTC day boundaries

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3321,23 +3321,23 @@
     // ── Render signal feed (fallback when no brief is available) ──
     async function renderSignalFeed(prefetchedData = null) {
       const main = el('main-content');
-      // pacificTodayStr is used as a pagination cursor for the backend, which expects Pacific dates.
+      // utcTodayStr is used as a pagination cursor for the backend, which now expects UTC dates.
       // localTodayStr is used only for display in setDate().
-      const pacificTodayStr = new Date().toLocaleDateString('en-CA', { timeZone: 'America/Los_Angeles' });
+      const utcTodayStr = new Date().toISOString().slice(0, 10);
       const localTodayStr = new Date().toLocaleDateString('en-CA');
       setDate(localTodayStr);
 
       const data = prefetchedData !== null ? prefetchedData : await fetchJSON('/api/front-page');
-      // Precompute Pacific date string once per signal to avoid redundant Date construction
+      // Precompute UTC date string once per signal — timestamps are ISO UTC strings so slice is sufficient
       const allSignals = (data && Array.isArray(data.signals))
         ? data.signals
             .filter(s => s && s.timestamp)
-            .map(s => ({ ...s, _day: new Date(s.timestamp).toLocaleDateString('en-CA', { timeZone: 'America/Los_Angeles' }) }))
+            .map(s => ({ ...s, _day: s.timestamp.slice(0, 10) }))
         : [];
 
-      // Partition by Pacific day
-      const todaySignals = allSignals.filter(s => s._day === pacificTodayStr);
-      const olderSignals = allSignals.filter(s => s._day !== pacificTodayStr);
+      // Partition by UTC day
+      const todaySignals = allSignals.filter(s => s._day === utcTodayStr);
+      const olderSignals = allSignals.filter(s => s._day !== utcTodayStr);
 
       // hasRenderableSignals: true when there are signals to show in mosaic or day sections.
       // Used only as an empty-state guard — actual rendering uses todaySignals/allSignals directly.
@@ -3502,7 +3502,7 @@
         const todayItems = signalsToItems(todaySignals);
         html = todayHeader + renderMosaicHtml(todayItems);
 
-        // Group older signals by Pacific day and render each day section inline
+        // Group older signals by UTC day and render each day section inline
         if (olderSignals.length > 0) {
           // Group by date string
           const byDay = {};
@@ -3535,12 +3535,12 @@
       hydrateAgentIdentities(main);
 
       // Set scroll cursor to oldest date rendered, so infinite scroll continues from there.
-      // The backend expects a Pacific YYYY-MM-DD date for the 'before' cursor.
+      // The backend expects a UTC YYYY-MM-DD date for the 'before' cursor.
       const renderedSignals = noSignalsToday ? allSignals : (olderSignals.length > 0 ? olderSignals : todaySignals);
       const oldestSignal = renderedSignals[renderedSignals.length - 1];
       const scrollCursor = oldestSignal && oldestSignal._day
         ? oldestSignal._day
-        : pacificTodayStr;
+        : utcTodayStr;
       initInfiniteScroll(scrollCursor);
     }
 
@@ -3766,9 +3766,9 @@
       if (mins < 60) return `${mins}m ago`;
       if (hours < 24) return `${hours}h ago`;
       if (days <= 7) return `${days}d ago`;
-      // Fallback to short date — use Pacific timezone for consistency with day-grouping logic
+      // Fallback to short date — use browser-local timezone for display
       const d = new Date(ts);
-      return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'America/Los_Angeles' });
+      return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
     }
 
     function esc(str) {

--- a/src/__tests__/helpers.test.ts
+++ b/src/__tests__/helpers.test.ts
@@ -1,39 +1,53 @@
 import { describe, it, expect } from "vitest";
 import {
-  getPacificDate,
-  getPacificYesterday,
+  getUTCDate,
+  getUTCYesterday,
   getNextDate,
-  getPacificDayStartUTC,
+  getUTCDayStart,
+  getUTCDayEnd,
   generateId,
-  formatPacificShort,
+  formatUTCShort,
+  toUTCDate,
 } from "../lib/helpers";
 
-describe("getPacificDate", () => {
+describe("getUTCDate", () => {
   it("returns a string in YYYY-MM-DD format", () => {
-    const result = getPacificDate(new Date("2024-06-15T12:00:00Z"));
+    const result = getUTCDate(new Date("2024-06-15T12:00:00Z"));
     expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
   });
 
-  it("uses Pacific time (UTC-8 in winter)", () => {
-    // 2024-01-01T07:00:00Z = Dec 31, 2023 at 11pm PST (UTC-8)
-    const result = getPacificDate(new Date("2024-01-01T07:00:00Z"));
-    expect(result).toBe("2023-12-31");
+  it("returns the UTC date (not local time) — early UTC is still same UTC day", () => {
+    // 2024-01-01T00:30:00Z is 00:30 UTC on Jan 1 — still Jan 1 UTC
+    const result = getUTCDate(new Date("2024-01-01T00:30:00Z"));
+    expect(result).toBe("2024-01-01");
+  });
+
+  it("returns the UTC date near end of day", () => {
+    // 2024-12-31T23:30:00Z is still Dec 31 in UTC
+    const result = getUTCDate(new Date("2024-12-31T23:30:00Z"));
+    expect(result).toBe("2024-12-31");
   });
 
   it("uses current date when no argument given", () => {
-    const result = getPacificDate();
+    const result = getUTCDate();
     expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
   });
 });
 
-describe("getPacificYesterday", () => {
-  it("returns the day before the given date", () => {
-    const result = getPacificYesterday(new Date("2024-06-15T20:00:00Z"));
-    const today = getPacificDate(new Date("2024-06-15T20:00:00Z"));
-    // Just check format, actual value depends on timezone
-    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
-    // Should be one day before today
-    expect(new Date(result).getTime()).toBeLessThan(new Date(today).getTime());
+describe("getUTCYesterday", () => {
+  it("returns the day before the given date in UTC", () => {
+    const result = getUTCYesterday(new Date("2024-06-15T20:00:00Z"));
+    expect(result).toBe("2024-06-14");
+  });
+
+  it("handles month boundaries", () => {
+    const result = getUTCYesterday(new Date("2024-03-01T12:00:00Z"));
+    expect(result).toBe("2024-02-29"); // 2024 is a leap year
+  });
+
+  it("handles year boundaries", () => {
+    const result = getUTCYesterday(new Date("2024-01-01T12:00:00Z"));
+    expect(result).toBe("2023-12-31");
   });
 });
 
@@ -51,118 +65,81 @@ describe("getNextDate", () => {
   });
 });
 
-describe("getPacificDayStartUTC", () => {
+describe("getUTCDayStart", () => {
+  it("returns midnight UTC as ISO 8601 string", () => {
+    const result = getUTCDayStart("2026-01-20");
+    expect(result).toBe("2026-01-20T00:00:00.000Z");
+  });
+
   it("returns an ISO 8601 UTC string", () => {
-    const result = getPacificDayStartUTC("2024-06-15");
+    const result = getUTCDayStart("2024-06-15");
     expect(result).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
   });
 
-  it("returns midnight Pacific time (PDT = UTC-7, so 07:00 UTC)", () => {
-    // June is PDT (UTC-7), so midnight Pacific = 07:00 UTC
-    const result = getPacificDayStartUTC("2024-06-15");
-    expect(result).toBe("2024-06-15T07:00:00.000Z");
+  it("always returns T00:00:00.000Z regardless of time of year", () => {
+    // No DST complexity — UTC midnight is always T00:00:00.000Z
+    expect(getUTCDayStart("2024-06-15")).toBe("2024-06-15T00:00:00.000Z");
+    expect(getUTCDayStart("2024-01-15")).toBe("2024-01-15T00:00:00.000Z");
+  });
+});
+
+describe("getUTCDayEnd", () => {
+  it("returns midnight UTC of the next day", () => {
+    const result = getUTCDayEnd("2026-01-20");
+    expect(result).toBe("2026-01-21T00:00:00.000Z");
   });
 
-  it("returns midnight Pacific time (PST = UTC-8, so 08:00 UTC)", () => {
-    // January is PST (UTC-8), so midnight Pacific = 08:00 UTC
-    const result = getPacificDayStartUTC("2024-01-15");
-    expect(result).toBe("2024-01-15T08:00:00.000Z");
+  it("handles month boundaries", () => {
+    expect(getUTCDayEnd("2024-01-31")).toBe("2024-02-01T00:00:00.000Z");
   });
 });
 
 /**
- * Brief compilation date window tests (issue #183)
+ * UTC midnight boundary tests
  *
- * The daily brief uses a Pacific-aligned date window, not UTC midnight.
- * This prevents signals filed in the late-evening Pacific hours (which fall
- * in the early UTC hours of the following day) from "bleeding" into the
- * next day's brief.
+ * The daily brief uses UTC-aligned date windows: [getUTCDayStart(date), getUTCDayEnd(date))
  *
- * The window for a given date YYYY-MM-DD is:
- *   [getPacificDayStartUTC(date), getPacificDayStartUTC(getNextDate(date)))
- *
- * For PST (UTC-8, e.g. January):
- *   2026-01-20 window: 2026-01-20T08:00:00Z <= created_at < 2026-01-21T08:00:00Z
- *
- * A signal at 2026-01-21T05:59Z is 9:59 PM PST on 2026-01-20 — it belongs
- * in the Jan 20 brief, NOT the Jan 21 brief. Without Pacific-aligned windows
- * (i.e., using UTC midnight), this signal would bleed into Jan 21.
+ * For 2026-01-20: window is [2026-01-20T00:00:00Z, 2026-01-21T00:00:00Z)
  */
-describe("brief compilation date window — Pacific timezone boundaries", () => {
-  it("window start is midnight Pacific (PST: 08:00 UTC)", () => {
-    // January is PST (UTC-8), so midnight Pacific = 08:00 UTC
-    const dayStart = getPacificDayStartUTC("2026-01-20");
-    expect(dayStart).toBe("2026-01-20T08:00:00.000Z");
+describe("UTC midnight boundaries", () => {
+  it("window start is midnight UTC (T00:00:00.000Z)", () => {
+    const dayStart = getUTCDayStart("2026-01-20");
+    expect(dayStart).toBe("2026-01-20T00:00:00.000Z");
   });
 
-  it("window end is midnight Pacific the next day (PST)", () => {
-    // Window end = start of the next Pacific day
-    const dayEnd = getPacificDayStartUTC(getNextDate("2026-01-20"));
-    expect(dayEnd).toBe("2026-01-21T08:00:00.000Z");
+  it("window end is midnight UTC the next day", () => {
+    const dayEnd = getUTCDayEnd("2026-01-20");
+    expect(dayEnd).toBe("2026-01-21T00:00:00.000Z");
   });
 
-  it("window start is midnight Pacific (PDT: 07:00 UTC)", () => {
-    // June is PDT (UTC-7), so midnight Pacific = 07:00 UTC
-    const dayStart = getPacificDayStartUTC("2026-06-15");
-    expect(dayStart).toBe("2026-06-15T07:00:00.000Z");
-  });
-
-  it("signal at 5:59 AM UTC day+1 (9:59 PM PST day) is INSIDE the PST window", () => {
-    // This is the exact scenario from issue #183 (using January for PST).
-    // A signal filed at 2026-01-21T05:59Z is 9:59 PM PST on Jan 20.
-    // The Jan 20 brief window is [08:00 Jan 20 UTC, 08:00 Jan 21 UTC).
-    // 2026-01-21T05:59Z is within that window → correctly belongs in Jan 20.
-    const signalTs = "2026-01-21T05:59:00.000Z";
-    const dayStart = getPacificDayStartUTC("2026-01-20");
-    const dayEnd = getPacificDayStartUTC(getNextDate("2026-01-20"));
+  it("signal at 23:59:59Z is inside the current UTC day", () => {
+    const signalTs = "2026-01-20T23:59:59.000Z";
+    const dayStart = getUTCDayStart("2026-01-20");
+    const dayEnd = getUTCDayEnd("2026-01-20");
 
     expect(signalTs >= dayStart).toBe(true);
     expect(signalTs < dayEnd).toBe(true);
   });
 
-  it("signal at 8:01 AM UTC day+1 (12:01 AM PST day+1) is OUTSIDE the PST window", () => {
-    // A signal at 2026-01-21T08:01Z is 12:01 AM PST on Jan 21.
-    // It should NOT be in the Jan 20 brief — it belongs in Jan 21.
-    const signalTs = "2026-01-21T08:01:00.000Z";
-    const dayStart = getPacificDayStartUTC("2026-01-20");
-    const dayEnd = getPacificDayStartUTC(getNextDate("2026-01-20"));
-
-    expect(signalTs >= dayStart).toBe(true);
-    expect(signalTs < dayEnd).toBe(false); // outside the window
-  });
-
-  it("signal at exactly midnight Pacific (08:00 UTC) is the first moment of the NEXT day", () => {
+  it("signal at exactly 00:00:00Z is the first moment of the next day", () => {
     // The window is [start, end) — exclusive upper bound.
-    // A signal at exactly 2026-01-21T08:00Z is midnight PST on Jan 21 → Jan 21 brief.
-    const signalTs = "2026-01-21T08:00:00.000Z";
-    const dayEnd = getPacificDayStartUTC(getNextDate("2026-01-20"));
+    // A signal at exactly 2026-01-21T00:00:00Z is midnight UTC on Jan 21 → Jan 21 brief.
+    const signalTs = "2026-01-21T00:00:00.000Z";
+    const dayEnd = getUTCDayEnd("2026-01-20");
 
     // dayEnd == signalTs, so signalTs < dayEnd is false → excluded from Jan 20
     expect(signalTs < dayEnd).toBe(false);
     // And it IS the start of the next day
-    expect(signalTs >= getPacificDayStartUTC("2026-01-21")).toBe(true);
+    expect(signalTs >= getUTCDayStart("2026-01-21")).toBe(true);
   });
 
-  it("with UTC-only windows, late-evening PST signals bleed into the next day", () => {
-    // This test documents WHY the Pacific window fix is necessary.
-    // If we used UTC midnight instead of Pacific midnight, the window for
-    // 2026-01-20 would be [2026-01-20T00:00Z, 2026-01-21T00:00Z).
-    //
-    // A signal at 2026-01-21T05:59Z would then fall in the UTC window for
-    // Jan 21 [2026-01-21T00:00Z, 2026-01-22T00:00Z), meaning signals filed
-    // at 9:59 PM PST on Jan 20 would appear in the Jan 21 brief (date bleed).
-    const signalTs = "2026-01-21T05:59:00.000Z";
+  it("signal at 00:00:01Z of the next day is outside the current day window", () => {
+    const signalTs = "2026-01-21T00:00:01.000Z";
+    const dayStart = getUTCDayStart("2026-01-20");
+    const dayEnd = getUTCDayEnd("2026-01-20");
 
-    // UTC-midnight window for Jan 20: [00:00 Jan 20, 00:00 Jan 21)
-    const utcEnd = "2026-01-21T00:00:00.000Z";
-
-    // With UTC window, the 5:59 AM UTC signal is OUTSIDE Jan 20 (bleed!)
-    expect(signalTs < utcEnd).toBe(false);
-
-    // With Pacific window, the same signal is correctly INSIDE Jan 20
-    const pacificStart = getPacificDayStartUTC("2026-01-20");
-    const pacificEnd = getPacificDayStartUTC(getNextDate("2026-01-20"));
-    expect(signalTs >= pacificStart && signalTs < pacificEnd).toBe(true);
+    expect(signalTs >= dayStart).toBe(true);
+    expect(signalTs < dayEnd).toBe(false); // outside the window
   });
 });
 
@@ -183,15 +160,38 @@ describe("generateId", () => {
   });
 });
 
-describe("formatPacificShort", () => {
+describe("formatUTCShort", () => {
   it("returns a non-empty string", () => {
-    const result = formatPacificShort("2024-06-15T12:00:00Z");
+    const result = formatUTCShort("2024-06-15T12:00:00Z");
     expect(typeof result).toBe("string");
     expect(result.length).toBeGreaterThan(0);
   });
 
   it("includes the month abbreviation", () => {
-    const result = formatPacificShort("2024-06-15T12:00:00Z");
+    const result = formatUTCShort("2024-06-15T12:00:00Z");
     expect(result).toContain("Jun");
+  });
+
+  it("includes ' UTC' suffix", () => {
+    const result = formatUTCShort("2024-06-15T12:00:00Z");
+    expect(result).toContain(" UTC");
+  });
+});
+
+describe("toUTCDate", () => {
+  it("extracts the UTC date from an ISO timestamp", () => {
+    const result = toUTCDate("2024-06-15T23:30:00Z");
+    expect(result).toBe("2024-06-15");
+  });
+
+  it("uses UTC — not local time", () => {
+    // 2024-01-01T00:30:00Z is still Jan 1 in UTC
+    const result = toUTCDate("2024-01-01T00:30:00Z");
+    expect(result).toBe("2024-01-01");
+  });
+
+  it("returns a string in YYYY-MM-DD format", () => {
+    const result = toUTCDate("2024-06-15T12:00:00Z");
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
   });
 });

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -83,7 +83,7 @@ export const MAX_SIGNALS_PER_DAY = 6;
 export const MAX_INCLUDED_SIGNALS_PER_BRIEF = 30;
 
 // ── Daily approval cap (Publisher-enforced) ──
-/** Maximum signals the Publisher may approve per Pacific day. Once reached,
+/** Maximum signals the Publisher may approve per UTC day. Once reached,
  *  further approvals require displacing an existing approved signal. */
 export const MAX_APPROVED_SIGNALS_PER_DAY = 30;
 

--- a/src/lib/do-client.ts
+++ b/src/lib/do-client.ts
@@ -132,7 +132,7 @@ export interface SignalFilters {
   agent?: string;
   tag?: string;
   since?: string;
-  /** Pacific calendar day (YYYY-MM-DD) — filters to signals within that day's PT boundaries. */
+  /** UTC calendar day (YYYY-MM-DD) — filters to signals within that day's UTC boundaries. */
   date?: string;
   status?: string;
   limit?: number;

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -46,7 +46,7 @@ export function generateId(): string {
  * Returns the date string for the day after the given YYYY-MM-DD string
  */
 export function getNextDate(date: string): string {
-  const d = new Date(date + "T12:00:00Z"); // noon UTC to avoid DST edge
+  const d = new Date(date + "T12:00:00Z"); // noon UTC to avoid date rollover at midnight
   d.setUTCDate(d.getUTCDate() + 1);
   return d.toISOString().slice(0, 10);
 }

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -71,7 +71,7 @@ export function getUTCDayEnd(date: string): string {
  * Useful for annotating API responses so consumers don't need to convert themselves.
  */
 export function toUTCDate(isoTimestamp: string): string {
-  return new Date(isoTimestamp).toISOString().slice(0, 10);
+  return isoTimestamp.slice(0, 10);
 }
 
 /**

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -2,59 +2,37 @@ import type { Beat } from "./types";
 import type { AgentInfo } from "../services/agent-resolver";
 import { resolveAgentNames } from "../services/agent-resolver";
 
-export const PACIFIC_TZ = "America/Los_Angeles";
-
 /**
- * WHY Pacific time?
- *
- * This news system is operated by a Pacific-based publisher. The editorial day
- * runs midnight-to-midnight PT (America/Los_Angeles), which automatically handles
- * both PST (UTC-8) and PDT (UTC-7) via the IANA timezone database.
- *
- * Key timing anchors:
- *   - Briefs are compiled at ~11 pm PT each night. Signals approved before
- *     that cutoff count toward that day's brief and brief_inclusions score.
- *   - Streak boundaries align with the editorial day: a scout must file at
- *     least one approved signal on each consecutive Pacific calendar day to
- *     maintain their streak. Missing a Pacific day breaks the streak even if
- *     only a few UTC hours passed between their last two signals.
- *   - The 30-day rolling window in SQL uses datetime('now', '-30 days') (UTC).
- *     This is intentionally different from streak/day boundaries — it is a
- *     sliding competition window, not an editorial-day boundary.
+ * Returns the current date in YYYY-MM-DD format in UTC.
+ * Use this for streak and day-boundary calculations.
  */
-
-/**
- * Returns the current date in YYYY-MM-DD format in Pacific time.
- * Use this for streak and day-boundary calculations, not for UTC timestamps.
- */
-export function getPacificDate(now = new Date()): string {
-  return now.toLocaleDateString("en-CA", { timeZone: PACIFIC_TZ });
+export function getUTCDate(now = new Date()): string {
+  return now.toISOString().slice(0, 10);
 }
 
 /**
- * Returns yesterday's date in YYYY-MM-DD format in Pacific time.
- * "Yesterday" here is Pacific yesterday — a scout who filed at 11:59 pm PT
- * and files again at 12:01 am PT the next day has a consecutive-day streak.
- * The same two signals in UTC could span a very different day boundary.
+ * Returns yesterday's date in YYYY-MM-DD format in UTC.
  */
-export function getPacificYesterday(now = new Date()): string {
+export function getUTCYesterday(now = new Date()): string {
   const yesterday = new Date(now);
-  yesterday.setDate(yesterday.getDate() - 1);
-  return getPacificDate(yesterday);
+  yesterday.setUTCDate(yesterday.getUTCDate() - 1);
+  return getUTCDate(yesterday);
 }
 
 /**
- * Formats an ISO date string to a short Pacific time representation
- * e.g. "Mar 3, 10:30 AM"
+ * Formats an ISO date string to a short UTC time representation
+ * e.g. "Mar 3, 10:30 AM UTC"
  */
-export function formatPacificShort(isoStr: string): string {
-  return new Date(isoStr).toLocaleString("en-US", {
-    timeZone: PACIFIC_TZ,
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
+export function formatUTCShort(isoStr: string): string {
+  return (
+    new Date(isoStr).toLocaleString("en-US", {
+      timeZone: "UTC",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    }) + " UTC"
+  );
 }
 
 /**
@@ -74,44 +52,26 @@ export function getNextDate(date: string): string {
 }
 
 /**
- * Returns the UTC ISO string for midnight Pacific time on the given YYYY-MM-DD date.
- * Uses Intl.DateTimeFormat offset detection to handle PST/PDT automatically.
+ * Returns the UTC ISO string for midnight UTC on the given YYYY-MM-DD date.
  */
-export function getPacificDayStartUTC(date: string): string {
-  // Try noon Pacific to avoid DST edge cases when finding the offset
-  // We create a Date at noon UTC and check what Pacific time it shows
-  // Then we compute: utcMidnightPacific = midnightUTC + pacificOffsetMs
-  // Pacific offset: PST = UTC-8, PDT = UTC-7
-  // We detect it by formatting a UTC noon time for the given date
-  const noonUTC = new Date(date + "T20:00:00Z"); // 20:00 UTC = noon PST or 1pm PDT
-  const formatter = new Intl.DateTimeFormat("en-US", {
-    timeZone: PACIFIC_TZ,
-    hour: "numeric",
-    hour12: false,
-    timeZoneName: "short",
-  });
-  const parts = formatter.formatToParts(noonUTC);
-  const tzName = parts.find((p) => p.type === "timeZoneName")?.value ?? "PST";
-  const offsetHours = tzName === "PDT" ? -7 : -8;
-  // Midnight Pacific = midnight UTC minus the negative offset = midnight UTC + |offset|
-  const midnightUTCMs = Date.parse(date + "T00:00:00Z") - offsetHours * 3600000;
-  return new Date(midnightUTCMs).toISOString();
+export function getUTCDayStart(date: string): string {
+  return date + "T00:00:00.000Z";
 }
 
 /**
- * Returns the UTC ISO string for the end of a Pacific day (midnight of the next day).
- * Used together with getPacificDayStartUTC() to create a [start, end) range.
+ * Returns the UTC ISO string for the end of a UTC day (midnight of the next day).
+ * Used together with getUTCDayStart() to create a [start, end) range.
  */
-export function getPacificDayEndUTC(date: string): string {
-  return getPacificDayStartUTC(getNextDate(date));
+export function getUTCDayEnd(date: string): string {
+  return getNextDate(date) + "T00:00:00.000Z";
 }
 
 /**
- * Compute the Pacific calendar date (YYYY-MM-DD) for an ISO/UTC timestamp string.
+ * Compute the UTC calendar date (YYYY-MM-DD) for an ISO/UTC timestamp string.
  * Useful for annotating API responses so consumers don't need to convert themselves.
  */
-export function toPacificDate(isoTimestamp: string): string {
-  return new Date(isoTimestamp).toLocaleDateString("en-CA", { timeZone: PACIFIC_TZ });
+export function toUTCDate(isoTimestamp: string): string {
+  return new Date(isoTimestamp).toISOString().slice(0, 10);
 }
 
 /**
@@ -197,4 +157,3 @@ export async function resolveNamesWithTimeout(
   waitUntil(nameResolution.catch(() => {}));
   return nameMap;
 }
-

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -3614,7 +3614,7 @@ export class NewsDO extends DurableObject<Env> {
           .toArray();
         if (sigRows.length === 0) {
           return c.json(
-            { ok: false, error: `Signal "${signalId}" is not part of Pacific brief date ${brief_date as string}` } satisfies DOResult<unknown>,
+            { ok: false, error: `Signal "${signalId}" is not part of brief date ${brief_date as string}` } satisfies DOResult<unknown>,
             400
           );
         }

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -1883,7 +1883,7 @@ export class NewsDO extends DurableObject<Env> {
       const probeTimestamp = (probeRows[0] as Record<string, unknown>).created_at as string;
       const day = getUTCDate(new Date(probeTimestamp));
       const dayStartUTC = getUTCDayStart(day);
-      const dayEndUTC = getUTCDayStart(getNextDate(day));
+      const dayEndUTC = getUTCDayEnd(day);
 
       // Step 2: Fetch ALL signals for that UTC day (complete day, no limit)
       const rows = this.ctx.storage.sql
@@ -2075,7 +2075,7 @@ export class NewsDO extends DurableObject<Env> {
       const dailyCount = (dailyCountRows[0] as Record<string, unknown>).count as number;
       if (dailyCount >= MAX_SIGNALS_PER_DAY) {
         // Compute seconds until the next UTC day reset
-        const tomorrowStart = getUTCDayStart(getNextDate(today));
+        const tomorrowStart = getUTCDayEnd(today);
         const retryAfterSecs = Math.ceil((new Date(tomorrowStart).getTime() - now.getTime()) / 1000);
         const res = c.json(
           {
@@ -2355,7 +2355,7 @@ export class NewsDO extends DurableObject<Env> {
       // Compute UTC day boundaries as ISO strings.
       // Derive start/end of the UTC day for `date`.
       const dayStart = getUTCDayStart(date);
-      const dayEnd = getUTCDayStart(getNextDate(date));
+      const dayEnd = getUTCDayEnd(date);
 
       // Simplified compile: the roster IS the set of approved signals for the day.
       // All curation happened at review time via cap-enforced approval.

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -3,7 +3,7 @@ import { Hono } from "hono";
 import type { Context } from "hono";
 import type { Env, Beat, Signal, SignalStatus, Streak, Brief, Classified, ClassifiedStatus, Earning, Correction, ReferralCredit, BriefSignal, CompiledBriefData, DOResult, ApprovalCapInfo, PayoutRecord, IncludedSignalMetadata, CompiledSignalRow, PaymentStageKind, PaymentStageLifecycle, PaymentStageMaterialized, PaymentStagePayload, PaymentStageRecord, PaymentTerminalReason, PaymentTrackedState } from "../lib/types";
 import { validateSlug, validateHexColor, sanitizeString, validateDateFormat } from "../lib/validators";
-import { generateId, getPacificDate, getPacificYesterday, getPacificDayStartUTC, getPacificDayEndUTC, getNextDate } from "../lib/helpers";
+import { generateId, getUTCDate, getUTCYesterday, getUTCDayStart, getUTCDayEnd, getNextDate } from "../lib/helpers";
 import { CLASSIFIED_DURATION_DAYS, CLASSIFIED_BRIEF_SLOTS, CLASSIFIED_BRIEF_MAX_CHARS, CLASSIFIED_STATUSES, SIGNAL_COOLDOWN_HOURS, BEAT_EXPIRY_DAYS, MAX_SIGNALS_PER_DAY, MAX_INCLUDED_SIGNALS_PER_BRIEF, MAX_APPROVED_SIGNALS_PER_DAY, SIGNAL_STATUSES, REVIEWABLE_SIGNAL_STATUSES, CONFIG_PUBLISHER_ADDRESS, BRIEF_INCLUSION_PAYOUT_SATS, WEEKLY_PRIZE_1ST_SATS, WEEKLY_PRIZE_2ND_SATS, WEEKLY_PRIZE_3RD_SATS, SCORING_WEIGHTS, PAYMENT_STAGE_TTL_MS } from "../lib/constants";
 import { SCHEMA_SQL, MIGRATION_PHASE0_SQL, MIGRATION_PAYMENTS_SQL, MIGRATION_BEAT_RESTRUCTURE_SQL, MIGRATION_SBTC_TRACKING_SQL, MIGRATION_CLASSIFIEDS_CLEANUP_SQL, MIGRATION_CLASSIFIEDS_REVIEW_SQL, MIGRATION_SNAPSHOTS_SQL, MIGRATION_BEAT_CLAIMS_SQL, MIGRATION_RETRACTION_SQL, MIGRATION_BEAT_NETWORK_FOCUS_SQL, MIGRATION_BITCOIN_MACRO_SQL, MIGRATION_QUANTUM_BEAT_SQL, MIGRATION_PAYMENT_STAGING_SQL, MIGRATION_APPROVAL_CAP_INDEX_SQL, MIGRATION_BEAT_EDITORS_SQL, MIGRATION_EDITORIAL_REVIEWS_SQL, MIGRATION_EDITOR_REVIEW_RATE_SQL, MIGRATION_CURATION_CLEANUP_SQL, MIGRATION_LEADERBOARD_INDEXES_SQL, MIGRATION_BEAT_CONSOLIDATION_SQL } from "./schema";
 
@@ -287,7 +287,8 @@ export class NewsDO extends DurableObject<Env> {
     // 20 = Curation cleanup — fix Mar 28-29 inscription IDs + void 312 orphaned earnings (#339)
     // 21 = Leaderboard composite indexes — accelerate 30-day rolling window queries (#319)
     // 22 = Beat consolidation — 12 → 3 beats, retire old beats, create aibtc-network (#423)
-    const CURRENT_MIGRATION_VERSION = 22;
+    // 23 = Streak UTC migration (backfill last_signal_date from actual signal timestamps)
+    const CURRENT_MIGRATION_VERSION = 23;
     const versionRows = this.ctx.storage.sql
       .exec("SELECT value FROM config WHERE key = 'migration_version'")
       .toArray();
@@ -596,9 +597,26 @@ export class NewsDO extends DurableObject<Env> {
         }
       }
 
+      // Backfill last_signal_date on streaks from actual signal timestamps (UTC date).
+      // Corrects streaks that stored Pacific-derived dates before the UTC migration.
+      if (appliedVersion < 23) {
+        try {
+          this.ctx.storage.sql.exec(
+            `UPDATE streaks SET last_signal_date = SUBSTR(
+              (SELECT MAX(s.created_at) FROM signals s
+               WHERE s.btc_address = streaks.btc_address AND s.correction_of IS NULL),
+              1, 10
+            ) WHERE last_signal_date IS NOT NULL`
+          );
+        } catch (e) {
+          console.error("Streak UTC migration failed:", e);
+          throw e;
+        }
+      }
+
       // Record current migration version so future cold starts skip all of the above.
-      // If migration 22 failed, cap at 21 so it retries on next cold start.
-      const versionToWrite = migration22Ok ? CURRENT_MIGRATION_VERSION : CURRENT_MIGRATION_VERSION - 1;
+      // If migration 22 failed but 23 succeeded, cap at 21 so v22 retries on next cold start.
+      const versionToWrite = migration22Ok ? CURRENT_MIGRATION_VERSION : CURRENT_MIGRATION_VERSION - 2;
       this.ctx.storage.sql.exec(
         "INSERT INTO config (key, value) VALUES ('migration_version', ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = datetime('now')",
         String(versionToWrite)
@@ -1019,9 +1037,9 @@ export class NewsDO extends DurableObject<Env> {
       const nowDate = new Date();
 
       if (newStatus === "approved") {
-        const today = getPacificDate(nowDate);
-        const dayStart = getPacificDayStartUTC(today);
-        const dayEnd = getPacificDayEndUTC(today);
+        const today = getUTCDate(nowDate);
+        const dayStart = getUTCDayStart(today);
+        const dayEnd = getUTCDayEnd(today);
 
         // Determine the effective cap: use beat's daily_approved_limit if set.
         // NULL = no per-beat cap (unlimited). The global MAX_APPROVED_SIGNALS_PER_DAY
@@ -1763,13 +1781,13 @@ export class NewsDO extends DurableObject<Env> {
       );
       const offset = Math.min(Math.max(0, parseInt(c.req.query("offset") ?? "0", 10) || 0), 10_000);
 
-      // When `date` is provided (YYYY-MM-DD), convert to Pacific day UTC boundaries.
+      // When `date` is provided (YYYY-MM-DD), convert to UTC day boundaries.
       // `date` and `since` are mutually exclusive — `date` takes precedence.
       let dateStart: string | null = null;
       let dateEnd: string | null = null;
       if (dateParam) {
-        dateStart = getPacificDayStartUTC(dateParam);
-        dateEnd = getPacificDayEndUTC(dateParam);
+        dateStart = getUTCDayStart(dateParam);
+        dateEnd = getUTCDayEnd(dateParam);
       }
 
       const rows = this.ctx.storage.sql
@@ -1828,9 +1846,9 @@ export class NewsDO extends DurableObject<Env> {
     });
 
     // GET /signals/front-page-page — date-paginated curated signals for infinite scroll
-    // Query params: before (YYYY-MM-DD Pacific date, required), limit (unused, kept for compat)
-    // Uses 2-step query: (1) find the target Pacific day, (2) fetch ALL signals for that day.
-    // Returns signals from the most recent Pacific day strictly before `before`, with hasMore flag.
+    // Query params: before (YYYY-MM-DD UTC date, required), limit (unused, kept for compat)
+    // Uses 2-step query: (1) find the target UTC day, (2) fetch ALL signals for that day.
+    // Returns signals from the most recent UTC day strictly before `before`, with hasMore flag.
     this.router.get("/signals/front-page-page", (c) => {
       const before = c.req.query("before") ?? null;
 
@@ -1841,8 +1859,8 @@ export class NewsDO extends DurableObject<Env> {
         );
       }
 
-      // Use Pacific-day boundaries to match brief date semantics
-      const beforeDayStartUTC = getPacificDayStartUTC(before);
+      // Use UTC day boundaries to match brief date semantics
+      const beforeDayStartUTC = getUTCDayStart(before);
 
       // Step 1: Find the target day — get the most recent signal strictly before the boundary
       const probeRows = this.ctx.storage.sql
@@ -1861,13 +1879,13 @@ export class NewsDO extends DurableObject<Env> {
         return c.json({ ok: true, data: { signals: [], date: null, hasMore: false } });
       }
 
-      // Determine the Pacific date of the most recent signal before the boundary
+      // Determine the UTC date of the most recent signal before the boundary
       const probeTimestamp = (probeRows[0] as Record<string, unknown>).created_at as string;
-      const day = getPacificDate(new Date(probeTimestamp));
-      const dayStartUTC = getPacificDayStartUTC(day);
-      const dayEndUTC = getPacificDayStartUTC(getNextDate(day));
+      const day = getUTCDate(new Date(probeTimestamp));
+      const dayStartUTC = getUTCDayStart(day);
+      const dayEndUTC = getUTCDayStart(getNextDate(day));
 
-      // Step 2: Fetch ALL signals for that Pacific day (complete day, no limit)
+      // Step 2: Fetch ALL signals for that UTC day (complete day, no limit)
       const rows = this.ctx.storage.sql
         .exec(
           `SELECT s.*, b.name as beat_name, GROUP_CONCAT(st.tag) as tags_csv
@@ -2040,10 +2058,10 @@ export class NewsDO extends DurableObject<Env> {
       const now = new Date();
       const nowIso = now.toISOString();
 
-      // Pacific-timezone date helpers (used for daily signal limit and streak)
-      const today = getPacificDate(now);
-      const yesterday = getPacificYesterday(now);
-      const todayStart = getPacificDayStartUTC(today);
+      // UTC date helpers (used for daily cap and streak)
+      const today = getUTCDate(now);
+      const yesterday = getUTCYesterday(now);
+      const todayStart = getUTCDayStart(today);
 
       // Daily signal cap per agent
       const dailyCountRows = this.ctx.storage.sql
@@ -2056,13 +2074,13 @@ export class NewsDO extends DurableObject<Env> {
         .toArray();
       const dailyCount = (dailyCountRows[0] as Record<string, unknown>).count as number;
       if (dailyCount >= MAX_SIGNALS_PER_DAY) {
-        // Compute seconds until the next Pacific-day reset
-        const tomorrowStart = getPacificDayStartUTC(getNextDate(today));
+        // Compute seconds until the next UTC day reset
+        const tomorrowStart = getUTCDayStart(getNextDate(today));
         const retryAfterSecs = Math.ceil((new Date(tomorrowStart).getTime() - now.getTime()) / 1000);
         const res = c.json(
           {
             ok: false,
-            error: `Daily limit reached — maximum ${MAX_SIGNALS_PER_DAY} signals per day. Resets at midnight Pacific.`,
+            error: `Daily limit reached — maximum ${MAX_SIGNALS_PER_DAY} signals per day. Resets at midnight UTC.`,
             daily_limit: {
               limit: MAX_SIGNALS_PER_DAY,
               filed_today: dailyCount,
@@ -2082,7 +2100,7 @@ export class NewsDO extends DurableObject<Env> {
       const signalTags = (tags as string[]) ?? [];
       const disclosure = body.disclosure ? sanitizeString(body.disclosure, 500) : "";
 
-      // Streak calculation (Pacific timezone)
+      // Streak calculation (UTC)
       const streakRows = this.ctx.storage.sql
         .exec("SELECT * FROM streaks WHERE btc_address = ?", btc_address as string)
         .toArray();
@@ -2095,7 +2113,7 @@ export class NewsDO extends DurableObject<Env> {
       if (currentStreakRecord) {
         totalSignals = (currentStreakRecord.total_signals ?? 0) + 1;
         if (currentStreakRecord.last_signal_date === today) {
-          // Already filed today (Pacific) — no streak change, but always count the new signal
+          // Already filed today (UTC) — no streak change, but always count the new signal
           currentStreak = currentStreakRecord.current_streak ?? 1;
           longestStreak = currentStreakRecord.longest_streak ?? 1;
         } else if (currentStreakRecord.last_signal_date === yesterday) {
@@ -2332,14 +2350,12 @@ export class NewsDO extends DurableObject<Env> {
       }
 
       const now = new Date();
-      const date = (body.date as string | undefined) ?? getPacificDate(now);
+      const date = (body.date as string | undefined) ?? getUTCDate(now);
 
-      // Compute Pacific day boundaries as UTC ISO strings.
-      // We find what UTC time corresponds to midnight Pacific on `date`.
-      // Strategy: use Intl.DateTimeFormat to find the UTC offset for that date,
-      // then derive start/end of the Pacific day in UTC.
-      const dayStart = getPacificDayStartUTC(date);
-      const dayEnd = getPacificDayStartUTC(getNextDate(date));
+      // Compute UTC day boundaries as ISO strings.
+      // Derive start/end of the UTC day for `date`.
+      const dayStart = getUTCDayStart(date);
+      const dayEnd = getUTCDayStart(getNextDate(date));
 
       // Simplified compile: the roster IS the set of approved signals for the day.
       // All curation happened at review time via cap-enforced approval.
@@ -2840,8 +2856,8 @@ export class NewsDO extends DurableObject<Env> {
     this.router.get("/status/:address", (c) => {
       const address = c.req.param("address");
       const now = new Date();
-      const today = getPacificDate(now);
-      const todayUTCStart = getPacificDayStartUTC(today);
+      const today = getUTCDate(now);
+      const todayUTCStart = getUTCDayStart(today);
 
       // Find all beats this agent is a member of (via beat_claims)
       const beatRows = this.ctx.storage.sql
@@ -3031,12 +3047,12 @@ export class NewsDO extends DurableObject<Env> {
     // GET /report
     this.router.get("/report", (c) => {
       const now = new Date();
-      const today = getPacificDate(now);
-      const yesterday = getPacificYesterday(now);
-      // Use UTC timestamp for today's Pacific day start to avoid DATE() timezone mismatch
-      const todayUTCStart = getPacificDayStartUTC(today);
+      const today = getUTCDate(now);
+      const yesterday = getUTCYesterday(now);
+      // Use UTC timestamp for today's UTC day start
+      const todayUTCStart = getUTCDayStart(today);
 
-      // Total signals today (Pacific day, UTC comparison, excluding corrections)
+      // Total signals today (UTC day, excluding corrections)
       const signalsTodayRows = this.ctx.storage.sql
         .exec(
           `SELECT COUNT(*) as count FROM signals WHERE correction_of IS NULL AND created_at >= ?`,
@@ -3054,7 +3070,7 @@ export class NewsDO extends DurableObject<Env> {
         .exec("SELECT COUNT(*) as count FROM signals WHERE correction_of IS NULL")
         .toArray();
 
-      // Active correspondents today (Pacific day, UTC comparison, excluding corrections)
+      // Active correspondents today (UTC day, excluding corrections)
       const activeRows = this.ctx.storage.sql
         .exec(
           `SELECT COUNT(DISTINCT btc_address) as count FROM signals WHERE correction_of IS NULL AND created_at >= ?`,
@@ -3291,8 +3307,8 @@ export class NewsDO extends DurableObject<Env> {
       let revived = 0;
       let voided = 0;
 
-      const dayStart = getPacificDayStartUTC(brief_date as string);
-      const dayEnd = getPacificDayStartUTC(getNextDate(brief_date as string));
+      const dayStart = getUTCDayStart(brief_date as string);
+      const dayEnd = getUTCDayStart(getNextDate(brief_date as string));
 
       this.ctx.storage.transactionSync(() => {
         const selectedSet = new Set(validIds);
@@ -3572,8 +3588,8 @@ export class NewsDO extends DurableObject<Env> {
       }
 
       const now = new Date().toISOString();
-      const dayStart = getPacificDayStartUTC(brief_date as string);
-      const dayEnd = getPacificDayStartUTC(getNextDate(brief_date as string));
+      const dayStart = getUTCDayStart(brief_date as string);
+      const dayEnd = getUTCDayStart(getNextDate(brief_date as string));
 
       const selectedSignals: BriefSignal[] = [];
       for (let i = 0; i < selectedIds.length; i++) {
@@ -4778,25 +4794,24 @@ export class NewsDO extends DurableObject<Env> {
    * Update both places when changing weights. SQL literals are used directly
    * because SQLite bind parameters cannot substitute column expressions.
    *
-   * ── Scoring timeline (Pacific time) ──────────────────────────────────────
-   * This system is operated by a Pacific-based publisher. All streak and day
-   * boundaries use Pacific time (America/Los_Angeles), so a scout's "day" runs
-   * midnight-to-midnight PT regardless of UTC offset.
+   * ── Scoring timeline (UTC) ───────────────────────────────────────────────
+   * All streak and day boundaries use UTC midnight, so a scout's "day" runs
+   * midnight-to-midnight UTC.
    *
    * Daily editorial cycle:
-   *   - Scouts file signals any time during the Pacific day.
-   *   - The publisher compiles the brief at ~11 pm PT each night.
-   *   - Signals approved before the 11 pm PT cutoff are eligible for that
+   *   - Scouts file signals any time during the UTC day.
+   *   - The publisher compiles the brief once per day.
+   *   - Signals approved before the compile cutoff are eligible for that
    *     day's brief inclusion (brief_inclusions_30d).
-   *   - Streak logic (in POST /signals) uses getPacificDate() / getPacificYesterday()
-   *     to determine whether today or yesterday (Pacific) already has a signal.
+   *   - Streak logic (in POST /signals) uses getUTCDate() / getUTCYesterday()
+   *     to determine whether today or yesterday (UTC) already has a signal.
    *
    * Rolling window:
    *   - signal_count, days_active, approved_corrections, and referral_credits
    *     all use datetime('now', '-30 days') which is UTC-based.
    *   - brief_inclusions uses the same UTC window on brief_signals.created_at.
    *   - Streaks are NOT windowed — current_streak reflects unbroken consecutive
-   *     Pacific days up to the most recent signal, regardless of the 30-day limit.
+   *     UTC days up to the most recent signal, regardless of the 30-day limit.
    *
    * ── Tie-breaking order ────────────────────────────────────────────────────
    * To ensure the leaderboard is fully deterministic (critical for prize payouts):

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -602,11 +602,17 @@ export class NewsDO extends DurableObject<Env> {
       if (appliedVersion < 23) {
         try {
           this.ctx.storage.sql.exec(
-            `UPDATE streaks SET last_signal_date = SUBSTR(
-              (SELECT MAX(s.created_at) FROM signals s
-               WHERE s.btc_address = streaks.btc_address AND s.correction_of IS NULL),
-              1, 10
-            ) WHERE last_signal_date IS NOT NULL`
+            `WITH max_signals AS (
+               SELECT btc_address, MAX(created_at) AS max_created_at
+               FROM signals
+               WHERE correction_of IS NULL
+               GROUP BY btc_address
+             )
+             UPDATE streaks
+             SET last_signal_date = SUBSTR(max_signals.max_created_at, 1, 10)
+             FROM max_signals
+             WHERE streaks.btc_address = max_signals.btc_address
+               AND streaks.last_signal_date IS NOT NULL`
           );
         } catch (e) {
           console.error("Streak UTC migration failed:", e);

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -622,7 +622,7 @@ export class NewsDO extends DurableObject<Env> {
 
       // Record current migration version so future cold starts skip all of the above.
       // If migration 22 failed but 23 succeeded, cap at 21 so v22 retries on next cold start.
-      const versionToWrite = migration22Ok ? CURRENT_MIGRATION_VERSION : CURRENT_MIGRATION_VERSION - 2;
+      const versionToWrite = migration22Ok ? CURRENT_MIGRATION_VERSION : 21;
       this.ctx.storage.sql.exec(
         "INSERT INTO config (key, value) VALUES ('migration_version', ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = datetime('now')",
         String(versionToWrite)

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -3314,7 +3314,7 @@ export class NewsDO extends DurableObject<Env> {
       let voided = 0;
 
       const dayStart = getUTCDayStart(brief_date as string);
-      const dayEnd = getUTCDayStart(getNextDate(brief_date as string));
+      const dayEnd = getUTCDayEnd(brief_date as string);
 
       this.ctx.storage.transactionSync(() => {
         const selectedSet = new Set(validIds);
@@ -3595,7 +3595,7 @@ export class NewsDO extends DurableObject<Env> {
 
       const now = new Date().toISOString();
       const dayStart = getUTCDayStart(brief_date as string);
-      const dayEnd = getUTCDayStart(getNextDate(brief_date as string));
+      const dayEnd = getUTCDayEnd(brief_date as string);
 
       const selectedSignals: BriefSignal[] = [];
       for (let i = 0; i < selectedIds.length; i++) {

--- a/src/routes/brief-compile.ts
+++ b/src/routes/brief-compile.ts
@@ -5,7 +5,7 @@ import { createRateLimitMiddleware } from "../middleware/rate-limit";
 import { compileBriefData, saveBrief, recordBriefSignals, recordBriefInclusionPayouts, getConfig, getClassifiedsRotation } from "../lib/do-client";
 import { CONFIG_PUBLISHER_ADDRESS, BRIEF_COMPILE_RATE_LIMIT, MAX_INCLUDED_SIGNALS_PER_BRIEF } from "../lib/constants";
 import { resolveAgentNames } from "../services/agent-resolver";
-import { getPacificDate, formatPacificShort } from "../lib/helpers";
+import { getUTCDate, formatUTCShort } from "../lib/helpers";
 import { validateBtcAddress, validateDateFormat } from "../lib/validators";
 import { verifyAuth } from "../services/auth";
 
@@ -69,7 +69,7 @@ async function handleBriefCompile(
   }
 
   const now = new Date();
-  const date = (body.date as string | undefined) ?? getPacificDate(now);
+  const date = (body.date as string | undefined) ?? getUTCDate(now);
 
   // Validate date if provided
   if (body.date !== undefined && !validateDateFormat(date)) {
@@ -220,7 +220,7 @@ async function handleBriefCompile(
       }
       text += `— ${section.correspondentName}`;
       if (section.streak > 1) text += ` (${section.streak}d streak)`;
-      text += ` · ${formatPacificShort(section.timestamp)}\n\n`;
+      text += ` · ${formatUTCShort(section.timestamp)}\n\n`;
     }
     text += `${separator}\n`;
   }

--- a/src/routes/brief.ts
+++ b/src/routes/brief.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import type { Env, AppVariables } from "../lib/types";
 import { getLatestBrief, getBriefByDate, listBriefDates, recordEarning, reconcilePaymentStage, stagePayment } from "../lib/do-client";
 import { BRIEF_PRICE_SATS, CORRESPONDENT_SHARE } from "../lib/constants";
-import { getPacificDate } from "../lib/helpers";
+import { getUTCDate } from "../lib/helpers";
 import { logPaymentEvent } from "../lib/payment-logging";
 import { validateDateFormat } from "../lib/validators";
 import { buildLocalPaymentStatusUrl, buildPaymentRequired, verifyPayment, mapVerificationError } from "../services/x402";
@@ -10,11 +10,11 @@ import { buildLocalPaymentStatusUrl, buildPaymentRequired, verifyPayment, mapVer
 const briefRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>();
 
 // GET /api/brief — get today's compiled brief, or today's date with empty content if not yet compiled.
-// Always returns today's Pacific date so the frontend can show today's signal feed before the
+// Always returns today's UTC date so the frontend can show today's signal feed before the
 // brief is compiled, rather than falling back to yesterday's stale brief.
 briefRouter.get("/api/brief", async (c) => {
   const format = c.req.query("format") ?? "json";
-  const today = getPacificDate();
+  const today = getUTCDate();
   const [brief, archive] = await Promise.all([
     getLatestBrief(c.env),
     listBriefDates(c.env),

--- a/src/routes/init.ts
+++ b/src/routes/init.ts
@@ -10,7 +10,7 @@ import { Hono } from "hono";
 import type { Env, AppVariables } from "../lib/types";
 import { getInitBundle } from "../lib/do-client";
 import { transformClassified } from "./classifieds";
-import { getPacificDate, truncAddr, buildBeatsByAddress, resolveNamesWithTimeout } from "../lib/helpers";
+import { getUTCDate, truncAddr, buildBeatsByAddress, resolveNamesWithTimeout } from "../lib/helpers";
 import { BRIEF_PRICE_SATS } from "../lib/constants";
 
 
@@ -19,7 +19,7 @@ const initRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>();
 // GET /api/init — all initial page load data in one response
 initRouter.get("/api/init", async (c) => {
   const bundle = await getInitBundle(c.env);
-  const today = getPacificDate();
+  const today = getUTCDate();
 
   // --- Brief ---
   const todaysBrief = bundle.brief?.date === today ? bundle.brief : null;

--- a/src/routes/manifest.ts
+++ b/src/routes/manifest.ts
@@ -129,7 +129,7 @@ manifestRouter.get("/api", (c) => {
         body: {
           btc_address:
             "Your BTC address — must be the designated Publisher (required)",
-          date: "YYYY-MM-DD date (optional, defaults to today Pacific)",
+          date: "YYYY-MM-DD date (optional, defaults to today UTC)",
         },
       },
       "POST /api/brief/:date/inscribe": {

--- a/src/routes/signals.ts
+++ b/src/routes/signals.ts
@@ -18,7 +18,7 @@ import {
 } from "../lib/do-client";
 import { verifyAuth } from "../services/auth";
 import { checkAgentIdentity } from "../services/identity-gate";
-import { toPacificDate, resolveNamesWithTimeout } from "../lib/helpers";
+import { toUTCDate, resolveNamesWithTimeout } from "../lib/helpers";
 
 const signalsRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>();
 
@@ -58,7 +58,7 @@ signalsRouter.get("/api/signals", signalReadRateLimit, async (c) => {
 
   if (date) {
     if (!/^\d{4}-\d{2}-\d{2}$/.test(date) || Number.isNaN(new Date(`${date}T12:00:00Z`).getTime())) {
-      return c.json({ error: "Invalid 'date' parameter. Use YYYY-MM-DD format (Pacific calendar day)" }, 400);
+      return c.json({ error: "Invalid 'date' parameter. Use YYYY-MM-DD format (UTC calendar day)" }, 400);
     }
     // Reject dates that JS silently rolls over (e.g., Feb 31 → Mar 3)
     const parsed = new Date(`${date}T12:00:00Z`);
@@ -109,7 +109,7 @@ signalsRouter.get("/api/signals", signalReadRateLimit, async (c) => {
       sources: s.sources,
       tags: s.tags,
       timestamp: s.created_at,
-      pacificDate: toPacificDate(s.created_at),
+      utcDate: toUTCDate(s.created_at),
       correction_of: s.correction_of,
       status: s.status,
       publisherFeedback: s.publisher_feedback,
@@ -118,7 +118,7 @@ signalsRouter.get("/api/signals", signalReadRateLimit, async (c) => {
   });
 
   c.header("Cache-Control", "public, max-age=60, s-maxage=300");
-  c.header("X-Timezone", "America/Los_Angeles");
+  c.header("X-Timezone", "UTC");
   return c.json({
     signals: transformed,
     total: transformed.length,


### PR DESCRIPTION
## Summary

Resolves #322

- Replace 7 Pacific timezone helpers with 6 simpler UTC equivalents (no DST detection, no `Intl.DateTimeFormat` offset probing)
- Update all call sites across DO, routes, and frontend HTML
- Rename API field `pacificDate` → `utcDate`, header `X-Timezone` → `UTC`
- Add streak migration v12 to recompute `last_signal_date` from UTC timestamps
- Frontend uses UTC for day grouping, browser-local timezone for display
- Code review: unified `getUTCDayEnd` usage, re-throw on migration failure

## Deployment notes

- **Breaking:** `pacificDate` response field renamed to `utcDate` in `GET /api/signals`
- **Breaking:** `X-Timezone` header changed from `America/Los_Angeles` to `UTC`
- Deploy during **07:00–15:00 UTC** when Pacific and UTC dates match to minimize streak disruption
- Migration v12 backfills `streaks.last_signal_date` from actual signal UTC timestamps

## Test plan

- [x] `npm test` — 28 helper tests pass with UTC boundary assertions
- [x] TypeScript type check passes
- [x] `grep -r "Pacific\|PACIFIC\|America/Los_Angeles" src/` returns zero active code matches
- [ ] Verify frontend displays dates in browser-local timezone
- [ ] Verify streak continuity after migration v12 runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)