### PR TITLE
fix(security): close identity gate fail-open when aibtc.com API is unreachable

### DIFF
--- a/src/routes/signals.ts
+++ b/src/routes/signals.ts
@@ -235,10 +235,22 @@ signalsRouter.post("/api/signals", signalRateLimit, async (c) => {
     return c.json({ error: authResult.error, code: authResult.code }, 401);
   }
 
-  // Identity gate: require Genesis level (level >= 2) registration
-  // Only block when API confirmed the identity level — fail open on API errors
+  // Identity gate: require Genesis level (level >= 2) registration.
+  // Fail-closed: if the identity API is unreachable, block with 503 rather than
+  // allowing unverified agents through. This prevents bypass via API downtime.
   const identity = await checkAgentIdentity(c.env.NEWS_KV, btc_address as string);
-  if (identity.apiReachable && (!identity.registered || identity.level === null || identity.level < 2)) {
+  if (identity.shouldBlock) {
+    const res = c.json(
+      {
+        error: "Identity verification service is temporarily unavailable. Please retry shortly.",
+        code: "IDENTITY_SERVICE_UNAVAILABLE",
+      },
+      503
+    );
+    res.headers.set("Retry-After", "30");
+    return res;
+  }
+  if (!identity.registered || identity.level === null || identity.level < 2) {
     return c.json(
       {
         error:
@@ -367,10 +379,22 @@ signalsRouter.patch("/api/signals/:id", async (c) => {
     return c.json({ error: authResult.error, code: authResult.code }, 401);
   }
 
-  // Identity gate: require Genesis level (level >= 2) registration
-  // Only block when API confirmed the identity level — fail open on API errors
+  // Identity gate: require Genesis level (level >= 2) registration.
+  // Fail-closed: if the identity API is unreachable, block with 503 rather than
+  // allowing unverified agents through. This prevents bypass via API downtime.
   const identity = await checkAgentIdentity(c.env.NEWS_KV, btc_address as string);
-  if (identity.apiReachable && (!identity.registered || identity.level === null || identity.level < 2)) {
+  if (identity.shouldBlock) {
+    const res = c.json(
+      {
+        error: "Identity verification service is temporarily unavailable. Please retry shortly.",
+        code: "IDENTITY_SERVICE_UNAVAILABLE",
+      },
+      503
+    );
+    res.headers.set("Retry-After", "30");
+    return res;
+  }
+  if (!identity.registered || identity.level === null || identity.level < 2) {
     return c.json(
       {
         error:

--- a/src/services/identity-gate.ts
+++ b/src/services/identity-gate.ts
@@ -4,23 +4,52 @@
  * Verifies a BTC address belongs to a registered AIBTC agent at Genesis level (level >= 2).
  * Cache key: `agent-level:{address}` with 1h TTL.
  * Fetches from https://aibtc.com/api/agents/{address}.
+ *
+ * Security: this gate is fail-closed. If the identity API is unreachable after one retry,
+ * shouldBlock is set to true and callers must deny the request with 503. This prevents
+ * unregistered agents from submitting signals during API downtime or targeted slowdowns.
  */
 
 const CACHE_TTL_SECONDS = 3600; // 1 hour
 const CACHE_KEY_PREFIX = "agent-level:";
 const AGENT_API_BASE = "https://aibtc.com/api/agents";
 
+// Short timeout per attempt - keeps latency low on the happy path
+const FETCH_TIMEOUT_MS = 3000;
+
 export interface IdentityCheckResult {
   registered: boolean;
   level: number | null;
   levelName: string | null;
   apiReachable: boolean;
+  // true when the caller should block the request (API unreachable after retries)
+  shouldBlock: boolean;
+}
+
+/**
+ * Performs a single fetch attempt with a timeout signal.
+ */
+async function fetchIdentity(btcAddress: string): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    return await fetch(`${AGENT_API_BASE}/${encodeURIComponent(btcAddress)}`, {
+      headers: { Accept: "application/json" },
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 /**
  * Checks if a BTC address belongs to a Genesis-level (level >= 2) AIBTC agent.
- * Returns { registered, level, levelName }.
+ * Returns { registered, level, levelName, apiReachable, shouldBlock }.
  * Caches results for 1h to avoid per-request external calls.
+ *
+ * Fail-closed: when the API cannot be reached after one retry, shouldBlock=true
+ * is returned so callers respond with 503 + Retry-After instead of allowing
+ * unverified submissions through.
  */
 export async function checkAgentIdentity(
   kv: KVNamespace,
@@ -33,35 +62,62 @@ export async function checkAgentIdentity(
     try {
       return JSON.parse(cached) as IdentityCheckResult;
     } catch {
-      // Stale or malformed cache entry — fall through to API
+      // Stale or malformed cache entry - fall through to API
     }
   }
 
-  try {
-    const res = await fetch(`${AGENT_API_BASE}/${encodeURIComponent(btcAddress)}`, {
-      headers: { Accept: "application/json" },
-    });
+  // Two attempts total: one initial try + one retry on transient failure.
+  // Keeps worst-case added latency under 6s while tolerating flaky networks.
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const res = await fetchIdentity(btcAddress);
 
-    if (res.ok) {
-      const data = (await res.json()) as Record<string, unknown>;
-      const result: IdentityCheckResult = {
-        registered: (data?.found as boolean) === true,
-        level: (data?.level as number | undefined) ?? null,
-        levelName: (data?.levelName as string | undefined) ?? null,
-        apiReachable: true,
-      };
+      if (res.ok) {
+        const data = (await res.json()) as Record<string, unknown>;
+        const result: IdentityCheckResult = {
+          registered: (data?.found as boolean) === true,
+          level: (data?.level as number | undefined) ?? null,
+          levelName: (data?.levelName as string | undefined) ?? null,
+          apiReachable: true,
+          shouldBlock: false,
+        };
 
-      // Cache for 1h — level changes are infrequent
-      await kv.put(cacheKey, JSON.stringify(result), {
-        expirationTtl: CACHE_TTL_SECONDS,
-      });
+        // Cache for 1h - level changes are infrequent
+        await kv.put(cacheKey, JSON.stringify(result), {
+          expirationTtl: CACHE_TTL_SECONDS,
+        });
 
-      return result;
+        return result;
+      }
+
+      // 404 = agent not found - treat as definitive, cache and return
+      if (res.status === 404) {
+        const notFound: IdentityCheckResult = {
+          registered: false,
+          level: null,
+          levelName: null,
+          apiReachable: true,
+          shouldBlock: false,
+        };
+        await kv.put(cacheKey, JSON.stringify(notFound), {
+          expirationTtl: CACHE_TTL_SECONDS,
+        });
+        return notFound;
+      }
+
+      // 5xx or other server-side error - retry once before failing closed
+    } catch {
+      // Network error or timeout - retry once before failing closed
     }
-  } catch {
-    // Network error — don't cache, allow through (fail open to avoid blocking real agents)
   }
 
-  // On API failure, return unknown state — fail open
-  return { registered: false, level: null, levelName: null, apiReachable: false };
+  // Both attempts failed. Fail-closed: do not allow unverified submissions.
+  // Callers should return 503 so agents know to retry after the service recovers.
+  return {
+    registered: false,
+    level: null,
+    levelName: null,
+    apiReachable: false,
+    shouldBlock: true,
+  };
 }


### PR DESCRIPTION
## Summary

This PR fixes a fail-open vulnerability in the identity gate that allows unregistered agents to submit signals whenever the aibtc.com identity API is unreachable.

## The Vulnerability

In `src/services/identity-gate.ts`, a network failure returns:

```ts
return { registered: false, level: null, levelName: null, apiReachable: false };
```

The gate check in `src/routes/signals.ts` was:

```ts
if (identity.apiReachable && (!identity.registered || identity.level === null || identity.level < 2))
```

When `apiReachable` is `false`, the entire condition short-circuits to `false` - the gate is skipped and the signal is accepted. Any actor who can cause API unavailability (network partition, targeted slowdown, or simple downtime) can bypass the Genesis-level registration requirement entirely.

## The Fix

**`src/services/identity-gate.ts`**
- Added `shouldBlock: boolean` to `IdentityCheckResult`
- Added `fetchIdentity()` helper with a 3s per-attempt timeout via `AbortController`
- Wrapped the fetch in a loop with one retry before giving up
- On both attempts failing, returns `shouldBlock: true` instead of silently allowing through
- Successful responses (including 404) set `shouldBlock: false`

**`src/routes/signals.ts` (POST and PATCH)**
- Replaced the `apiReachable &&` guard with an explicit `shouldBlock` check
- When `shouldBlock` is true, returns `503 Service Unavailable` with `Retry-After: 30`
- When API confirms identity, proceeds to the existing level check as before
- The 503 response tells well-behaved agents to retry; it does not leak registration status

## Security Properties

- **Fail-closed by default**: API unavailability now blocks rather than allows
- **Retry tolerance**: one automatic retry absorbs transient network blips before blocking
- **Correct HTTP semantics**: 503 + Retry-After signals a temporary service issue, not an auth failure
- **Minimal surface change**: no refactor, no new dependencies, two files touched

## Testing

Logic paths verified mentally:

| Scenario | Before | After |
|---|---|---|  
| API reachable, agent registered (level >= 2) | allowed | allowed |
| API reachable, agent not registered | blocked (403) | blocked (403) |
| API down (both attempts fail) | **allowed (bug)** | blocked (503) |
| API flaky (first attempt fails, retry succeeds) | allowed | allowed |
| 404 from API (agent not found) | allowed | blocked (403) |