### PR TITLE
fix(agents): remove 200-agent cap from /correspondents queries (closes #391)

### DIFF
--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -2700,8 +2700,7 @@ export class NewsDO extends DurableObject<Env> {
            LEFT JOIN streaks st ON s.btc_address = st.btc_address
            WHERE s.correction_of IS NULL
            GROUP BY s.btc_address
-           ORDER BY signal_count DESC
-           LIMIT 200`
+           ORDER BY signal_count DESC`
         )
         .toArray();
       return c.json({ ok: true, data: rows } satisfies DOResult<unknown[]>);
@@ -4072,8 +4071,7 @@ export class NewsDO extends DurableObject<Env> {
            LEFT JOIN streaks st ON s.btc_address = st.btc_address
            WHERE s.correction_of IS NULL
            GROUP BY s.btc_address
-           ORDER BY signal_count DESC
-           LIMIT 200`
+           ORDER BY signal_count DESC`
         )
         .toArray();
 
@@ -4195,8 +4193,7 @@ export class NewsDO extends DurableObject<Env> {
            LEFT JOIN streaks st ON s.btc_address = st.btc_address
            WHERE s.correction_of IS NULL
            GROUP BY s.btc_address
-           ORDER BY signal_count DESC
-           LIMIT 200`
+           ORDER BY signal_count DESC`
         )
         .toArray();
 

--- a/src/routes/agents.ts
+++ b/src/routes/agents.ts
@@ -40,7 +40,7 @@ agentsRouter.get("/api/agents", async (c) => {
     };
   }
 
-  return c.json({ agents });
+  return c.json({ agents, total: Object.keys(agents).length });
 });
 
 export { agentsRouter };


### PR DESCRIPTION
## Summary

- **Root cause**: Three SQL queries in the DO all had `LIMIT 200` hardcoded — `/correspondents`, `/correspondents-bundle`, and the `/init` bundle. The `/api/agents` route calls `listCorrespondents` which hits `/correspondents`, so no matter what `?limit=` param the caller passes it was always capped at 200.
- **Fix**: Remove `LIMIT 200` from all three correspondent queries. The result set is naturally bounded by the number of distinct agents who have filed signals, so no explicit cap is needed.
- **Added `total`**: `/api/agents` now returns `{ agents: {...}, total: N }` so the UI and callers can surface the real network size without re-counting keys client-side.

## Test plan

- [ ] `GET /api/agents` returns more than 200 agents once deployed
- [ ] `GET /api/agents?addresses=addr1,addr2` still filters correctly (unchanged behavior)
- [ ] `/agents` page renders all correspondents
- [ ] `total` field in response matches `Object.keys(agents).length`
- [ ] `/correspondents-bundle` and `/init` bundle also return full correspondent list

## Operational context

Arc runs the `/api/agents` endpoint in production (agent name resolution for sensors). We observed the response always returning exactly 200 entries. This matches the hardcoded `LIMIT 200` identified in the DO source. No migration or schema change is required — this is a pure query change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)