### PR TITLE
feat(beats): re-add bitcoin-macro beat with daily approved-signal cap (closes #348)

### DIFF
--- a/src/__tests__/do-client.test.ts
+++ b/src/__tests__/do-client.test.ts
@@ -6,13 +6,13 @@ import { SELF } from "cloudflare:test";
  * These verify error propagation and not-found handling for DO-backed resources.
  */
 describe("do-client error propagation via HTTP", () => {
-  it("GET /api/beats returns 10 network-focused beats from migration", async () => {
+  it("GET /api/beats returns 11 beats from migration", async () => {
     const res = await SELF.fetch("http://example.com/api/beats");
     expect(res.status).toBe(200);
     const body = await res.json<unknown[]>();
-    // Fresh DO auto-populates 10 beats via restructure + network-focus migrations
+    // Fresh DO auto-populates 11 beats: 10 network-focused + re-added bitcoin-macro
     expect(Array.isArray(body)).toBe(true);
-    expect(body.length).toBe(10);
+    expect(body.length).toBe(11);
   });
 
   it("GET /api/beats/:slug returns 404 for unknown beat", async () => {

--- a/src/__tests__/schema-migration.test.ts
+++ b/src/__tests__/schema-migration.test.ts
@@ -49,15 +49,15 @@ describe("DO constructor: schema initialization", () => {
     expect(res.status).toBe(200);
   });
 
-  it("beat network-focus migration populates 10 canonical beats", async () => {
-    // MIGRATION_BEAT_NETWORK_FOCUS_SQL runs after the restructure migration
-    // and reduces 17 beats to 10 network-focused beats.
+  it("beat network-focus migration populates 11 canonical beats", async () => {
+    // MIGRATION_BEAT_NETWORK_FOCUS_SQL reduces 17 beats to 10 network-focused beats.
+    // MIGRATION_BITCOIN_MACRO_SQL (migration 12) re-adds bitcoin-macro, bringing the total to 11.
     const res = await SELF.fetch("http://example.com/api/beats");
     expect(res.status).toBe(200);
     const body = await res.json<{ slug: string; name: string }[]>();
-    expect(body.length).toBe(10);
+    expect(body.length).toBe(11);
     const slugs = body.map((b) => b.slug);
-    // New/surviving beats
+    // Network-focused beats (migration 11)
     expect(slugs).toContain("agent-economy");
     expect(slugs).toContain("agent-trading");
     expect(slugs).toContain("agent-social");
@@ -68,8 +68,9 @@ describe("DO constructor: schema initialization", () => {
     expect(slugs).toContain("governance");
     expect(slugs).toContain("distribution");
     expect(slugs).toContain("infrastructure");
-    // Removed beats should not be present
-    expect(slugs).not.toContain("bitcoin-macro");
+    // Re-added beat (migration 12)
+    expect(slugs).toContain("bitcoin-macro");
+    // Other previously-removed beats should not be present
     expect(slugs).not.toContain("bitcoin-culture");
     expect(slugs).not.toContain("bitcoin-yield");
     expect(slugs).not.toContain("ordinals");

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -5,7 +5,7 @@ import type { Env, Beat, Signal, SignalStatus, Streak, Brief, Classified, Classi
 import { validateSlug, validateHexColor, sanitizeString, validateDateFormat } from "../lib/validators";
 import { generateId, getPacificDate, getPacificYesterday, getPacificDayStartUTC, getPacificDayEndUTC, getNextDate } from "../lib/helpers";
 import { CLASSIFIED_DURATION_DAYS, CLASSIFIED_BRIEF_SLOTS, CLASSIFIED_BRIEF_MAX_CHARS, CLASSIFIED_STATUSES, SIGNAL_COOLDOWN_HOURS, BEAT_EXPIRY_DAYS, MAX_SIGNALS_PER_DAY, MAX_INCLUDED_SIGNALS_PER_BRIEF, SIGNAL_STATUSES, REVIEWABLE_SIGNAL_STATUSES, CONFIG_PUBLISHER_ADDRESS, BRIEF_INCLUSION_PAYOUT_SATS, WEEKLY_PRIZE_1ST_SATS, WEEKLY_PRIZE_2ND_SATS, WEEKLY_PRIZE_3RD_SATS, SCORING_WEIGHTS } from "../lib/constants";
-import { SCHEMA_SQL, MIGRATION_PHASE0_SQL, MIGRATION_PAYMENTS_SQL, MIGRATION_BEAT_RESTRUCTURE_SQL, MIGRATION_SBTC_TRACKING_SQL, MIGRATION_CLASSIFIEDS_CLEANUP_SQL, MIGRATION_CLASSIFIEDS_REVIEW_SQL, MIGRATION_SNAPSHOTS_SQL, MIGRATION_BEAT_CLAIMS_SQL, MIGRATION_RETRACTION_SQL, MIGRATION_BEAT_NETWORK_FOCUS_SQL } from "./schema";
+import { SCHEMA_SQL, MIGRATION_PHASE0_SQL, MIGRATION_PAYMENTS_SQL, MIGRATION_BEAT_RESTRUCTURE_SQL, MIGRATION_SBTC_TRACKING_SQL, MIGRATION_CLASSIFIEDS_CLEANUP_SQL, MIGRATION_CLASSIFIEDS_REVIEW_SQL, MIGRATION_SNAPSHOTS_SQL, MIGRATION_BEAT_CLAIMS_SQL, MIGRATION_RETRACTION_SQL, MIGRATION_BEAT_NETWORK_FOCUS_SQL, MIGRATION_BITCOIN_MACRO_SQL } from "./schema";
 
 // ── State machine transition maps ──
 // Hoisted to module level so they are created once and are testable.
@@ -181,7 +181,7 @@ export class NewsDO extends DurableObject<Env> {
     // 9 = Retraction support (retracted_at on brief_signals, voided_at on earnings)
     // 10 = Network-focus beats (reduce 17 → 10 beats, remap signals, delete retired beats)
     // 11 = Re-run network-focus (migration 10 failed silently due to beat_claims FK constraint)
-    const CURRENT_MIGRATION_VERSION = 11;
+    const CURRENT_MIGRATION_VERSION = 12;
     const versionRows = this.ctx.storage.sql
       .exec("SELECT value FROM config WHERE key = 'migration_version'")
       .toArray();
@@ -331,6 +331,21 @@ export class NewsDO extends DurableObject<Env> {
         }
       }
 
+      // Re-add bitcoin-macro beat with daily_approved_limit column (closes #348).
+      // Adds `daily_approved_limit` column to beats table and inserts the beat.
+      if (appliedVersion < 12) {
+        for (const stmt of MIGRATION_BITCOIN_MACRO_SQL) {
+          try {
+            this.ctx.storage.sql.exec(stmt);
+          } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            if (!msg.includes("duplicate column")) {
+              console.error("Bitcoin macro migration statement failed:", e);
+            }
+          }
+        }
+      }
+
       // Record current migration version so future cold starts skip all of the above.
       this.ctx.storage.sql.exec(
         "INSERT INTO config (key, value) VALUES ('migration_version', ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = datetime('now')",
@@ -475,6 +490,42 @@ export class NewsDO extends DurableObject<Env> {
             ok: false,
             error: "Cannot retract a signal after its brief has been inscribed. Use a correction instead.",
           } satisfies DOResult<Signal>, 409);
+        }
+      }
+
+      // Per-beat daily approved-signal cap (e.g. bitcoin-macro: 4/day).
+      // Only applies when approving; rejections and other transitions are unrestricted.
+      if (newStatus === "approved") {
+        const beatSlugRow = this.ctx.storage.sql
+          .exec("SELECT beat_slug FROM signals WHERE id = ?", id)
+          .toArray();
+        if (beatSlugRow.length > 0) {
+          const beatSlug = (beatSlugRow[0] as { beat_slug: string }).beat_slug;
+          const limitRow = this.ctx.storage.sql
+            .exec("SELECT daily_approved_limit FROM beats WHERE slug = ?", beatSlug)
+            .toArray();
+          if (limitRow.length > 0) {
+            const dailyLimit = (limitRow[0] as { daily_approved_limit: number | null }).daily_approved_limit;
+            if (dailyLimit !== null) {
+              const approvedToday = this.ctx.storage.sql
+                .exec(
+                  `SELECT COUNT(*) as cnt FROM signals
+                   WHERE beat_slug = ?
+                     AND status IN ('approved', 'brief_included')
+                     AND reviewed_at >= date('now')`,
+                  beatSlug
+                )
+                .toArray();
+              const count = (approvedToday[0] as { cnt: number }).cnt ?? 0;
+              if (count >= dailyLimit) {
+                return c.json({
+                  ok: false,
+                  error: `Daily approved-signal cap reached for "${beatSlug}" — maximum ${dailyLimit} approvals per day.`,
+                  beat_daily_limit: { beat: beatSlug, limit: dailyLimit, approved_today: count },
+                } as unknown as DOResult<Signal>, 429);
+              }
+            }
+          }
         }
       }
 

--- a/src/objects/schema.ts
+++ b/src/objects/schema.ts
@@ -435,3 +435,27 @@ export const MIGRATION_BEAT_NETWORK_FOCUS_SQL = `
     'aibtc-network', 'dao-watch', 'dev-tools'
   );
 `;
+
+/**
+ * MIGRATION_BITCOIN_MACRO_SQL — re-adds the bitcoin-macro beat (closes #348).
+ *
+ * Phase A: Add daily_approved_limit column (nullable; NULL = no per-beat cap).
+ * Phase B: Insert bitcoin-macro beat with a daily approved-signal cap of 4.
+ *
+ * Idempotent:
+ *   - ALTER TABLE ADD COLUMN is safe to re-run (duplicate column error is caught).
+ *   - INSERT ON CONFLICT updates name/description/color/limit on re-run.
+ */
+export const MIGRATION_BITCOIN_MACRO_SQL = [
+  // Phase A: add column (safe to re-run; caller catches "duplicate column" errors)
+  `ALTER TABLE beats ADD COLUMN daily_approved_limit INTEGER DEFAULT NULL`,
+  // Phase B: re-add the bitcoin-macro beat with a 4-signal daily approved cap
+  `INSERT INTO beats (slug, name, description, color, daily_approved_limit, created_by, created_at, updated_at) VALUES
+    ('bitcoin-macro', 'Bitcoin Macro', 'Broader Bitcoin macroeconomic news: price milestones, ETF flows, institutional adoption, regulatory developments, and macro events relevant to the Bitcoin-native AI economy.', '#F9A825', 4, 'system', datetime('now'), datetime('now'))
+  ON CONFLICT(slug) DO UPDATE SET
+    name                = excluded.name,
+    description         = excluded.description,
+    color               = excluded.color,
+    daily_approved_limit = excluded.daily_approved_limit,
+    updated_at          = datetime('now')`,
+];


### PR DESCRIPTION
## Summary
- Re-adds the `bitcoin-macro` beat (removed in the network-focus migration) per #348
- Adds a `daily_approved_limit` column to the beats table (NULL = no cap; bitcoin-macro gets 4)
- Enforces the per-beat daily approved cap at review time: Publisher gets a 429 once 4 bitcoin-macro signals are approved in a UTC day

## Implementation
**Schema change (migration 12):**
- `ALTER TABLE beats ADD COLUMN daily_approved_limit INTEGER DEFAULT NULL`
- `INSERT ... ON CONFLICT DO UPDATE` for bitcoin-macro with `daily_approved_limit = 4`

**Review handler gate (`PATCH /signals/:id/review`):**
```
if newStatus == "approved":
  look up beat's daily_approved_limit
  if limit set: count approved+brief_included signals today for that beat
  if count >= limit: return 429 with beat_daily_limit metadata
```

**Tests:** 220/220 passing. Updated 2 test files that hard-coded the 10-beat count from the previous migration.

## Test plan
- [ ] Fresh DO init populates 11 beats (10 network-focused + bitcoin-macro)
- [ ] `GET /api/beats` includes `bitcoin-macro` with `daily_approved_limit: 4`
- [ ] Publisher can approve up to 4 bitcoin-macro signals per UTC day
- [ ] 5th approval attempt returns 429 with `beat_daily_limit` in response body
- [ ] Rejections and other transitions are unaffected by the cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)