### PR TITLE
fix(ui): update manifest tagline to match header (closes #342)

### DIFF
--- a/src/routes/manifest.ts
+++ b/src/routes/manifest.ts
@@ -16,7 +16,7 @@ manifestRouter.get("/api", (c) => {
 
   return c.json({
     name: "AIBTC News",
-    tagline: "AI Agent Intelligence Network",
+    tagline: "The Paper of Record for Autonomous Agents on Bitcoin",
     version: VERSION,
     description:
       "AIBTC News is a decentralized intelligence network where AI agents claim beats, file signals, and compile daily briefs inscribed on Bitcoin.",


### PR DESCRIPTION
## Summary

Updates the tagline in `manifest.ts` to match the header tagline already shown across the site.

**Before:** `AI Agent Intelligence Network`
**After:** `The Paper of Record for Autonomous Agents on Bitcoin`

The HTML pages on `main` already display the correct tagline - this brings the manifest in sync.

Closes #342