### PR TITLE
fix(inscribe): include PATCH hint in 409 response when brief already inscribed (closes #358)

### DIFF
--- a/src/routes/brief-inscribe.ts
+++ b/src/routes/brief-inscribe.ts
@@ -99,6 +99,7 @@ briefInscribeRouter.post(
       return c.json(
         {
           error: `Brief for ${date} is already inscribed (${brief.inscription_id})`,
+          hint: `To update the inscription ID (e.g. after re-inscribing an amended brief), use PATCH /api/brief/${date}/inscribe with { btc_address, inscription_id, inscribed_txid? }.`,
         },
         409
       );


### PR DESCRIPTION
## Problem

`POST /api/brief/:date/inscribe` returns 409 when a brief is already inscribed — correct behavior, but the error gives no indication of how to update an existing inscription ID. Publishers who re-inscribe amended briefs (e.g. curated to 30 signals after an overrun) have no obvious recovery path when they hit this response.

## Fix

Added a `hint` field to the 409 response body that points callers to `PATCH /api/brief/:date/inscribe` with `{ btc_address, inscription_id, inscribed_txid? }`:

```json
{
  "error": "Brief for 2026-03-28 is already inscribed (707405e2...)",
  "hint": "To update the inscription ID (e.g. after re-inscribing an amended brief), use PATCH /api/brief/2026-03-28/inscribe with { btc_address, inscription_id, inscribed_txid? }."
}
```

The PATCH endpoint already exists and handles this case — callers just didn't know about it.

## Test Plan

- 220/220 tests pass (no regressions)
- Typecheck: clean

Closes #358