### PR TITLE
fix(correspondents): surface unpaidSats in correspondents and init responses

### DIFF
--- a/src/routes/correspondents.ts
+++ b/src/routes/correspondents.ts
@@ -23,9 +23,11 @@ correspondentsRouter.get("/api/correspondents", async (c) => {
   // Build address → leaderboard score map and earnings map
   const scoreMap = new Map<string, number>();
   const earningsMap = new Map<string, number>();
+  const unpaidMap = new Map<string, number>();
   for (const entry of leaderboardEntries) {
     scoreMap.set(entry.btc_address, Number(entry.score));
     earningsMap.set(entry.btc_address, Number(entry.total_earned_sats));
+    unpaidMap.set(entry.btc_address, Number(entry.unpaid_sats ?? 0));
   }
 
   const beatsByAddress = buildBeatsByAddress(beats, bundle.claims);
@@ -58,7 +60,7 @@ correspondentsRouter.get("/api/correspondents", async (c) => {
       daysActive,
       lastActive: row.last_signal_date ?? null,
       score,
-      earnings: { total: earningsMap.get(row.btc_address) ?? 0, recentPayments: [] as unknown[] },
+      earnings: { total: earningsMap.get(row.btc_address) ?? 0, unpaidSats: unpaidMap.get(row.btc_address) ?? 0, recentPayments: [] as unknown[] },
       display_name: info?.name ?? null,
       avatar: `https://bitcoinfaces.xyz/api/get-image?name=${encodeURIComponent(avatarAddr)}`,
       registered: info?.name !== null && info?.name !== undefined,

--- a/src/routes/init.ts
+++ b/src/routes/init.ts
@@ -87,9 +87,11 @@ initRouter.get("/api/init", async (c) => {
   // --- Correspondents (with agent name resolution) ---
   const scoreMap = new Map<string, number>();
   const earningsMap = new Map<string, number>();
+  const unpaidMap = new Map<string, number>();
   for (const entry of bundle.leaderboard) {
     scoreMap.set(entry.btc_address, Number(entry.score));
     earningsMap.set(entry.btc_address, Number(entry.total_earned_sats));
+    unpaidMap.set(entry.btc_address, Number(entry.unpaid_sats ?? 0));
   }
 
   const beatsByAddress = buildBeatsByAddress(bundle.beats, bundle.claims);
@@ -119,7 +121,7 @@ initRouter.get("/api/init", async (c) => {
       daysActive,
       lastActive: row.last_signal_date ?? null,
       score,
-      earnings: { total: earningsMap.get(row.btc_address) ?? 0, recentPayments: [] as unknown[] },
+      earnings: { total: earningsMap.get(row.btc_address) ?? 0, unpaidSats: unpaidMap.get(row.btc_address) ?? 0, recentPayments: [] as unknown[] },
       display_name: info?.name ?? null,
       avatar: `https://bitcoinfaces.xyz/api/get-image?name=${encodeURIComponent(avatarAddr)}`,
       registered: info?.name !== null && info?.name !== undefined,


### PR DESCRIPTION
## Summary

- Adds `unpaidSats` to the `earnings` object in `/api/correspondents` and `/api/init` responses
- The leaderboard query (PR #409) now splits paid vs unpaid earnings, but the correspondents and init routes were not passing `unpaid_sats` through — agents hitting these endpoints had no visibility into unpaid earnings

## Test plan

- [ ] Verify `/api/correspondents` returns `earnings.unpaidSats` for each correspondent
- [ ] Verify `/api/init` returns `earnings.unpaidSats` in correspondent data
- [ ] Confirm typecheck passes