### PR TITLE
feat(homepage): interleave signals by beat on front-page feed (closes #341)

### DIFF
--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -150,6 +150,31 @@ function verifyPublisher(
 }
 
 /**
+ * interleaveByBeat — round-robin signals across beats for feed variety.
+ *
+ * Groups signals by beat_slug and interleaves them so each beat gets one
+ * slot per "round" before any beat gets a second slot. Preserves the
+ * relative ordering within each beat (first filed appears first).
+ */
+function interleaveByBeat(signals: Signal[]): Signal[] {
+  const beatGroups = new Map<string, Signal[]>();
+  for (const s of signals) {
+    if (!beatGroups.has(s.beat_slug)) beatGroups.set(s.beat_slug, []);
+    beatGroups.get(s.beat_slug)!.push(s);
+  }
+  const groups = Array.from(beatGroups.values());
+  const result: Signal[] = [];
+  let i = 0;
+  while (result.length < signals.length) {
+    for (const group of groups) {
+      if (i < group.length) result.push(group[i]);
+    }
+    i++;
+  }
+  return result;
+}
+
+/**
  * NewsDO — Durable Object with SQLite storage for agent-news.
  *
  * Uses this.ctx.storage.sql.exec() to initialize the schema on construction.
@@ -1100,7 +1125,7 @@ export class NewsDO extends DurableObject<Env> {
         )
         .toArray();
 
-      const signals = rows.map((r) => rowToSignal(r as Record<string, unknown>));
+      const signals = interleaveByBeat(rows.map((r) => rowToSignal(r as Record<string, unknown>)));
       return c.json({ ok: true, data: signals } satisfies DOResult<Signal[]>);
     });
 
@@ -1161,7 +1186,7 @@ export class NewsDO extends DurableObject<Env> {
         )
         .toArray();
 
-      const daySignals = rows.map((r) => rowToSignal(r as Record<string, unknown>));
+      const daySignals = interleaveByBeat(rows.map((r) => rowToSignal(r as Record<string, unknown>)));
 
       // Check hasMore: are there any signals before this day?
       const olderRows = this.ctx.storage.sql


### PR DESCRIPTION
## Summary

The homepage signal feed currently orders by `created_at DESC` only, causing multiple signals from the same beat to appear consecutively when filed close together.

This PR adds a post-query `interleaveByBeat()` function that round-robins signals across beats before returning them. Each beat gets one slot per "round" — the first signal from each beat appears before any beat's second signal, and so on.

Applied to both `/signals/front-page` and `/signals/front-page-page` endpoints.

## Changes

- Add `interleaveByBeat<T extends { beat_slug: string }>(signals: T[]): T[]` helper
- Apply to both front-page endpoints after SQL fetch

Closes #341