### PR TITLE
fix: show classifieds above signals on mobile

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1843,6 +1843,13 @@
         grid-template-columns: 1fr;
       }
 
+      /* When promoted into main content on mobile */
+      .page > .marketplace-section {
+        margin: 0 calc(-1 * var(--page-padding, 0px));
+        padding: var(--space-4) var(--page-padding);
+        border-bottom: 2px solid var(--rule);
+      }
+
       .roster-grid {
         grid-template-columns: repeat(2, 1fr);
       }
@@ -2760,6 +2767,7 @@
         if (classifiedsData) {
           renderMarketplace(classifiedsData.classifieds || []);
         }
+        promoteSidebarOnMobile();
 
         if (correspondentsList.length > 0) {
           renderLeaderboard(correspondentsList);
@@ -2830,6 +2838,7 @@
           if (classifiedsData) {
             renderMarketplace(classifiedsData.classifieds || []);
           }
+          promoteSidebarOnMobile();
 
           if (correspondentsList.length > 0) {
             renderLeaderboard(correspondentsList);
@@ -3943,6 +3952,17 @@
         `;
       }).join('') + '</div>';
       hydrateAgentIdentities(content);
+    }
+
+    // ── Mobile: show classifieds above signals ──
+    function promoteSidebarOnMobile() {
+      if (window.innerWidth > 768) return;
+      const main = document.getElementById('main-content');
+      const section = document.getElementById('marketplace-section');
+      if (!main || !section) return;
+      // Already inside main — nothing to do
+      if (section.parentNode === main || main.contains(section)) return;
+      main.insertBefore(section, main.firstChild);
     }
 
     // ── Infinite scroll ──


### PR DESCRIPTION
## Summary
- On mobile (≤768px), the marketplace/classifieds section was trapped in the sidebar which has `order: 2` — but infinite scroll keeps appending content to `<main>`, pushing the sidebar infinitely out of reach so users could never see classifieds
- Adds `promoteSidebarOnMobile()` to move the marketplace section to the top of `<main>` on mobile so classifieds display above the signal feed
- Adds `.page > .marketplace-section` CSS for proper full-width styling when promoted

## Test plan
- [ ] Open the site on a mobile viewport (≤768px) and confirm classifieds appear above the signal feed
- [ ] Verify classifieds still render correctly in the sidebar on desktop (>768px)
- [ ] Scroll down on mobile and confirm infinite scroll still works after the marketplace section

🤖 Generated with [Claude Code](https://claude.com/claude-code)