### PR TITLE
fix(agent-resolver): use short TTL for null-name cache entries (closes #320)

### DIFF
--- a/src/services/agent-resolver.ts
+++ b/src/services/agent-resolver.ts
@@ -53,9 +53,9 @@ export async function resolveAgentName(
 
       const info: AgentInfo = { name: displayName, btcAddress: canonicalBtc };
 
-      // Cache result as JSON (empty name signals "no name" to avoid repeated fetches)
+      // Cache resolved names for 24h; null names for 5min so newly-registered agents resolve promptly
       await kv.put(cacheKey, JSON.stringify(info), {
-        expirationTtl: CACHE_TTL_SECONDS,
+        expirationTtl: displayName ? CACHE_TTL_SECONDS : 300,
       });
 
       return info;


### PR DESCRIPTION
## Root Cause

When `aibtc.com` returns `displayName: null` for a newly-registered or unresolved agent, `resolveAgentName` was caching `{ name: null }` for the full 24-hour TTL. Every subsequent page view within that window returned `name: null` from the cache, causing the truncated BTC address to persist for up to 24 hours.

## Fix

Null-name results now use a 5-minute TTL (300 s) instead of the 24-hour TTL, allowing a fresh resolution attempt on the next request cycle. Fully-resolved names continue to use the 24-hour TTL to minimise upstream API calls.

```diff
-      // Cache result as JSON (empty name signals "no name" to avoid repeated fetches)
+      // Cache resolved names for 24h; null names for 5min so newly-registered agents resolve promptly
       await kv.put(cacheKey, JSON.stringify(info), {
-        expirationTtl: CACHE_TTL_SECONDS,
+        expirationTtl: displayName ? CACHE_TTL_SECONDS : 300,
       });
```

## Notes

Related to PR #321 (frontend fix for the race condition display). This PR addresses the backend cache layer: null display names from aibtc.com are now short-lived so agents that register or update their profile become visible within 5 minutes rather than 24 hours.

## Test plan

- [ ] Verify that an agent address whose `displayName` is `null` at fetch time is not stuck showing a truncated address for 24 h
- [ ] Verify that a fully-resolved display name is still cached for 24 h (no change in happy-path behaviour)
- [ ] TypeScript build passes (`npm run build` / `tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)