### PR TITLE
revert: undo #355 brief-cap merge (signal selection is editorial)

### DIFF
--- a/src/__tests__/brief-compile-reconciliation.test.ts
+++ b/src/__tests__/brief-compile-reconciliation.test.ts
@@ -71,9 +71,9 @@ describe("brief compile reconciliation", () => {
     }>();
 
     expect(body.brief.included_signal_ids).toEqual([
-      "under-30-1",
-      "under-30-2",
       "under-30-3",
+      "under-30-2",
+      "under-30-1",
     ]);
     expect(body.brief.included_signals.map((signal) => signal.position)).toEqual([0, 1, 2]);
     expect(body.brief.roster).toEqual(expect.objectContaining({
@@ -127,11 +127,11 @@ describe("brief compile reconciliation", () => {
       brief_signals: briefSignals,
       earnings: [
         {
-          id: "earning-overflow-30",
-          btc_address: REPORTER_B,
+          id: "earning-overflow-00",
+          btc_address: REPORTER_A,
           amount_sats: 30000,
           reason: "brief_inclusion",
-          reference_id: "over-cap-30",
+          reference_id: "over-cap-00",
           created_at: "2026-04-11T23:59:30Z",
         },
       ],
@@ -148,12 +148,12 @@ describe("brief compile reconciliation", () => {
       payouts: { paid: number; skipped: number; revived: number; voided: number };
     }>();
 
-    // Compile orders by reviewed_at ASC — earliest-approved first.
-    // With 31 signals (reviewed_at 23:00-23:30), signal 00 (earliest) is first,
-    // signal 30 (latest) is the overflow candidate dropped at the 30-signal cap.
+    // Simplified compile orders by reviewed_at DESC — most recently reviewed first.
+    // With 31 signals (reviewed_at 23:00-23:30), signal 30 (latest) is first,
+    // signal 00 (earliest) is the overflow candidate dropped at the 30-signal cap.
     expect(firstCompile.brief.included_signal_ids).toHaveLength(30);
-    expect(firstCompile.brief.included_signal_ids[0]).toBe("over-cap-00");
-    expect(firstCompile.brief.included_signal_ids[29]).toBe("over-cap-29");
+    expect(firstCompile.brief.included_signal_ids[0]).toBe("over-cap-30");
+    expect(firstCompile.brief.included_signal_ids[29]).toBe("over-cap-01");
     expect(firstCompile.brief.roster).toEqual(expect.objectContaining({
       candidate_count: 31,
       selected_count: 30,
@@ -170,17 +170,17 @@ describe("brief compile reconciliation", () => {
     expect(briefSignalsRes.status).toBe(200);
     const briefSignalsBody = await briefSignalsRes.json<{ ok: true; data: Array<{ signal_id: string }> }>();
     expect(briefSignalsBody.data).toHaveLength(30);
-    expect(briefSignalsBody.data.some((row) => row.signal_id === "over-cap-30")).toBe(false);
+    expect(briefSignalsBody.data.some((row) => row.signal_id === "over-cap-00")).toBe(false);
 
     const replacedRes = await SELF.fetch(`http://example.com/api/signals?date=${date}&status=replaced`);
     expect(replacedRes.status).toBe(200);
     const replacedBody = await replacedRes.json<{ signals: Array<{ id: string }> }>();
-    expect(replacedBody.signals.map((signal) => signal.id)).toContain("over-cap-30");
+    expect(replacedBody.signals.map((signal) => signal.id)).toContain("over-cap-00");
 
     const curatedRes = await SELF.fetch("http://example.com/api/front-page");
     expect(curatedRes.status).toBe(200);
     const curatedBody = await curatedRes.json<{ signals: Array<{ id: string }> }>();
-    expect(curatedBody.signals.some((signal) => signal.id === "over-cap-30")).toBe(false);
+    expect(curatedBody.signals.some((signal) => signal.id === "over-cap-00")).toBe(false);
 
     const secondCompileRes = await compile(date);
     expect(secondCompileRes.status).toBe(201);

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -2258,7 +2258,7 @@ export class NewsDO extends DurableObject<Env> {
       // Simplified compile: the roster IS the set of approved signals for the day.
       // All curation happened at review time via cap-enforced approval.
       // Include both 'approved' (new) and 'brief_included' (recompile) signals.
-      const candidateRows = this.ctx.storage.sql
+      const candidateSignals = this.ctx.storage.sql
         .exec(
           `SELECT s.id, s.beat_slug, s.btc_address, s.headline, s.body, s.sources,
                   s.created_at, s.correction_of, s.reviewed_at,
@@ -2281,7 +2281,9 @@ export class NewsDO extends DurableObject<Env> {
       // reviewed_at DESC, created_at DESC, id ASC above, so compilation deterministically
       // includes the first N approved candidates for the day. This is the effective
       // selection behavior whenever approvals exceed the brief limit.
-      const selectedSignals = candidateRows.slice(0, MAX_INCLUDED_SIGNALS_PER_BRIEF);
+      // Note: fetches all candidates to preserve candidate_count accuracy; revisit
+      // with SQL LIMIT + separate COUNT if daily volumes grow significantly.
+      const selectedSignals = candidateSignals.slice(0, MAX_INCLUDED_SIGNALS_PER_BRIEF);
       const includedSignals = buildIncludedSignalMetadata(selectedSignals);
 
       const compiledAt = now.toISOString();
@@ -2291,8 +2293,8 @@ export class NewsDO extends DurableObject<Env> {
         signals: selectedSignals,
         included_signal_ids: includedSignals.map((signal) => signal.signal_id),
         included_signals: includedSignals,
-        candidate_count: candidateRows.length,
-        overflow_count: Math.max(0, candidateRows.length - MAX_INCLUDED_SIGNALS_PER_BRIEF),
+        candidate_count: candidateSignals.length,
+        overflow_count: Math.max(0, candidateSignals.length - MAX_INCLUDED_SIGNALS_PER_BRIEF),
       };
 
       return c.json({ ok: true, data } satisfies DOResult<CompiledBriefData>);

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -2277,10 +2277,10 @@ export class NewsDO extends DurableObject<Env> {
         .toArray()
         .map((row) => rowToCompiledSignal(row as Record<string, unknown>));
 
-      // Safety cap at MAX_INCLUDED_SIGNALS_PER_BRIEF. Each beat editor approves up to
-      // their beat's daily_approved_limit (e.g. 6/30 for quantum); the publisher fills
-      // remaining slots from other beats. Per-beat caps should sum to <= 30, so this
-      // slice is a hard ceiling for misconfigured caps, not a curation mechanism.
+      // Safety cap at MAX_INCLUDED_SIGNALS_PER_BRIEF. Candidates are already ordered by
+      // reviewed_at DESC, created_at DESC, id ASC above, so compilation deterministically
+      // includes the first N approved candidates for the day. This is the effective
+      // selection behavior whenever approvals exceed the brief limit.
       const selectedSignals = candidateRows.slice(0, MAX_INCLUDED_SIGNALS_PER_BRIEF);
       const includedSignals = buildIncludedSignalMetadata(selectedSignals);
 

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -2257,20 +2257,8 @@ export class NewsDO extends DurableObject<Env> {
 
       // Simplified compile: the roster IS the set of approved signals for the day.
       // All curation happened at review time via cap-enforced approval.
-      // Count total candidates before applying the cap so overflow is reported accurately.
-      const totalCandidates = this.ctx.storage.sql
-        .exec(
-          `SELECT COUNT(*) as cnt FROM signals
-           WHERE created_at >= ?1 AND created_at < ?2
-             AND status IN ('approved', 'brief_included')`,
-          dayStart,
-          dayEnd
-        )
-        .toArray()[0]?.cnt as number ?? 0;
-
       // Include both 'approved' (new) and 'brief_included' (recompile) signals.
-      // Earliest-approved first; LIMIT enforces the 30-signal cap at the DB layer.
-      const selectedSignals = this.ctx.storage.sql
+      const candidateRows = this.ctx.storage.sql
         .exec(
           `SELECT s.id, s.beat_slug, s.btc_address, s.headline, s.body, s.sources,
                   s.created_at, s.correction_of, s.reviewed_at,
@@ -2282,15 +2270,18 @@ export class NewsDO extends DurableObject<Env> {
            WHERE s.created_at >= ?1
              AND s.created_at < ?2
              AND s.status IN ('approved', 'brief_included')
-           ORDER BY s.reviewed_at ASC, s.created_at ASC, s.id ASC
-           LIMIT ?3`,
+           ORDER BY s.reviewed_at DESC, s.created_at DESC, s.id ASC`,
           dayStart,
-          dayEnd,
-          MAX_INCLUDED_SIGNALS_PER_BRIEF
+          dayEnd
         )
         .toArray()
         .map((row) => rowToCompiledSignal(row as Record<string, unknown>));
 
+      // Safety cap at MAX_INCLUDED_SIGNALS_PER_BRIEF. Each beat editor approves up to
+      // their beat's daily_approved_limit (e.g. 6/30 for quantum); the publisher fills
+      // remaining slots from other beats. Per-beat caps should sum to <= 30, so this
+      // slice is a hard ceiling for misconfigured caps, not a curation mechanism.
+      const selectedSignals = candidateRows.slice(0, MAX_INCLUDED_SIGNALS_PER_BRIEF);
       const includedSignals = buildIncludedSignalMetadata(selectedSignals);
 
       const compiledAt = now.toISOString();
@@ -2300,8 +2291,8 @@ export class NewsDO extends DurableObject<Env> {
         signals: selectedSignals,
         included_signal_ids: includedSignals.map((signal) => signal.signal_id),
         included_signals: includedSignals,
-        candidate_count: totalCandidates,
-        overflow_count: Math.max(0, totalCandidates - MAX_INCLUDED_SIGNALS_PER_BRIEF),
+        candidate_count: candidateRows.length,
+        overflow_count: Math.max(0, candidateRows.length - MAX_INCLUDED_SIGNALS_PER_BRIEF),
       };
 
       return c.json({ ok: true, data } satisfies DOResult<CompiledBriefData>);


### PR DESCRIPTION
## Summary

- Reverts #355 — the 30-signal brief cap with earliest-approved-first ordering
- Signal selection for the daily brief is the Publisher's editorial role, not an automated DB-layer cutoff
- This conflicts with the direction of #347 (featured signals) which gives the Publisher curation control

## Context

The deterministic ordering idea has merit as a tiebreaker, but not as the primary selection mechanism. Beat editors manage per-beat daily caps; the Publisher curates which approved signals make the brief.

## Test plan

- [ ] Revert is clean — restores prior behavior exactly
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)