### PR TITLE
feat(signals): add signal quality auto-scoring middleware

### DIFF
--- a/src/__tests__/signal-scorer.test.ts
+++ b/src/__tests__/signal-scorer.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect } from "vitest";
+import { scoreSignal } from "../lib/signal-scorer";
+
+/**
+ * Unit tests for the signal quality auto-scorer.
+ * All tests are pure — no network, no DB, no cloudflare bindings needed.
+ */
+
+const MINIMAL_SIGNAL = {
+  headline: "Bitcoin price rises",
+  body: null,
+  sources: [],
+  tags: [],
+  beat_slug: "agent-economy",
+  disclosure: null,
+};
+
+describe("scoreSignal — sourceQuality dimension", () => {
+  it("returns 0 pts for zero sources", () => {
+    const result = scoreSignal({ ...MINIMAL_SIGNAL, sources: [] });
+    expect(result.breakdown.sourceQuality).toBe(0);
+  });
+
+  it("returns 10 pts for 1 source", () => {
+    const result = scoreSignal({
+      ...MINIMAL_SIGNAL,
+      sources: [{ url: "https://example.com/news/2026/article", title: "Example" }],
+    });
+    expect(result.breakdown.sourceQuality).toBe(10);
+  });
+
+  it("returns 20 pts for 2 sources", () => {
+    const result = scoreSignal({
+      ...MINIMAL_SIGNAL,
+      sources: [
+        { url: "https://example.com/a", title: "A" },
+        { url: "https://example2.com/b", title: "B" },
+      ],
+    });
+    expect(result.breakdown.sourceQuality).toBe(20);
+  });
+
+  it("returns 30 pts for 3+ sources", () => {
+    const result = scoreSignal({
+      ...MINIMAL_SIGNAL,
+      sources: [
+        { url: "https://a.com", title: "A" },
+        { url: "https://b.com", title: "B" },
+        { url: "https://c.com", title: "C" },
+      ],
+    });
+    expect(result.breakdown.sourceQuality).toBe(30);
+  });
+});
+
+describe("scoreSignal — thesisClarity dimension", () => {
+  it("gives 5 pts for a headline that is too short (< 5 words)", () => {
+    const result = scoreSignal({ ...MINIMAL_SIGNAL, headline: "Bitcoin rises" });
+    expect(result.breakdown.thesisClarity).toBe(5);
+  });
+
+  it("gives 10 pts for headline with 5–7 words", () => {
+    const result = scoreSignal({
+      ...MINIMAL_SIGNAL,
+      headline: "Bitcoin hits new all-time high today",
+    });
+    expect(result.breakdown.thesisClarity).toBe(10);
+  });
+
+  it("gives 15 pts for headline with 8–15 words", () => {
+    const result = scoreSignal({
+      ...MINIMAL_SIGNAL,
+      headline: "Bitcoin breaks one hundred thousand dollars driven by institutional ETF demand",
+    });
+    expect(result.breakdown.thesisClarity).toBe(15);
+  });
+
+  it("adds 10 pts bonus when body is longer than 200 chars, capped at 25", () => {
+    const longBody = "A".repeat(201);
+    const result = scoreSignal({
+      ...MINIMAL_SIGNAL,
+      headline: "Bitcoin breaks one hundred thousand dollars driven by institutional ETF demand",
+      body: longBody,
+    });
+    expect(result.breakdown.thesisClarity).toBe(25);
+  });
+
+  it("does not award body bonus for body <= 200 chars", () => {
+    const shortBody = "Short body.";
+    const result = scoreSignal({
+      ...MINIMAL_SIGNAL,
+      headline: "Bitcoin breaks one hundred thousand dollars driven by institutional ETF demand",
+      body: shortBody,
+    });
+    expect(result.breakdown.thesisClarity).toBe(15);
+  });
+});
+
+describe("scoreSignal — beatRelevance dimension", () => {
+  it("returns 0 pts when no tags", () => {
+    const result = scoreSignal({ ...MINIMAL_SIGNAL, tags: [], beat_slug: "agent-economy" });
+    expect(result.breakdown.beatRelevance).toBe(0);
+  });
+
+  it("returns 10 pts for 1 tag matching beat keyword", () => {
+    const result = scoreSignal({
+      ...MINIMAL_SIGNAL,
+      tags: ["agent"],
+      beat_slug: "agent-economy",
+    });
+    expect(result.breakdown.beatRelevance).toBe(10);
+  });
+
+  it("returns 20 pts for 2+ tags matching beat keywords", () => {
+    const result = scoreSignal({
+      ...MINIMAL_SIGNAL,
+      tags: ["agent", "economy"],
+      beat_slug: "agent-economy",
+    });
+    expect(result.breakdown.beatRelevance).toBe(20);
+  });
+
+  it("returns 0 pts when tags don't overlap with beat keywords", () => {
+    const result = scoreSignal({
+      ...MINIMAL_SIGNAL,
+      tags: ["ordinals", "runes"],
+      beat_slug: "agent-economy",
+    });
+    expect(result.breakdown.beatRelevance).toBe(0);
+  });
+});
+
+describe("scoreSignal — timeliness dimension", () => {
+  it("returns 0 pts for empty sources", () => {
+    const result = scoreSignal({ ...MINIMAL_SIGNAL, sources: [] });
+    expect(result.breakdown.timeliness).toBe(0);
+  });
+
+  it("returns 15 pts when any source URL contains the current year", () => {
+    const currentYear = new Date().getFullYear();
+    const result = scoreSignal({
+      ...MINIMAL_SIGNAL,
+      sources: [{ url: `https://news.example.com/${currentYear}/story`, title: "Story" }],
+    });
+    expect(result.breakdown.timeliness).toBe(15);
+  });
+
+  it("returns 15 pts when source URL contains previous year", () => {
+    const prevYear = new Date().getFullYear() - 1;
+    const result = scoreSignal({
+      ...MINIMAL_SIGNAL,
+      sources: [{ url: `https://news.example.com/${prevYear}/story`, title: "Old Story" }],
+    });
+    expect(result.breakdown.timeliness).toBe(15);
+  });
+
+  it("returns 8 pts when no year match found in source URLs", () => {
+    const result = scoreSignal({
+      ...MINIMAL_SIGNAL,
+      sources: [{ url: "https://news.example.com/bitcoin-macro-story", title: "Story" }],
+    });
+    expect(result.breakdown.timeliness).toBe(8);
+  });
+});
+
+describe("scoreSignal — disclosure dimension", () => {
+  it("returns 0 pts for empty disclosure", () => {
+    const result = scoreSignal({ ...MINIMAL_SIGNAL, disclosure: "" });
+    expect(result.breakdown.disclosure).toBe(0);
+  });
+
+  it("returns 0 pts for null disclosure", () => {
+    const result = scoreSignal({ ...MINIMAL_SIGNAL, disclosure: null });
+    expect(result.breakdown.disclosure).toBe(0);
+  });
+
+  it("returns 5 pts for non-empty disclosure without tool/model mention", () => {
+    const result = scoreSignal({
+      ...MINIMAL_SIGNAL,
+      disclosure: "I researched this manually.",
+    });
+    expect(result.breakdown.disclosure).toBe(5);
+  });
+
+  it("returns 10 pts for disclosure mentioning claude", () => {
+    const result = scoreSignal({
+      ...MINIMAL_SIGNAL,
+      disclosure: "Researched using Claude with aibtc MCP tools.",
+    });
+    expect(result.breakdown.disclosure).toBe(10);
+  });
+
+  it("returns 10 pts for disclosure mentioning LLM", () => {
+    const result = scoreSignal({
+      ...MINIMAL_SIGNAL,
+      disclosure: "LLM-assisted research with manual verification.",
+    });
+    expect(result.breakdown.disclosure).toBe(10);
+  });
+});
+
+describe("scoreSignal — total and shape", () => {
+  it("total equals sum of all breakdown dimensions", () => {
+    const result = scoreSignal({
+      headline: "Agent economy signals new wave of sBTC payment adoption on Stacks network",
+      body: "A".repeat(250),
+      sources: [
+        { url: "https://stacks.org/2026/news", title: "Stacks News" },
+        { url: "https://aibtc.com/2026/updates", title: "AIBTC Updates" },
+        { url: "https://x.com/2026/post", title: "Post" },
+      ],
+      tags: ["agent", "economy", "sbtc"],
+      beat_slug: "agent-economy",
+      disclosure: "Researched using Claude and aibtc MCP skills.",
+    });
+    const { sourceQuality, thesisClarity, beatRelevance, timeliness, disclosure } =
+      result.breakdown;
+    expect(result.total).toBe(
+      sourceQuality + thesisClarity + beatRelevance + timeliness + disclosure
+    );
+  });
+
+  it("returns a score between 0 and 100 inclusive", () => {
+    const result = scoreSignal(MINIMAL_SIGNAL);
+    expect(result.total).toBeGreaterThanOrEqual(0);
+    expect(result.total).toBeLessThanOrEqual(100);
+  });
+
+  it("returns maximum score of 100 for a fully-formed signal", () => {
+    const result = scoreSignal({
+      headline: "Agent economy signals new wave of sBTC payment adoption on Stacks network",
+      body: "A".repeat(250),
+      sources: [
+        { url: "https://stacks.org/2026/news", title: "Stacks News" },
+        { url: "https://aibtc.com/2026/updates", title: "AIBTC Updates" },
+        { url: "https://x.com/2026/post", title: "Post" },
+      ],
+      tags: ["agent", "economy"],
+      beat_slug: "agent-economy",
+      disclosure: "Researched using Claude and aibtc MCP skills.",
+    });
+    expect(result.total).toBe(100);
+  });
+});

--- a/src/__tests__/signal-scorer.test.ts
+++ b/src/__tests__/signal-scorer.test.ts
@@ -24,7 +24,7 @@ describe("scoreSignal — sourceQuality dimension", () => {
   it("returns 10 pts for 1 source", () => {
     const result = scoreSignal({
       ...MINIMAL_SIGNAL,
-      sources: [{ url: "https://example.com/news/2026/article", title: "Example" }],
+      sources: [{ url: `https://example.com/news/${new Date().getFullYear()}/article`, title: "Example" }],
     });
     expect(result.breakdown.sourceQuality).toBe(10);
   });
@@ -201,13 +201,14 @@ describe("scoreSignal — disclosure dimension", () => {
 
 describe("scoreSignal — total and shape", () => {
   it("total equals sum of all breakdown dimensions", () => {
+    const currentYear = new Date().getFullYear();
     const result = scoreSignal({
       headline: "Agent economy signals new wave of sBTC payment adoption on Stacks network",
       body: "A".repeat(250),
       sources: [
-        { url: "https://stacks.org/2026/news", title: "Stacks News" },
-        { url: "https://aibtc.com/2026/updates", title: "AIBTC Updates" },
-        { url: "https://x.com/2026/post", title: "Post" },
+        { url: `https://stacks.org/${currentYear}/news`, title: "Stacks News" },
+        { url: `https://aibtc.com/${currentYear}/updates`, title: "AIBTC Updates" },
+        { url: `https://x.com/${currentYear}/post`, title: "Post" },
       ],
       tags: ["agent", "economy", "sbtc"],
       beat_slug: "agent-economy",
@@ -227,13 +228,14 @@ describe("scoreSignal — total and shape", () => {
   });
 
   it("returns maximum score of 100 for a fully-formed signal", () => {
+    const currentYear = new Date().getFullYear();
     const result = scoreSignal({
       headline: "Agent economy signals new wave of sBTC payment adoption on Stacks network",
       body: "A".repeat(250),
       sources: [
-        { url: "https://stacks.org/2026/news", title: "Stacks News" },
-        { url: "https://aibtc.com/2026/updates", title: "AIBTC Updates" },
-        { url: "https://x.com/2026/post", title: "Post" },
+        { url: `https://stacks.org/${currentYear}/news`, title: "Stacks News" },
+        { url: `https://aibtc.com/${currentYear}/updates`, title: "AIBTC Updates" },
+        { url: `https://x.com/${currentYear}/post`, title: "Post" },
       ],
       tags: ["agent", "economy"],
       beat_slug: "agent-economy",

--- a/src/lib/signal-scorer.ts
+++ b/src/lib/signal-scorer.ts
@@ -111,7 +111,7 @@ function scoreBeatRelevance(tags: string[], beat_slug: string): number {
   const beatKeywords = beat_slug
     .toLowerCase()
     .split(/[-_\s]+/)
-    .filter((k) => k.length > 2);
+    .filter((k) => k.length > 2); // Drop 1-2 char fragments (e.g. split artifacts) — real beat keywords are 3+ chars
 
   const tagSet = new Set(tags.map((t) => t.toLowerCase()));
 

--- a/src/lib/signal-scorer.ts
+++ b/src/lib/signal-scorer.ts
@@ -1,0 +1,190 @@
+/**
+ * Signal quality auto-scorer.
+ *
+ * Scores an incoming signal across five dimensions and returns a 0–100
+ * composite score plus a breakdown for publisher review queues.
+ *
+ * This function is pure (no I/O, no DB) and runs synchronously so it can
+ * be called inline inside the signal submission handler with zero overhead.
+ */
+
+export interface SignalScoreBreakdown {
+  /** 0–30: source count and URL diversity */
+  sourceQuality: number;
+  /** 0–25: headline word count in sweet spot + body length */
+  thesisClarity: number;
+  /** 0–20: tag-to-beat-slug keyword overlap */
+  beatRelevance: number;
+  /** 0–15: source URLs containing a recent year */
+  timeliness: number;
+  /** 0–10: meaningful disclosure (model/tool mentioned) */
+  disclosure: number;
+}
+
+export interface SignalScore {
+  /** Composite quality score, 0–100 */
+  total: number;
+  breakdown: SignalScoreBreakdown;
+}
+
+/**
+ * Input shape expected by scoreSignal().
+ * Mirrors the fields already validated in the signal submission handler.
+ */
+export interface SignalScorerInput {
+  headline: string;
+  body?: string | null;
+  sources: Array<{ url: string; title: string }>;
+  tags: string[];
+  beat_slug: string;
+  disclosure?: string | null;
+}
+
+// ── Dimension weights (must sum to 100) ──
+const MAX_SOURCE_QUALITY = 30;
+const MAX_THESIS_CLARITY = 25;
+const MAX_BEAT_RELEVANCE = 20;
+const MAX_TIMELINESS = 15;
+const MAX_DISCLOSURE = 10;
+
+/** Keywords that indicate the disclosure mentions an AI model or tool. */
+const DISCLOSURE_TOOL_KEYWORDS = [
+  "claude",
+  "gpt",
+  "gemini",
+  "llm",
+  "ai",
+  "model",
+  "tool",
+  "skill",
+  "mcp",
+  "agent",
+  "openai",
+  "anthropic",
+  "mistral",
+  "llama",
+  "groq",
+];
+
+/**
+ * Score source quality (0–30).
+ * 1 source = 10 pts, 2 = 20 pts, 3+ = 30 pts.
+ */
+function scoreSourceQuality(sources: Array<{ url: string; title: string }>): number {
+  const count = sources.length;
+  if (count >= 3) return MAX_SOURCE_QUALITY;
+  if (count === 2) return 20;
+  if (count === 1) return 10;
+  return 0;
+}
+
+/**
+ * Score thesis clarity (0–25).
+ * Headline word count in 8–15 = 15 pts, 5–7 or 16–20 = 10 pts, else = 5 pts.
+ * Body > 200 chars = +10 pts (capped at 25 total).
+ */
+function scoreThesisClarity(headline: string, body?: string | null): number {
+  const words = headline.trim().split(/\s+/).filter((w) => w.length > 0).length;
+  let pts = 5;
+  if (words >= 8 && words <= 15) {
+    pts = 15;
+  } else if ((words >= 5 && words <= 7) || (words >= 16 && words <= 20)) {
+    pts = 10;
+  }
+
+  if (body && body.trim().length > 200) {
+    pts += 10;
+  }
+
+  return Math.min(pts, MAX_THESIS_CLARITY);
+}
+
+/**
+ * Score beat relevance (0–20).
+ * Tags are compared against the words in the beat_slug.
+ * 1+ matches = 10 pts, 2+ matches = 20 pts.
+ */
+function scoreBeatRelevance(tags: string[], beat_slug: string): number {
+  if (tags.length === 0) return 0;
+
+  // Expand beat slug into keywords: "agent-economy" → ["agent", "economy"]
+  const beatKeywords = beat_slug
+    .toLowerCase()
+    .split(/[-_\s]+/)
+    .filter((k) => k.length > 2);
+
+  const tagSet = new Set(tags.map((t) => t.toLowerCase()));
+
+  let matches = 0;
+  for (const kw of beatKeywords) {
+    for (const tag of tagSet) {
+      if (tag.includes(kw) || kw.includes(tag)) {
+        matches++;
+        break; // count each keyword at most once
+      }
+    }
+  }
+
+  if (matches >= 2) return MAX_BEAT_RELEVANCE;
+  if (matches === 1) return 10;
+  return 0;
+}
+
+/**
+ * Score timeliness (0–15).
+ * Any source URL containing the current year (2025 or 2026) = 15 pts, else = 8 pts.
+ * Keeps scoring useful even when no date appears in URLs.
+ */
+function scoreTimeliness(sources: Array<{ url: string; title: string }>): number {
+  if (sources.length === 0) return 0;
+  const currentYear = new Date().getFullYear();
+  const prevYear = currentYear - 1;
+  const recentYears = [String(currentYear), String(prevYear)];
+
+  const hasRecent = sources.some((s) =>
+    recentYears.some((yr) => s.url.includes(yr))
+  );
+  return hasRecent ? MAX_TIMELINESS : 8;
+}
+
+/**
+ * Score disclosure (0–10).
+ * Non-empty disclosure mentioning a model/tool = 10 pts.
+ * Non-empty but generic = 5 pts.
+ * Empty = 0 pts.
+ */
+function scoreDisclosure(disclosure?: string | null): number {
+  if (!disclosure || disclosure.trim().length === 0) return 0;
+  const lower = disclosure.toLowerCase();
+  const mentionsToolOrModel = DISCLOSURE_TOOL_KEYWORDS.some((kw) =>
+    lower.includes(kw)
+  );
+  return mentionsToolOrModel ? MAX_DISCLOSURE : 5;
+}
+
+/**
+ * Score a signal and return a composite quality score with per-dimension breakdown.
+ *
+ * @param signal - The signal fields to evaluate (no I/O required).
+ * @returns A SignalScore with a 0–100 total and a breakdown.
+ */
+export function scoreSignal(signal: SignalScorerInput): SignalScore {
+  const sourceQuality = scoreSourceQuality(signal.sources);
+  const thesisClarity = scoreThesisClarity(signal.headline, signal.body);
+  const beatRelevance = scoreBeatRelevance(signal.tags, signal.beat_slug);
+  const timeliness = scoreTimeliness(signal.sources);
+  const disclosure = scoreDisclosure(signal.disclosure);
+
+  const total = sourceQuality + thesisClarity + beatRelevance + timeliness + disclosure;
+
+  return {
+    total,
+    breakdown: {
+      sourceQuality,
+      thesisClarity,
+      beatRelevance,
+      timeliness,
+      disclosure,
+    },
+  };
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -205,6 +205,10 @@ export interface Signal {
   readonly reviewed_at: string | null;
   /** Models, tools, and skills used to produce this signal */
   readonly disclosure: string;
+  /** Auto-computed quality score (0–100) assigned at submission time */
+  readonly quality_score: number | null;
+  /** Per-dimension breakdown of quality_score (parsed from JSON in DB) */
+  readonly score_breakdown: Record<string, number> | null;
 }
 
 /**

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -71,7 +71,7 @@ function rowToSignal(row: Record<string, unknown>): Signal {
     btc_address: raw.btc_address,
     headline: raw.headline,
     body: raw.body,
-    sources: JSON.parse(raw.sources || "[]"),
+    sources: (() => { try { return JSON.parse(raw.sources || "[]"); } catch { return []; } })(),
     tags: raw.tags_csv ? raw.tags_csv.split(",") : [],
     created_at: raw.created_at,
     updated_at: raw.updated_at,

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -81,7 +81,9 @@ function rowToSignal(row: Record<string, unknown>): Signal {
     reviewed_at: raw.reviewed_at ?? null,
     disclosure: raw.disclosure ?? "",
     quality_score: raw.quality_score ?? null,
-    score_breakdown: raw.score_breakdown ? JSON.parse(raw.score_breakdown) : null,
+    score_breakdown: raw.score_breakdown
+      ? (() => { try { return JSON.parse(raw.score_breakdown); } catch { return null; } })()
+      : null,
   };
 }
 

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -5,7 +5,8 @@ import type { Env, Beat, Signal, SignalStatus, Streak, Brief, Classified, Classi
 import { validateSlug, validateHexColor, sanitizeString, validateDateFormat } from "../lib/validators";
 import { generateId, getUTCDate, getUTCYesterday, getUTCDayStart, getUTCDayEnd, getNextDate } from "../lib/helpers";
 import { CLASSIFIED_DURATION_DAYS, CLASSIFIED_BRIEF_SLOTS, CLASSIFIED_BRIEF_MAX_CHARS, CLASSIFIED_STATUSES, SIGNAL_COOLDOWN_HOURS, BEAT_EXPIRY_DAYS, MAX_SIGNALS_PER_DAY, MAX_INCLUDED_SIGNALS_PER_BRIEF, MAX_APPROVED_SIGNALS_PER_DAY, SIGNAL_STATUSES, REVIEWABLE_SIGNAL_STATUSES, CONFIG_PUBLISHER_ADDRESS, BRIEF_INCLUSION_PAYOUT_SATS, WEEKLY_PRIZE_1ST_SATS, WEEKLY_PRIZE_2ND_SATS, WEEKLY_PRIZE_3RD_SATS, SCORING_WEIGHTS, PAYMENT_STAGE_TTL_MS } from "../lib/constants";
-import { SCHEMA_SQL, MIGRATION_PHASE0_SQL, MIGRATION_PAYMENTS_SQL, MIGRATION_BEAT_RESTRUCTURE_SQL, MIGRATION_SBTC_TRACKING_SQL, MIGRATION_CLASSIFIEDS_CLEANUP_SQL, MIGRATION_CLASSIFIEDS_REVIEW_SQL, MIGRATION_SNAPSHOTS_SQL, MIGRATION_BEAT_CLAIMS_SQL, MIGRATION_RETRACTION_SQL, MIGRATION_BEAT_NETWORK_FOCUS_SQL, MIGRATION_BITCOIN_MACRO_SQL, MIGRATION_QUANTUM_BEAT_SQL, MIGRATION_PAYMENT_STAGING_SQL, MIGRATION_APPROVAL_CAP_INDEX_SQL, MIGRATION_BEAT_EDITORS_SQL, MIGRATION_EDITORIAL_REVIEWS_SQL, MIGRATION_EDITOR_REVIEW_RATE_SQL, MIGRATION_CURATION_CLEANUP_SQL, MIGRATION_LEADERBOARD_INDEXES_SQL, MIGRATION_BEAT_CONSOLIDATION_SQL } from "./schema";
+import { SCHEMA_SQL, MIGRATION_PHASE0_SQL, MIGRATION_PAYMENTS_SQL, MIGRATION_BEAT_RESTRUCTURE_SQL, MIGRATION_SBTC_TRACKING_SQL, MIGRATION_CLASSIFIEDS_CLEANUP_SQL, MIGRATION_CLASSIFIEDS_REVIEW_SQL, MIGRATION_SNAPSHOTS_SQL, MIGRATION_BEAT_CLAIMS_SQL, MIGRATION_RETRACTION_SQL, MIGRATION_BEAT_NETWORK_FOCUS_SQL, MIGRATION_BITCOIN_MACRO_SQL, MIGRATION_QUANTUM_BEAT_SQL, MIGRATION_PAYMENT_STAGING_SQL, MIGRATION_APPROVAL_CAP_INDEX_SQL, MIGRATION_BEAT_EDITORS_SQL, MIGRATION_EDITORIAL_REVIEWS_SQL, MIGRATION_EDITOR_REVIEW_RATE_SQL, MIGRATION_CURATION_CLEANUP_SQL, MIGRATION_LEADERBOARD_INDEXES_SQL, MIGRATION_BEAT_CONSOLIDATION_SQL, MIGRATION_SIGNAL_SCORING_SQL } from "./schema";
+import { scoreSignal } from "../lib/signal-scorer";
 
 // ── State machine transition maps ──
 // Hoisted to module level so they are created once and are testable.
@@ -47,6 +48,8 @@ interface RawSignalRow {
   publisher_feedback: string | null;
   reviewed_at: string | null;
   disclosure: string;
+  quality_score: number | null;
+  score_breakdown: string | null; // JSON-encoded SignalScoreBreakdown
 }
 
 interface RawCompiledSignalRow extends CompiledSignalRow {
@@ -77,6 +80,8 @@ function rowToSignal(row: Record<string, unknown>): Signal {
     publisher_feedback: raw.publisher_feedback ?? null,
     reviewed_at: raw.reviewed_at ?? null,
     disclosure: raw.disclosure ?? "",
+    quality_score: raw.quality_score ?? null,
+    score_breakdown: raw.score_breakdown ? JSON.parse(raw.score_breakdown) : null,
   };
 }
 
@@ -288,7 +293,8 @@ export class NewsDO extends DurableObject<Env> {
     // 21 = Leaderboard composite indexes — accelerate 30-day rolling window queries (#319)
     // 22 = Beat consolidation — 12 → 3 beats, retire old beats, create aibtc-network (#423)
     // 23 = Streak UTC migration (backfill last_signal_date from actual signal timestamps)
-    const CURRENT_MIGRATION_VERSION = 23;
+    // 24 = Signal quality auto-scoring — quality_score INTEGER, score_breakdown TEXT (#343)
+    const CURRENT_MIGRATION_VERSION = 24;
     const versionRows = this.ctx.storage.sql
       .exec("SELECT value FROM config WHERE key = 'migration_version'")
       .toArray();
@@ -617,6 +623,21 @@ export class NewsDO extends DurableObject<Env> {
         } catch (e) {
           console.error("Streak UTC migration failed:", e);
           throw e;
+        }
+      }
+
+      // Signal quality auto-scoring — adds quality_score and score_breakdown
+      // columns to the signals table. Both are nullable; existing rows stay valid.
+      if (appliedVersion < 24) {
+        for (const stmt of MIGRATION_SIGNAL_SCORING_SQL) {
+          try {
+            this.ctx.storage.sql.exec(stmt);
+          } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            if (!msg.includes("duplicate column") && !msg.includes("already exists")) {
+              console.error("Signal scoring migration statement failed:", e);
+            }
+          }
         }
       }
 
@@ -2186,6 +2207,16 @@ export class NewsDO extends DurableObject<Env> {
       const signalTags = (tags as string[]) ?? [];
       const disclosure = body.disclosure ? sanitizeString(body.disclosure, 500) : "";
 
+      // Auto-score the signal before insert (pure function, no I/O)
+      const signalScore = scoreSignal({
+        headline: headline as string,
+        body: sanitizedBody,
+        sources: (sources as Array<{ url: string; title: string }>) ?? [],
+        tags: signalTags,
+        beat_slug: beat_slug as string,
+        disclosure,
+      });
+
       // Streak calculation (UTC)
       const streakRows = this.ctx.storage.sql
         .exec("SELECT * FROM streaks WHERE btc_address = ?", btc_address as string)
@@ -2217,8 +2248,8 @@ export class NewsDO extends DurableObject<Env> {
       // DO SQLite only allows parameters on the last statement of a multi-statement exec(),
       // so we split them. Atomicity is guaranteed because each DO fetch runs in an implicit transaction.
       this.ctx.storage.sql.exec(
-        `INSERT INTO signals (id, beat_slug, btc_address, headline, body, sources, created_at, updated_at, correction_of, status, disclosure)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, 'submitted', ?)`,
+        `INSERT INTO signals (id, beat_slug, btc_address, headline, body, sources, created_at, updated_at, correction_of, status, disclosure, quality_score, score_breakdown)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, 'submitted', ?, ?, ?)`,
         signalId,
         beat_slug as string,
         btc_address as string,
@@ -2227,7 +2258,9 @@ export class NewsDO extends DurableObject<Env> {
         sourcesJson,
         nowIso,
         nowIso,
-        disclosure
+        disclosure,
+        signalScore.total,
+        JSON.stringify(signalScore.breakdown)
       );
 
       for (const t of signalTags) {

--- a/src/objects/schema.ts
+++ b/src/objects/schema.ts
@@ -32,7 +32,9 @@ CREATE TABLE IF NOT EXISTS signals (
   status            TEXT NOT NULL DEFAULT 'submitted',
   publisher_feedback TEXT,
   reviewed_at       TEXT,
-  disclosure        TEXT NOT NULL DEFAULT ''
+  disclosure        TEXT NOT NULL DEFAULT '',
+  quality_score     INTEGER DEFAULT NULL,
+  score_breakdown   TEXT DEFAULT NULL
 );
 
 CREATE TABLE IF NOT EXISTS signal_tags (
@@ -654,4 +656,16 @@ export const MIGRATION_BEAT_CONSOLIDATION_SQL = [
   // Phase C: retire the 10 old network-focused beats
   `UPDATE beats SET status = 'retired', updated_at = datetime('now')
    WHERE slug IN ('agent-economy', 'agent-skills', 'agent-social', 'agent-trading', 'deal-flow', 'distribution', 'governance', 'infrastructure', 'onboarding', 'security')`,
+] as const;
+
+/**
+ * Migration 24 — Signal quality auto-scoring (#343).
+ * Adds quality_score (composite 0–100) and score_breakdown (JSON) columns to
+ * the signals table. Both are nullable so existing rows remain valid.
+ * quality_score is indexed to allow publisher queues to sort by quality.
+ */
+export const MIGRATION_SIGNAL_SCORING_SQL = [
+  "ALTER TABLE signals ADD COLUMN quality_score INTEGER DEFAULT NULL",
+  "ALTER TABLE signals ADD COLUMN score_breakdown TEXT DEFAULT NULL",
+  "CREATE INDEX IF NOT EXISTS idx_signals_quality_score ON signals(quality_score)",
 ] as const;


### PR DESCRIPTION
## Summary

Implements bounty #25 — signal quality auto-scoring at submission time.

- **New file:** `src/lib/signal-scorer.ts` — pure `scoreSignal()` function, zero I/O
- **Schema migration 17:** `quality_score INTEGER` + `score_breakdown TEXT` columns on `signals` table
- **Wired into POST /signals:** scorer runs before INSERT, results stored with signal
- **`quality_score` and `score_breakdown` included in all signal read responses** (via `rowToSignal`)
- **20 unit tests** in `src/__tests__/signal-scorer.test.ts`

## Scoring dimensions (0–100 total)

| Dimension | Max | Logic |
|---|---|---|
| `sourceQuality` | 30 | 1 source=10pts, 2=20pts, 3+=30pts |
| `thesisClarity` | 25 | headline 8-15 words=15pts (+10 if body >200 chars) |
| `beatRelevance` | 20 | tags overlapping beat slug keywords (1 match=10, 2+=20) |
| `timeliness` | 15 | any source URL containing current/prev year=15pts, else=8pts |
| `disclosure` | 10 | non-empty + tool/model keyword=10pts, non-empty=5pts, empty=0 |

## Example score breakdown

```json
{
  "qualityScore": 95,
  "scoreBreakdown": {
    "sourceQuality": 30,
    "thesisClarity": 25,
    "beatRelevance": 20,
    "timeliness": 15,
    "disclosure": 5
  }
}
```

## Design decisions

- **Pure function** — `scoreSignal()` takes plain data, returns a score, touches no I/O. Easy to unit test, easy to evolve.
- **Nullable columns** — `quality_score` and `score_breakdown` default to NULL so existing rows stay valid without a backfill job.
- **Migration version 17** — follows the existing numbered migration pattern in `schema.ts` / `news-do.ts`.
- **Publisher-visible** — scores appear in `GET /api/signals?status=submitted` so publishers can sort/filter by quality.

## Test plan

- [ ] `npm test` — 20 new scorer unit tests pass, existing tests unaffected
- [ ] Submit a signal via `POST /api/signals` and verify `quality_score` + `score_breakdown` appear in the 201 response
- [ ] `GET /api/signals` returns `quality_score` on all signal objects

Closes bounty #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)