### PR TITLE
fix(signals): case-insensitive publisher address comparison and gate reorder

### DIFF
--- a/src/routes/signals.ts
+++ b/src/routes/signals.ts
@@ -280,7 +280,35 @@ signalsRouter.post("/api/signals", signalRateLimit, async (c) => {
 
   // Publisher bypass: skip payment if authenticated address is the publisher
   const publisherConfig = await getConfig(c.env, CONFIG_PUBLISHER_ADDRESS);
-  const isPublisher = publisherConfig?.value === btc_address;
+  const isPublisher = publisherConfig?.value?.toLowerCase().trim() === (btc_address as string)?.toLowerCase().trim();
+
+  // Identity gate: require Genesis level (level >= 2) registration.
+  // Run before payment gate so agents aren't charged when they'd be rejected anyway.
+  // Fail-closed: if the identity API is unreachable, block with 503 rather than
+  // allowing unverified agents through. This prevents bypass via API downtime.
+  const identity = await checkAgentIdentity(c.env.NEWS_KV, btc_address as string);
+  if (identity.shouldBlock) {
+    const res = c.json(
+      {
+        error: "Identity verification service is temporarily unavailable. Please retry shortly.",
+        code: "IDENTITY_SERVICE_UNAVAILABLE",
+      },
+      503
+    );
+    res.headers.set("Retry-After", "30");
+    return res;
+  }
+  if (!identity.registered || identity.level === null || identity.level < 2) {
+    return c.json(
+      {
+        error:
+          "Signal submission requires a registered AIBTC agent account at Genesis level. " +
+          "Register at aibtc.com and reach Genesis (Level 2) by completing a claim on X.",
+        code: "IDENTITY_REQUIRED",
+      },
+      403
+    );
+  }
 
   // Payment gate (when enabled)
   const requirePayment = c.env.SIGNALS_REQUIRE_PAYMENT === "true";
@@ -336,33 +364,6 @@ signalsRouter.post("/api/signals", signalRateLimit, async (c) => {
         return c.json(errorBody, status);
       }
     }
-  }
-
-  // Identity gate: require Genesis level (level >= 2) registration.
-  // Fail-closed: if the identity API is unreachable, block with 503 rather than
-  // allowing unverified agents through. This prevents bypass via API downtime.
-  const identity = await checkAgentIdentity(c.env.NEWS_KV, btc_address as string);
-  if (identity.shouldBlock) {
-    const res = c.json(
-      {
-        error: "Identity verification service is temporarily unavailable. Please retry shortly.",
-        code: "IDENTITY_SERVICE_UNAVAILABLE",
-      },
-      503
-    );
-    res.headers.set("Retry-After", "30");
-    return res;
-  }
-  if (!identity.registered || identity.level === null || identity.level < 2) {
-    return c.json(
-      {
-        error:
-          "Signal submission requires a registered AIBTC agent account at Genesis level. " +
-          "Register at aibtc.com and reach Genesis (Level 2) by completing a claim on X.",
-        code: "IDENTITY_REQUIRED",
-      },
-      403
-    );
   }
 
   const result = await createSignal(c.env, {


### PR DESCRIPTION
## Summary

Addresses two CHANGES_REQUESTED items from PR #325 (feat: require x402 payment for signal submission).

- **Case-insensitive publisher bypass**: publisher config value and incoming `btc_address` are now compared with `.toLowerCase().trim()` on both sides, preventing bypass failures caused by mixed-case addresses stored in config vs. what the agent submits.
- **Gate reorder — identity before payment**: identity gate now runs before the payment gate. Previously an unregistered agent would be asked to pay 100 sats sBTC and only then receive a 403. The new order returns 403 IDENTITY_REQUIRED before any payment prompt, protecting agents from spending money on a request that would be rejected anyway.

## Changes

File: `src/routes/signals.ts`

- Line 221: `publisherConfig?.value === btc_address` → `publisherConfig?.value?.toLowerCase().trim() === (btc_address as string)?.toLowerCase().trim()`
- Moved `checkAgentIdentity` block to run before the payment gate block

## Test plan

- [ ] `bun run typecheck` passes (verified locally — zero errors)
- [ ] Publisher with exact-case address still bypasses payment
- [ ] Publisher with mixed-case address (e.g. `BC1Q...`) now correctly bypasses payment
- [ ] Unregistered agent receives 403 IDENTITY_REQUIRED without a payment prompt
- [ ] Registered agent without payment header receives 402 as before
- [ ] Registered agent with valid payment proceeds to signal creation

Ref: #325

Co-Authored-By: tfibtcagent <tfi.reubs@gmail.com>