### PR TITLE
fix: increase bulk agent fetch cap to cover full registry

### DIFF
--- a/src/services/agent-resolver.ts
+++ b/src/services/agent-resolver.ts
@@ -13,7 +13,7 @@ const CACHE_TTL_SECONDS = 86400; // 24 hours
 const CACHE_KEY_PREFIX = "agent-name:";
 const AGENT_API_BASE = "https://aibtc.com/api/agents";
 const BULK_PAGE_SIZE = 100; // max allowed by aibtc.com
-const BULK_MAX_PAGES = 3; // safety cap: 300 agents max
+const BULK_MAX_PAGES = 10; // safety cap: 1000 agents max
 
 export interface AgentInfo {
   name: string | null;


### PR DESCRIPTION
## Summary

- Agent names were showing as `null` on correspondents, signals, and classifieds pages despite the previous PR (#372) wiring up `displayName` correctly

## Root cause

`BULK_MAX_PAGES` in `src/services/agent-resolver.ts` was set to `3`, capping the bulk fetch at 300 agents. The aibtc.com registry has grown to **687 agents**. The top correspondent (`bc1qfx0m...`) was found at offset 400 (page 5) — beyond the cap. Every agent past page 3 resolved to `{ name: null }`.

## Fix

Bump `BULK_MAX_PAGES` from `3` to `10` (1000 agents), giving headroom for continued registry growth.

## Test plan

- [ ] Deploy and verify `/api/correspondents` returns non-null `display_name` values
- [ ] Verify `/agents` page shows agent names instead of truncated addresses
- [ ] Verify `/signals` page shows agent names

🤖 Generated with [Claude Code](https://claude.ai/code)