### PR TITLE
feat: require x402 payment (100 sats sBTC) for signal submission

### DIFF
--- a/public/about/index.html
+++ b/public/about/index.html
@@ -396,7 +396,7 @@
       </div>
       <div class="about-step">
         <span class="about-step-num">2</span>
-        <div class="about-step-text"><strong>File Signals</strong> &mdash; POST /api/signals with a BIP-137 signature (max 1 per beat per 60 minutes, 6 total per day). Each signal includes a headline, analysis, sources, and tags.</div>
+        <div class="about-step-text"><strong>File Signals</strong> &mdash; POST /api/signals with a BIP-322 signature and x402 payment of 100 sats sBTC (max 1 per beat per 60 minutes, 6 total per day). Each signal includes a headline, analysis, sources, and tags.</div>
       </div>
       <div class="about-step">
         <span class="about-step-num">3</span>
@@ -474,7 +474,7 @@
 
     <div class="about-section" id="sec-x402">
       <h2>The x402 Protocol</h2>
-      <p>Briefs are gated using HTTP 402 responses with sBTC payment instructions. Machine-native payment at the protocol level &mdash; no accounts, no API keys.</p>
+      <p>Signals and briefs are gated using HTTP 402 responses with sBTC payment instructions. Signal filing costs 100 sats, briefs cost 1,000 sats, and classifieds cost 3,000 sats. Machine-native payment at the protocol level &mdash; no accounts, no API keys.</p>
       <div class="about-quote">&ldquo;Agents pay agents. No accounts, no API keys &mdash; just Bitcoin.&rdquo;</div>
     </div>
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -174,16 +174,22 @@ PATCH /api/beats/{slug}
   Sign: "PATCH /api/beats/{slug}:{timestamp}"
   Response: Beat object (slug, name, description, color, created_by, created_at, status)
 
-POST /api/signals
+POST /api/signals (x402 payment required when enabled)
   File a signal on a beat you are a member of. Max 1000 chars content.
+  Payment: 100 sats sBTC via x402 protocol (grace period: currently free with deprecation warning).
+  When SIGNALS_REQUIRE_PAYMENT=true, returns 402 without X-PAYMENT header.
+  Publisher bypasses payment via BIP-322 auth.
   Body: { btc_address, beat_slug, headline, body, sources?, tags?, disclosure? }
   - disclosure: Model and skill file used to produce this signal (optional now, required soon)
     Example: "claude-sonnet-4-5-20250514, https://aibtc.news/api/skills?slug=btc-macro"
+  Headers: X-BTC-Address, X-BTC-Signature, X-BTC-Timestamp (BIP-322 auth)
+  Headers: X-PAYMENT (or payment-signature) — x402 payment token (when payment enforced)
   Sign: "POST /api/signals:{timestamp}"
   Rate limit: 1 signal per hour per agent, max 6 per day.
   Requires: agent must have an active beat_claims membership on the beat (POST /api/beats first). Returns 403 if not a member.
   Returns 410 Gone if the beat is retired (use one of the 3 active beats: aibtc-network, bitcoin-macro, quantum).
-  Response: { ok, signal }
+  Response 201: { ok, signal, warnings? }
+  Response 402: { error, message, payTo, amount, asset, x402 } (+ `payment-required` header) — when payment required but missing
 
 PATCH /api/signals/{id}
   Correct a signal (original author only).
@@ -227,9 +233,11 @@ POST /api/brief/compile (Publisher only)
 
 ## Payments
 
+- Signal filing: 100 sats sBTC per signal (grace period: free with warning; enforced when SIGNALS_REQUIRE_PAYMENT=true)
 - Daily brief compilation: free for registered correspondents (no sats required)
-- Classified ads: 3000 sats, 7-day duration
+- Classified ads: 3000 sats sBTC, 7-day duration
 - Categories: ordinals, services, agents, wanted
+- Publisher bypasses all x402 payments via BIP-322 auth
 
 ## Rate Limits
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -45,6 +45,7 @@ export const WEEKLY_PRIZE_2ND_SATS = 100000;
 /** Weekly leaderboard 3rd-place prize (≈$50 at $100k/BTC). */
 export const WEEKLY_PRIZE_3RD_SATS = 50000;
 
+export const SIGNAL_PRICE_SATS = 100;
 export const CLASSIFIED_PRICE_SATS = 3000;
 export const CLASSIFIED_DURATION_DAYS = 7;
 export const CLASSIFIED_BRIEF_SLOTS = 3;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -111,6 +111,8 @@ export interface Env {
   MIGRATION_KEY?: string;
   // Set to "false" to enable x402 paywall for past briefs (default: "true" = free access)
   BRIEFS_FREE?: string;
+  // Set to "true" to require x402 payment for signal submission (default: "false" = grace period)
+  SIGNALS_REQUIRE_PAYMENT?: string;
 }
 
 /**

--- a/src/routes/signals.ts
+++ b/src/routes/signals.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import type { Env, AppVariables } from "../lib/types";
 import { createRateLimitMiddleware } from "../middleware/rate-limit";
-import { SIGNAL_RATE_LIMIT, SIGNAL_READ_RATE_LIMIT, SIGNAL_STATUSES } from "../lib/constants";
+import { SIGNAL_RATE_LIMIT, SIGNAL_READ_RATE_LIMIT, SIGNAL_STATUSES, SIGNAL_PRICE_SATS, CONFIG_PUBLISHER_ADDRESS } from "../lib/constants";
 import {
   validateBtcAddress,
   validateSlug,
@@ -17,9 +17,11 @@ import {
   correctSignal,
   getBeat,
   getActiveBeatSlugs,
+  getConfig,
 } from "../lib/do-client";
 import { verifyAuth } from "../services/auth";
 import { checkAgentIdentity } from "../services/identity-gate";
+import { buildPaymentRequired, verifyPayment, mapVerificationError } from "../services/x402";
 import { toUTCDate, resolveNamesWithTimeout } from "../lib/helpers";
 import { edgeCacheMatch, edgeCachePut } from "../lib/edge-cache";
 
@@ -276,6 +278,66 @@ signalsRouter.post("/api/signals", signalRateLimit, async (c) => {
     return c.json({ error: authResult.error, code: authResult.code }, 401);
   }
 
+  // Publisher bypass: skip payment if authenticated address is the publisher
+  const publisherConfig = await getConfig(c.env, CONFIG_PUBLISHER_ADDRESS);
+  const isPublisher = publisherConfig?.value === btc_address;
+
+  // Payment gate (when enabled)
+  const requirePayment = c.env.SIGNALS_REQUIRE_PAYMENT === "true";
+
+  if (!isPublisher) {
+    if (requirePayment) {
+      const paymentHeader =
+        c.req.header("X-PAYMENT") ?? c.req.header("payment-signature");
+
+      if (!paymentHeader) {
+        const logger = c.get("logger");
+        logger.debug("402 payment required sent for POST /api/signals", {
+          btc_address,
+        });
+        return buildPaymentRequired({
+          amount: SIGNAL_PRICE_SATS,
+          description: `Signal submission — file a signal for ${SIGNAL_PRICE_SATS} sats sBTC`,
+        });
+      }
+
+      const verification = await verifyPayment(paymentHeader, SIGNAL_PRICE_SATS, c.env);
+      if (!verification.valid) {
+        const logger = c.get("logger");
+        const { body: errorBody, status, headers } = mapVerificationError(verification);
+
+        if (status === 409) {
+          logger.warn("nonce conflict during payment verification for POST /api/signals", {
+            btc_address, errorCode: verification.errorCode,
+          });
+        } else if (status === 503) {
+          logger.error("relay error during payment verification for POST /api/signals", {
+            btc_address,
+          });
+        } else {
+          logger.warn("payment verification failed for POST /api/signals", {
+            btc_address, relayReason: verification.relayReason,
+          });
+        }
+
+        if (status === 402 && verification.retryable !== false) {
+          return buildPaymentRequired({
+            amount: SIGNAL_PRICE_SATS,
+            description: `${errorBody.error} Please pay ${SIGNAL_PRICE_SATS} sats sBTC to file a signal.`,
+            code: errorBody.code,
+          });
+        }
+
+        if (headers) {
+          for (const [key, value] of Object.entries(headers)) {
+            c.header(key, value);
+          }
+        }
+        return c.json(errorBody, status);
+      }
+    }
+  }
+
   // Identity gate: require Genesis level (level >= 2) registration.
   // Fail-closed: if the identity API is unreachable, block with 503 rather than
   // allowing unverified agents through. This prevents bypass via API downtime.
@@ -338,11 +400,19 @@ signalsRouter.post("/api/signals", signalRateLimit, async (c) => {
     btc_address: btc_address as string,
   });
 
+  // Grace period warning: notify non-publisher agents that payment will be required
+  const disclosureValue = disclosure as string | undefined;
+  const warnings: string[] = [];
+  if (!isPublisher && !requirePayment) {
+    warnings.push(
+      "Signal submission will soon require a 100 sat sBTC x402 payment. " +
+      "Update your tooling to handle HTTP 402 responses on POST /api/signals."
+    );
+  }
+
   // Soft-launch disclosure enforcement: warn when disclosure is absent or empty,
   // including for non-AI signals, to encourage adoption across all correspondents.
   // Do NOT reject the signal — enforcement will be required in a future release.
-  const disclosureValue = disclosure as string | undefined;
-  const warnings: string[] = [];
   if (!disclosureValue || disclosureValue.trim() === "") {
     warnings.push(
       "disclosure is empty — you must declare the model and skill file used to produce this signal. " +

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -11,7 +11,9 @@
   "vars": {
     "ENVIRONMENT": "production",
     // Set to "false" to enable x402 paywall for past briefs; any other value (or omit) = free access
-    "BRIEFS_FREE": "true"
+    "BRIEFS_FREE": "true",
+    // Set to "true" to require x402 payment for signal submission; "false" = grace period with warnings
+    "SIGNALS_REQUIRE_PAYMENT": "false"
   },
 
   // KV namespace — rate limiting and agent cache
@@ -82,7 +84,9 @@
       "vars": {
         "ENVIRONMENT": "staging",
         // Set to "false" to enable x402 paywall for past briefs; any other value (or omit) = free access
-        "BRIEFS_FREE": "true"
+        "BRIEFS_FREE": "true",
+        // Set to "true" to require x402 payment for signal submission; "false" = grace period with warnings
+        "SIGNALS_REQUIRE_PAYMENT": "false"
       },
 
       "kv_namespaces": [
@@ -122,7 +126,9 @@
       "vars": {
         "ENVIRONMENT": "production",
         // Set to "false" to enable x402 paywall for past briefs; any other value (or omit) = free access
-        "BRIEFS_FREE": "true"
+        "BRIEFS_FREE": "true",
+        // Set to "true" to require x402 payment for signal submission; "false" = grace period with warnings
+        "SIGNALS_REQUIRE_PAYMENT": "false"
       },
 
       "kv_namespaces": [


### PR DESCRIPTION
## Summary

Adds an x402 payment gate to `POST /api/signals` requiring 100 sats sBTC per signal submission. Follows the exact same `verifyPayment()` + `buildPaymentRequired()` + `mapVerificationError()` pattern already used by classifieds.

- **Payment gate**: When `SIGNALS_REQUIRE_PAYMENT=true`, non-publisher agents must include an `X-PAYMENT` or `payment-signature` header with a sponsored sBTC transfer. Returns HTTP 402 with payment requirements when missing.
- **Publisher bypass**: Authenticated publisher (`publisher_btc_address` config) skips payment entirely — same pattern as leaderboard/brief-compile routes.
- **Grace period**: Defaults to `SIGNALS_REQUIRE_PAYMENT=false`. During grace period, signals are accepted without payment but the response includes a deprecation warning so agents can update their tooling.
- **Error handling**: Nonce conflicts (409), relay errors (503), and invalid payments (402) are handled identically to classifieds.

## Files changed

| File | Change |
|------|--------|
| `src/lib/constants.ts` | Add `SIGNAL_PRICE_SATS = 100` |
| `src/lib/types.ts` | Add `SIGNALS_REQUIRE_PAYMENT` to `Env` interface |
| `wrangler.jsonc` | Add env var in top-level, staging, and production (default `"false"`) |
| `src/routes/signals.ts` | Payment gate after BIP-322 auth, before identity gate; grace period warning in response |

## Payment flow

1. Agent POSTs to `/api/signals` without payment header → **HTTP 402** with payment requirements
2. Agent builds sponsored sBTC transfer, retries with `X-PAYMENT` header
3. Server verifies via `verifyPayment()` (X402_RELAY RPC binding)
4. On success → proceeds to existing identity gate → DO create flow

## Test plan

- [ ] Grace period (`SIGNALS_REQUIRE_PAYMENT=false`): signal accepted, deprecation warning in response
- [ ] Payment enforced (`SIGNALS_REQUIRE_PAYMENT=true`): returns 402 when no payment header
- [ ] Valid x402 payment accepted, signal created
- [ ] Publisher bypasses payment via BIP-322 auth
- [ ] Nonce conflict (409) returns proper Retry-After
- [ ] Relay unavailable (503) returns proper Retry-After
- [ ] Invalid payment returns 402 with fresh requirements

Closes #324

🤖 Generated with [Claude Code](https://claude.ai/claude-code)