### PR TITLE
fix: align classifieds section on mobile

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1845,8 +1845,8 @@
 
       /* When promoted into main content on mobile */
       .page > .marketplace-section {
-        margin: 0 calc(-1 * var(--page-padding, 0px));
-        padding: var(--space-4) var(--page-padding);
+        margin: 0;
+        padding: var(--space-4) 0;
         border-bottom: 2px solid var(--rule);
       }
 


### PR DESCRIPTION
## Summary
- Fixes the marketplace/classifieds section being shifted left on mobile
- Removes the negative margin (`calc(-1 * var(--page-padding))`) that was pulling the section outside its container
- Uses `margin: 0` and `padding: var(--space-4) 0` to align flush with the rest of the main content

## Test plan
- [ ] Open on mobile (≤768px) and confirm classifieds section is properly aligned with signal content
- [ ] Verify desktop sidebar layout is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)