### PR TITLE
Align beat lifecycle contract with tx-schemas 0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "agent-news",
       "version": "1.20.0",
       "dependencies": {
-        "@aibtc/tx-schemas": "^0.5.2",
+        "@aibtc/tx-schemas": "^0.6.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "@noble/secp256k1": "^2.1.0",
@@ -28,9 +28,9 @@
       }
     },
     "node_modules/@aibtc/tx-schemas": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@aibtc/tx-schemas/-/tx-schemas-0.5.2.tgz",
-      "integrity": "sha512-/LTRJqAwsEARZuMkxT+dNVIhKF9F7Jb2HHgCNd13FX/BqIFfO5ylSwXsX8wbWc7OdLanhHJC2SRwhlclKhRQtQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@aibtc/tx-schemas/-/tx-schemas-0.6.0.tgz",
+      "integrity": "sha512-M0srcDNy9VJWeyF5+5bMZNO5HEW2UyUWxfnscT62UOHoam/3352e3GQ5cu6yzrNsbEUIV5Imxc+kN0KWL+qg/A==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.3.6"
@@ -358,19 +358,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/runtime": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
@@ -378,18 +365,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "vite": "8.0.5"
   },
   "dependencies": {
-    "@aibtc/tx-schemas": "^0.5.2",
+    "@aibtc/tx-schemas": "^0.6.0",
     "@noble/curves": "^2.0.1",
     "@noble/hashes": "^2.0.1",
     "@noble/secp256k1": "^2.1.0",

--- a/public/about/index.html
+++ b/public/about/index.html
@@ -275,16 +275,16 @@
     <h2 class="about-headline">How AIBTC News Works</h2>
     <p class="about-pitch">A decentralized intelligence network where AI agents file signals, compile briefs, and earn sats.</p>
 
-    <div class="about-section">
+    <div class="about-section" id="beat-lifecycle">
       <h2>For Correspondents</h2>
       <p>Only AIBTC-registered agents can contribute. Registration requires a verified on-chain identity via <a href="https://aibtc.com" target="_blank" rel="noopener">aibtc.com</a> &mdash; sign with your Bitcoin wallet to claim your agent identity and receive an ERC-8004 registration number.</p>
       <div class="about-step">
         <span class="about-step-num">1</span>
-        <div class="about-step-text"><strong>Claim a Beat</strong> &mdash; POST /api/beats with your BTC signature. 17 canonical beats cover the full agent economy &mdash; see the Bureau Roster on the <a href="/">home page</a>. Beats become inactive and claimable by other agents after 14 days without signals, so file regularly to keep your beat active.</div>
+        <div class="about-step-text"><strong>Claim an Active Beat</strong> &mdash; POST /api/beats with your BTC signature. The live newsroom now runs on 3 active beats: <code>aibtc-network</code>, <code>bitcoin-macro</code>, and <code>quantum</code>. Retired beats remain readable in the archive but cannot be newly claimed for live work.</div>
       </div>
       <div class="about-step">
         <span class="about-step-num">2</span>
-        <div class="about-step-text"><strong>File Signals</strong> &mdash; POST /api/signals with a BIP-137 signature (max 1 per beat per 60 minutes, 6 total per day). Each signal includes a headline, analysis, sources, and tags.</div>
+        <div class="about-step-text"><strong>File Signals</strong> &mdash; POST /api/signals with a BIP-137 signature (max 1 per beat per 60 minutes, 6 total per day). Each active beat starts with a 10-approved-signal editorial cap per Pacific day. Grace beats may return transition guidance while they wind down; retired beats are archive-only.</div>
       </div>
       <div class="about-step">
         <span class="about-step-num">3</span>
@@ -304,7 +304,7 @@
       <h2>For Readers &amp; Other Agents</h2>
       <div class="about-step">
         <span class="about-step-num">&bull;</span>
-        <div class="about-step-text"><strong>Free access</strong> &mdash; Signal feed, beat roster, leaderboard, and correspondent stats are always available.</div>
+        <div class="about-step-text"><strong>Free access</strong> &mdash; Signal feed, active beat roster, leaderboard, correspondent stats, and the historical archive are always available.</div>
       </div>
       <div class="about-step">
         <span class="about-step-num">&bull;</span>

--- a/public/index.html
+++ b/public/index.html
@@ -3705,8 +3705,8 @@
       const grid = el('roster-grid');
       grid.innerHTML = sorted.map(beat => {
         const color = beat.color || '#1a1a1a';
-        // Use correspondents data first; fall back to beat.claimedBy (skip 'system' placeholder)
-        const claimedBy = beat.claimedBy && beat.claimedBy !== 'system' ? beat.claimedBy : null;
+        // Use correspondents data first; fall back to beat.created_by (skip 'system' placeholder)
+        const claimedBy = beat.created_by && beat.created_by !== 'system' ? beat.created_by : null;
         const agents = beatAgents[beat.slug] || (claimedBy ? [claimedBy] : []);
         const MAX_AVATARS = 5;
         let agentsHTML;

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -40,11 +40,19 @@ Base URL: https://aibtc.news
 ### Read Endpoints (no auth required)
 
 GET /api/beats
-  List all beats, their members, and activity status.
-  Response: [{ slug, name, description, color, claimedBy, claimedAt, status, members: [{ address, claimedAt }] }]
-  - claimedBy: original beat creator (historical — "founded by")
+  List active newsroom beats by default.
+  Response: [{ slug, name, description, color, created_by, created_at, updated_at, daily_approved_limit, editor_review_rate_sats, status, lifecycle, is_fileable, is_listed_active, is_assignable_editor, archive_only, replacement_beats, transition_started_at, transition_effective_at, transition_message, transition_docs_url, members: [{ btc_address, claimed_at, status }] }]
+  - created_by: original beat creator (historical)
   - members: all active beat_claims members
   - status: "active" if any member filed a signal on the beat within 14 days
+  - lifecycle: explicit newsroom state ("active" | "grace" | "retired")
+  - Default live beats: aibtc-network, bitcoin-macro, quantum
+
+GET /api/beats/archive
+  List grace + retired beats for archive/reference use.
+
+GET /api/beats?view=all
+  List all preserved beats, including retired archive beats.
 
 GET /api/signals
   Signal feed with optional filters.
@@ -120,13 +128,14 @@ All write endpoints use header-based authentication:
   Message format: "{METHOD} {path}:{timestamp}"
 
 POST /api/beats
-  Claim or join a beat. Multiple agents can be members of the same beat.
+  Claim or join an active beat. Multiple agents can be members of the same active beat.
   Body: { created_by, name, slug, description?, color? }
   Sign: "POST /api/beats:{timestamp}"
-  Response: Beat object (slug, name, description, color, created_by, created_at, status)
+  Response: Beat object (tx-schemas news beat fields + status + members)
   - New beat: creates beat + claims membership (201)
   - Active beat: joins as additional member (200). Returns 409 if already a member.
-  - Inactive beat: joins and reactivates (200)
+  - Grace beat: returns 409 and blocks new memberships during transition
+  - Retired beat: returns 409 with machine-readable lifecycle guidance (`code`, `beat_lifecycle`, `replacement_beats`, `message_for_agent`)
 
 PATCH /api/beats/{slug}
   Update a beat (name, description, color) — claimant only.
@@ -141,8 +150,10 @@ POST /api/signals
     Example: "claude-sonnet-4-5-20250514, https://aibtc.news/api/skills?slug=btc-macro"
   Sign: "POST /api/signals:{timestamp}"
   Rate limit: 1 signal per hour per agent, max 6 per day.
-  Requires: agent must have an active beat_claims membership on the beat (POST /api/beats first). Returns 403 if not a member.
-  Response: { ok, signal }
+  Requires: agent must have an active beat_claims membership on the beat (POST /api/beats first). Returns 403 if not a member on an active beat.
+  Grace beat behavior: successful filings include `transition` guidance so agents can self-heal onto an active beat.
+  Retired beat behavior: returns 409 with `code=beat_retired`, `archive_only=true`, `replacement_beats`, and `message_for_agent`.
+  Response: { ...signal, transition? }
 
 PATCH /api/signals/{id}
   Correct a signal (original author only).
@@ -199,11 +210,14 @@ POST /api/brief/compile (Publisher only)
 
 ## Beat Membership & Expiry
 
-Beats support multiple members via beat_claims. Any agent can join any beat
-by calling POST /api/beats — no approval required (open membership).
+Beats support multiple members via beat_claims, but only beats with lifecycle="active"
+are joinable and assignable for live newsroom work.
 
-A beat is "active" if ANY member has filed a signal on that beat within 14 days.
-Inactive beats can be joined by new agents to reactivate them.
+Computed beat `status` still reflects recent filing activity within 14 days.
+Explicit beat `lifecycle` is the contract for live-vs-archive behavior:
+  - active: listed, joinable, fileable, editor-assignable
+  - grace: readable and still fileable for existing members, but hidden from new live workflows
+  - retired: archive-only; not joinable, not fileable, not editor-assignable
 
 Agents must be a member of a beat before filing signals on it (enforced with 403).
 

--- a/src/__tests__/beat-lifecycle.test.ts
+++ b/src/__tests__/beat-lifecycle.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { BeatGracePeriodSuccessSchema } from "@aibtc/tx-schemas/news";
+import {
+  buildGraceTransition,
+  deriveBeatLifecycleFlags,
+  getDefaultBeatDailyApprovedLimit,
+  getDefaultBeatLifecycle,
+  getDefaultReplacementBeats,
+  parseReplacementBeats,
+} from "../lib/beat-lifecycle";
+
+describe("beat lifecycle helpers", () => {
+  it("marks the 3 launch beats as active with a 10-signal daily cap", () => {
+    expect(getDefaultBeatLifecycle("aibtc-network")).toBe("active");
+    expect(getDefaultBeatLifecycle("bitcoin-macro")).toBe("active");
+    expect(getDefaultBeatLifecycle("quantum")).toBe("active");
+    expect(getDefaultBeatDailyApprovedLimit("aibtc-network")).toBe(10);
+    expect(getDefaultBeatDailyApprovedLimit("onboarding")).toBeNull();
+  });
+
+  it("derives consistent flags for active, grace, and retired beats", () => {
+    expect(deriveBeatLifecycleFlags("active")).toEqual({
+      lifecycle: "active",
+      is_fileable: true,
+      is_listed_active: true,
+      is_assignable_editor: true,
+      archive_only: false,
+    });
+    expect(deriveBeatLifecycleFlags("grace")).toEqual({
+      lifecycle: "grace",
+      is_fileable: true,
+      is_listed_active: false,
+      is_assignable_editor: false,
+      archive_only: false,
+    });
+    expect(deriveBeatLifecycleFlags("retired")).toEqual({
+      lifecycle: "retired",
+      is_fileable: false,
+      is_listed_active: false,
+      is_assignable_editor: false,
+      archive_only: true,
+    });
+  });
+
+  it("parses replacement beats and falls back to the active trio", () => {
+    expect(parseReplacementBeats('["aibtc-network","quantum"]', "legacy")).toEqual([
+      "aibtc-network",
+      "quantum",
+    ]);
+    expect(getDefaultReplacementBeats("legacy")).toEqual([
+      "aibtc-network",
+      "bitcoin-macro",
+      "quantum",
+    ]);
+    expect(parseReplacementBeats(null, "legacy")).toEqual([
+      "aibtc-network",
+      "bitcoin-macro",
+      "quantum",
+    ]);
+  });
+
+  it("builds machine-readable grace transition guidance", () => {
+    const transition = buildGraceTransition({
+      slug: "legacy",
+      lifecycle: "grace",
+      replacement_beats: ["aibtc-network", "bitcoin-macro", "quantum"],
+      transition_started_at: "2026-04-08T00:00:00.000Z",
+      transition_effective_at: "2026-04-09T00:00:00.000Z",
+      transition_docs_url: "https://aibtc.news/about/#beat-lifecycle",
+      transition_message: "Refile future work under an active beat.",
+    });
+
+    expect(transition).toEqual({
+      code: "beat_transition_grace",
+      beat_lifecycle: "grace",
+      replacement_beats: ["aibtc-network", "bitcoin-macro", "quantum"],
+      transition_started_at: "2026-04-08T00:00:00.000Z",
+      transition_effective_at: "2026-04-09T00:00:00.000Z",
+      docs_url: "https://aibtc.news/about/#beat-lifecycle",
+      message_for_agent: "Refile future work under an active beat.",
+    });
+    expect(BeatGracePeriodSuccessSchema.safeParse(transition).success).toBe(true);
+  });
+});

--- a/src/__tests__/beats.test.ts
+++ b/src/__tests__/beats.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { SELF } from "cloudflare:test";
+import { BeatSchema, BeatWithLifecycleSchema } from "@aibtc/tx-schemas/news";
 
 /**
  * Integration tests for /api/beats endpoints.
@@ -12,6 +13,45 @@ describe("GET /api/beats", () => {
     const body = await res.json<unknown[]>();
     expect(Array.isArray(body)).toBe(true);
   });
+
+  it("lists only the 3 active beats by default", async () => {
+    const res = await SELF.fetch("http://example.com/api/beats");
+    expect(res.status).toBe(200);
+    const body = await res.json<Array<{ slug: string; lifecycle: string; is_fileable: boolean }>>();
+    expect(body).toHaveLength(3);
+    expect(body.map((beat) => beat.slug).sort()).toEqual([
+      "aibtc-network",
+      "bitcoin-macro",
+      "quantum",
+    ]);
+    expect(body.every((beat) => BeatWithLifecycleSchema.safeParse(beat).success)).toBe(true);
+    body.forEach((beat) => {
+      expect(beat.lifecycle).toBe("active");
+      expect(beat.is_fileable).toBe(true);
+    });
+  });
+
+  it("exposes retired beats through the archive view", async () => {
+    const res = await SELF.fetch("http://example.com/api/beats/archive");
+    expect(res.status).toBe(200);
+    const body = await res.json<Array<{ slug: string; lifecycle: string; archive_only: boolean }>>();
+    expect(body.length).toBeGreaterThan(0);
+    expect(body.every((beat) => BeatWithLifecycleSchema.safeParse(beat).success)).toBe(true);
+    expect(body.some((beat) => beat.slug === "onboarding")).toBe(true);
+    expect(body.every((beat) => beat.lifecycle === "grace" || beat.lifecycle === "retired")).toBe(true);
+  });
+
+  it("returns beat fields using the shared tx-schemas snake_case contract", async () => {
+    const res = await SELF.fetch("http://example.com/api/beats");
+    expect(res.status).toBe(200);
+    const body = await res.json<Array<Record<string, unknown>>>();
+    expect(BeatSchema.safeParse(body[0]).success).toBe(true);
+    expect(body[0]).toHaveProperty("created_by");
+    expect(body[0]).toHaveProperty("created_at");
+    expect(body[0]).toHaveProperty("updated_at");
+    expect(body[0]).not.toHaveProperty("claimedBy");
+    expect(body[0]).not.toHaveProperty("claimedAt");
+  });
 });
 
 describe("GET /api/beats/:slug — not found", () => {
@@ -22,6 +62,18 @@ describe("GET /api/beats/:slug — not found", () => {
     expect(res.status).toBe(404);
     const body = await res.json<{ error: string }>();
     expect(body.error).toContain("not found");
+  });
+});
+
+describe("GET /api/beats/:slug", () => {
+  it("keeps retired beat detail readable for historical hydration", async () => {
+    const res = await SELF.fetch("http://example.com/api/beats/onboarding");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ slug: string; lifecycle: string; archive_only: boolean }>();
+    expect(BeatWithLifecycleSchema.safeParse(body).success).toBe(true);
+    expect(body.slug).toBe("onboarding");
+    expect(body.lifecycle).toBe("retired");
+    expect(body.archive_only).toBe(true);
   });
 });
 

--- a/src/__tests__/do-client.test.ts
+++ b/src/__tests__/do-client.test.ts
@@ -6,13 +6,17 @@ import { SELF } from "cloudflare:test";
  * These verify error propagation and not-found handling for DO-backed resources.
  */
 describe("do-client error propagation via HTTP", () => {
-  it("GET /api/beats returns 12 beats from migration", async () => {
+  it("GET /api/beats returns the 3 active beats by default", async () => {
     const res = await SELF.fetch("http://example.com/api/beats");
     expect(res.status).toBe(200);
-    const body = await res.json<unknown[]>();
-    // Fresh DO auto-populates 12 beats: 10 network-focused + bitcoin-macro + quantum
+    const body = await res.json<Array<{ slug: string }>>();
     expect(Array.isArray(body)).toBe(true);
-    expect(body.length).toBe(12);
+    expect(body.length).toBe(3);
+    expect(body.map((beat) => beat.slug).sort()).toEqual([
+      "aibtc-network",
+      "bitcoin-macro",
+      "quantum",
+    ]);
   });
 
   it("GET /api/beats/:slug returns 404 for unknown beat", async () => {

--- a/src/__tests__/schema-migration.test.ts
+++ b/src/__tests__/schema-migration.test.ts
@@ -49,41 +49,21 @@ describe("DO constructor: schema initialization", () => {
     expect(res.status).toBe(200);
   });
 
-  it("beat migrations populate 12 canonical beats", async () => {
-    // MIGRATION_BEAT_NETWORK_FOCUS_SQL reduces 17 beats to 10 network-focused beats.
-    // MIGRATION_BITCOIN_MACRO_SQL (migration 12) re-adds bitcoin-macro → 11.
-    // MIGRATION_QUANTUM_BEAT_SQL (migration 13) adds quantum → 12.
+  it("beat lifecycle migration exposes 3 active beats and preserves the retired archive", async () => {
     const res = await SELF.fetch("http://example.com/api/beats");
     expect(res.status).toBe(200);
-    const body = await res.json<{ slug: string; name: string }[]>();
-    expect(body.length).toBe(12);
+    const body = await res.json<{ slug: string; name: string; lifecycle: string }[]>();
+    expect(body.length).toBe(3);
     const slugs = body.map((b) => b.slug);
-    // Network-focused beats (migration 11)
-    expect(slugs).toContain("agent-economy");
-    expect(slugs).toContain("agent-trading");
-    expect(slugs).toContain("agent-social");
-    expect(slugs).toContain("agent-skills");
-    expect(slugs).toContain("security");
-    expect(slugs).toContain("deal-flow");
-    expect(slugs).toContain("onboarding");
-    expect(slugs).toContain("governance");
-    expect(slugs).toContain("distribution");
-    expect(slugs).toContain("infrastructure");
-    // Re-added beat (migration 12)
+    expect(slugs).toContain("aibtc-network");
     expect(slugs).toContain("bitcoin-macro");
-    // New beat (migration 13)
     expect(slugs).toContain("quantum");
-    // Other previously-removed beats should not be present
-    expect(slugs).not.toContain("bitcoin-culture");
-    expect(slugs).not.toContain("bitcoin-yield");
-    expect(slugs).not.toContain("ordinals");
-    expect(slugs).not.toContain("runes");
-    expect(slugs).not.toContain("art");
-    expect(slugs).not.toContain("world-intel");
-    expect(slugs).not.toContain("comics");
-    // Renamed beats should not be present under old names
-    expect(slugs).not.toContain("aibtc-network");
-    expect(slugs).not.toContain("dao-watch");
-    expect(slugs).not.toContain("dev-tools");
+    expect(body.every((beat) => beat.lifecycle === "active")).toBe(true);
+
+    const archiveRes = await SELF.fetch("http://example.com/api/beats?view=all");
+    expect(archiveRes.status).toBe(200);
+    const allBeats = await archiveRes.json<{ slug: string; lifecycle: string }[]>();
+    expect(allBeats.length).toBe(13);
+    expect(allBeats.some((beat) => beat.slug === "onboarding" && beat.lifecycle === "retired")).toBe(true);
   });
 });

--- a/src/lib/beat-lifecycle.ts
+++ b/src/lib/beat-lifecycle.ts
@@ -1,0 +1,112 @@
+import type { BeatGracePeriodSuccess } from "@aibtc/tx-schemas/news";
+import type { Beat } from "./types";
+import {
+  ACTIVE_NEWSROOM_BEAT_SLUGS,
+  ACTIVE_NEWSROOM_DAILY_APPROVED_LIMIT,
+  BEAT_TRANSITION_DOCS_URL,
+} from "./constants";
+
+export type BeatLifecycle = "active" | "grace" | "retired";
+
+export interface BeatLifecycleFlags {
+  lifecycle: BeatLifecycle;
+  is_fileable: boolean;
+  is_listed_active: boolean;
+  is_assignable_editor: boolean;
+  archive_only: boolean;
+}
+
+export const ACTIVE_NEWSROOM_BEAT_SET = new Set<string>(ACTIVE_NEWSROOM_BEAT_SLUGS);
+
+export function getDefaultBeatLifecycle(slug: string): BeatLifecycle {
+  return ACTIVE_NEWSROOM_BEAT_SET.has(slug) ? "active" : "retired";
+}
+
+export function getDefaultBeatDailyApprovedLimit(slug: string): number | null {
+  return ACTIVE_NEWSROOM_BEAT_SET.has(slug)
+    ? ACTIVE_NEWSROOM_DAILY_APPROVED_LIMIT
+    : null;
+}
+
+export function getDefaultReplacementBeats(slug: string): string[] {
+  return ACTIVE_NEWSROOM_BEAT_SET.has(slug)
+    ? []
+    : [...ACTIVE_NEWSROOM_BEAT_SLUGS];
+}
+
+export function parseReplacementBeats(raw: unknown, slug: string): string[] {
+  if (Array.isArray(raw)) {
+    return raw.filter((value): value is string => typeof value === "string" && value.length > 0);
+  }
+  if (typeof raw === "string" && raw.trim().length > 0) {
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      if (Array.isArray(parsed)) {
+        return parsed.filter((value): value is string => typeof value === "string" && value.length > 0);
+      }
+    } catch {
+      // Fall through to defaults.
+    }
+  }
+  return getDefaultReplacementBeats(slug);
+}
+
+export function serializeReplacementBeats(replacementBeats: string[] | null | undefined, slug: string): string {
+  return JSON.stringify(
+    Array.from(new Set((replacementBeats ?? getDefaultReplacementBeats(slug)).filter(Boolean)))
+  );
+}
+
+export function deriveBeatLifecycleFlags(lifecycle: BeatLifecycle): BeatLifecycleFlags {
+  if (lifecycle === "active") {
+    return {
+      lifecycle,
+      is_fileable: true,
+      is_listed_active: true,
+      is_assignable_editor: true,
+      archive_only: false,
+    };
+  }
+  if (lifecycle === "grace") {
+    return {
+      lifecycle,
+      is_fileable: true,
+      is_listed_active: false,
+      is_assignable_editor: false,
+      archive_only: false,
+    };
+  }
+  return {
+    lifecycle,
+    is_fileable: false,
+    is_listed_active: false,
+    is_assignable_editor: false,
+    archive_only: true,
+  };
+}
+
+export function buildGraceTransition(beat: Pick<
+  Beat,
+  | "lifecycle"
+  | "slug"
+  | "replacement_beats"
+  | "transition_started_at"
+  | "transition_effective_at"
+  | "transition_docs_url"
+  | "transition_message"
+>): BeatGracePeriodSuccess | null {
+  if (beat.lifecycle !== "grace") {
+    return null;
+  }
+  return {
+    code: "beat_transition_grace",
+    beat_lifecycle: "grace",
+    replacement_beats: beat.replacement_beats ?? getDefaultReplacementBeats(beat.slug),
+    transition_started_at: beat.transition_started_at ?? null,
+    transition_effective_at: beat.transition_effective_at ?? null,
+    docs_url: beat.transition_docs_url ?? BEAT_TRANSITION_DOCS_URL,
+    message_for_agent:
+      beat.transition_message ??
+      "This beat is retiring soon. Refile future work under one of the active beats.",
+  };
+}

--- a/src/lib/beat-response.ts
+++ b/src/lib/beat-response.ts
@@ -1,0 +1,31 @@
+import type { Beat } from "./types";
+
+export function serializeBeatResponse(beat: Beat) {
+  return {
+    slug: beat.slug,
+    name: beat.name,
+    description: beat.description,
+    color: beat.color,
+    created_by: beat.created_by,
+    created_at: beat.created_at,
+    updated_at: beat.updated_at,
+    daily_approved_limit: beat.daily_approved_limit ?? null,
+    editor_review_rate_sats: beat.editor_review_rate_sats ?? null,
+    status: beat.status,
+    lifecycle: beat.lifecycle,
+    is_fileable: beat.is_fileable,
+    is_listed_active: beat.is_listed_active,
+    is_assignable_editor: beat.is_assignable_editor,
+    archive_only: beat.archive_only,
+    replacement_beats: beat.replacement_beats ?? [],
+    transition_started_at: beat.transition_started_at ?? null,
+    transition_effective_at: beat.transition_effective_at ?? null,
+    transition_message: beat.transition_message ?? null,
+    transition_docs_url: beat.transition_docs_url ?? null,
+    members: (beat.members ?? []).map((member) => ({
+      btc_address: member.btc_address,
+      claimed_at: member.claimed_at,
+      status: member.status,
+    })),
+  };
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -168,6 +168,15 @@ export const BRIEF_INSCRIBE_RATE_LIMIT = {
 // ── Config keys ──
 export const CONFIG_PUBLISHER_ADDRESS = "publisher_btc_address" as const;
 
+// ── Beat lifecycle / soft-retire cutover ──
+export const ACTIVE_NEWSROOM_BEAT_SLUGS = [
+  "aibtc-network",
+  "bitcoin-macro",
+  "quantum",
+] as const;
+export const ACTIVE_NEWSROOM_DAILY_APPROVED_LIMIT = 10;
+export const BEAT_TRANSITION_DOCS_URL = "https://aibtc.news/about/#beat-lifecycle" as const;
+
 // ── Canonical parent inscription ──
 /** The root ordinal inscription for the aibtc.news collection. All daily brief
  *  child inscriptions reference this parent to establish on-chain provenance. */

--- a/src/lib/do-client.ts
+++ b/src/lib/do-client.ts
@@ -38,9 +38,13 @@ async function doFetch<T>(
 // Beats
 // ---------------------------------------------------------------------------
 
-export async function listBeats(env: Env): Promise<Beat[]> {
+export async function listBeats(
+  env: Env,
+  view: "active" | "archive" | "all" = "active"
+): Promise<Beat[]> {
   const stub = getStub(env);
-  const result = await doFetch<Beat[]>(stub, "/beats");
+  const suffix = view === "active" ? "" : `?view=${encodeURIComponent(view)}`;
+  const result = await doFetch<Beat[]>(stub, `/beats${suffix}`);
   if (!result.ok) throw new Error(result.error ?? "Failed to list beats");
   if (result.data === undefined) throw new Error("Missing data in response");
   return result.data;
@@ -57,7 +61,7 @@ export async function getBeat(env: Env, slug: string): Promise<Beat | null> {
 
 export async function createBeat(
   env: Env,
-  beat: Omit<Beat, "created_at" | "updated_at">
+  beat: Pick<Beat, "slug" | "name" | "description" | "color" | "created_by">
 ): Promise<DOResult<Beat>> {
   const stub = getStub(env);
   return doFetch<Beat>(stub, "/beats", {
@@ -668,6 +672,8 @@ export interface ReportData {
   signalsToday: number;
   totalSignals: number;
   totalBeats: number;
+  preservedBeats?: number;
+  retiredBeats?: number;
   activeCorrespondents: number;
   latestBrief: { date: string; inscribed_txid: string | null; inscription_id: string | null } | null;
   topAgents: { btc_address: string; signal_count: number }[];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -10,6 +10,12 @@ import type {
   TerminalReason,
   TrackedPaymentState,
 } from "@aibtc/tx-schemas";
+import type {
+  Beat as SharedBeat,
+  BeatClaim as SharedBeatClaim,
+  BeatGracePeriodSuccess,
+  BeatMember as SharedBeatMember,
+} from "@aibtc/tx-schemas/news";
 import type { SIGNAL_STATUSES, CLASSIFIED_STATUSES } from "./constants";
 
 /**
@@ -126,42 +132,22 @@ export type AppContext = Context<{ Bindings: Env; Variables: AppVariables }>;
 /**
  * A beat is a named topic category for signals
  */
-export interface Beat {
-  readonly slug: string;
-  readonly name: string;
-  readonly description: string | null;
-  readonly color: string | null;
-  readonly created_by: string;
-  readonly created_at: string;
-  readonly updated_at: string;
-  /** Per-beat daily approval cap (null = unlimited). Added in MIGRATION_BITCOIN_MACRO_SQL. */
-  readonly daily_approved_limit?: number | null;
-  /** Per-review payment rate for the beat editor in satoshis (null = not configured). Added in migration 19. */
-  readonly editor_review_rate_sats?: number | null;
+export type Beat = SharedBeat & {
   /** Computed on read — not stored in DB */
   readonly status?: "active" | "inactive";
   /** Active members from beat_claims — populated when joined */
   readonly members?: BeatMember[];
-}
+};
 
 /**
  * A beat claim row from the beat_claims table (full row including beat_slug)
  */
-export interface BeatClaim {
-  readonly beat_slug: string;
-  readonly btc_address: string;
-  readonly claimed_at: string;
-  readonly status: "active" | "inactive";
-}
+export type BeatClaim = SharedBeatClaim;
 
 /**
  * A beat member nested inside a Beat response (beat_slug omitted since it's the parent)
  */
-export interface BeatMember {
-  readonly btc_address: string;
-  readonly claimed_at: string;
-  readonly status: "active" | "inactive";
-}
+export type BeatMember = SharedBeatMember;
 
 /**
  * A URL+title pair for signal source attribution
@@ -382,6 +368,15 @@ export interface DOResult<T> {
   error?: string;
   /** HTTP status hint from DO, present on error paths */
   status?: DOErrorStatus;
+  code?: string;
+  beat_lifecycle?: import("./beat-lifecycle").BeatLifecycle;
+  archive_only?: boolean;
+  replacement_beats?: string[];
+  transition_started_at?: string | null;
+  transition_effective_at?: string | null;
+  docs_url?: string | null;
+  message_for_agent?: string;
+  transition?: BeatGracePeriodSuccess | null;
   /** Present on approval responses — current daily cap status */
   approval_cap?: ApprovalCapInfo;
 }

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -4,8 +4,9 @@ import type { Context } from "hono";
 import type { Env, Beat, Signal, SignalStatus, Streak, Brief, Classified, ClassifiedStatus, Earning, Correction, ReferralCredit, BriefSignal, CompiledBriefData, DOResult, ApprovalCapInfo, PayoutRecord, IncludedSignalMetadata, CompiledSignalRow, PaymentStageKind, PaymentStageLifecycle, PaymentStageMaterialized, PaymentStagePayload, PaymentStageRecord, PaymentTerminalReason, PaymentTrackedState } from "../lib/types";
 import { validateSlug, validateHexColor, sanitizeString, validateDateFormat } from "../lib/validators";
 import { generateId, getPacificDate, getPacificYesterday, getPacificDayStartUTC, getPacificDayEndUTC, getNextDate } from "../lib/helpers";
-import { CLASSIFIED_DURATION_DAYS, CLASSIFIED_BRIEF_SLOTS, CLASSIFIED_BRIEF_MAX_CHARS, CLASSIFIED_STATUSES, SIGNAL_COOLDOWN_HOURS, BEAT_EXPIRY_DAYS, MAX_SIGNALS_PER_DAY, MAX_INCLUDED_SIGNALS_PER_BRIEF, MAX_APPROVED_SIGNALS_PER_DAY, SIGNAL_STATUSES, REVIEWABLE_SIGNAL_STATUSES, CONFIG_PUBLISHER_ADDRESS, BRIEF_INCLUSION_PAYOUT_SATS, WEEKLY_PRIZE_1ST_SATS, WEEKLY_PRIZE_2ND_SATS, WEEKLY_PRIZE_3RD_SATS, SCORING_WEIGHTS, PAYMENT_STAGE_TTL_MS } from "../lib/constants";
-import { SCHEMA_SQL, MIGRATION_PHASE0_SQL, MIGRATION_PAYMENTS_SQL, MIGRATION_BEAT_RESTRUCTURE_SQL, MIGRATION_SBTC_TRACKING_SQL, MIGRATION_CLASSIFIEDS_CLEANUP_SQL, MIGRATION_CLASSIFIEDS_REVIEW_SQL, MIGRATION_SNAPSHOTS_SQL, MIGRATION_BEAT_CLAIMS_SQL, MIGRATION_RETRACTION_SQL, MIGRATION_BEAT_NETWORK_FOCUS_SQL, MIGRATION_BITCOIN_MACRO_SQL, MIGRATION_QUANTUM_BEAT_SQL, MIGRATION_PAYMENT_STAGING_SQL, MIGRATION_APPROVAL_CAP_INDEX_SQL, MIGRATION_BEAT_EDITORS_SQL, MIGRATION_EDITORIAL_REVIEWS_SQL, MIGRATION_EDITOR_REVIEW_RATE_SQL, MIGRATION_CURATION_CLEANUP_SQL, MIGRATION_LEADERBOARD_INDEXES_SQL } from "./schema";
+import { CLASSIFIED_DURATION_DAYS, CLASSIFIED_BRIEF_SLOTS, CLASSIFIED_BRIEF_MAX_CHARS, CLASSIFIED_STATUSES, SIGNAL_COOLDOWN_HOURS, BEAT_EXPIRY_DAYS, MAX_SIGNALS_PER_DAY, MAX_INCLUDED_SIGNALS_PER_BRIEF, MAX_APPROVED_SIGNALS_PER_DAY, SIGNAL_STATUSES, REVIEWABLE_SIGNAL_STATUSES, CONFIG_PUBLISHER_ADDRESS, BRIEF_INCLUSION_PAYOUT_SATS, WEEKLY_PRIZE_1ST_SATS, WEEKLY_PRIZE_2ND_SATS, WEEKLY_PRIZE_3RD_SATS, SCORING_WEIGHTS, PAYMENT_STAGE_TTL_MS, BEAT_TRANSITION_DOCS_URL } from "../lib/constants";
+import { buildGraceTransition, deriveBeatLifecycleFlags, getDefaultBeatLifecycle, getDefaultReplacementBeats, parseReplacementBeats, serializeReplacementBeats, type BeatLifecycle } from "../lib/beat-lifecycle";
+import { SCHEMA_SQL, MIGRATION_PHASE0_SQL, MIGRATION_PAYMENTS_SQL, MIGRATION_BEAT_RESTRUCTURE_SQL, MIGRATION_SBTC_TRACKING_SQL, MIGRATION_CLASSIFIEDS_CLEANUP_SQL, MIGRATION_CLASSIFIEDS_REVIEW_SQL, MIGRATION_SNAPSHOTS_SQL, MIGRATION_BEAT_CLAIMS_SQL, MIGRATION_RETRACTION_SQL, MIGRATION_BEAT_NETWORK_FOCUS_SQL, MIGRATION_BITCOIN_MACRO_SQL, MIGRATION_QUANTUM_BEAT_SQL, MIGRATION_PAYMENT_STAGING_SQL, MIGRATION_APPROVAL_CAP_INDEX_SQL, MIGRATION_BEAT_EDITORS_SQL, MIGRATION_EDITORIAL_REVIEWS_SQL, MIGRATION_EDITOR_REVIEW_RATE_SQL, MIGRATION_CURATION_CLEANUP_SQL, MIGRATION_LEADERBOARD_INDEXES_SQL, MIGRATION_BEAT_LIFECYCLE_SQL } from "./schema";
 
 // ── State machine transition maps ──
 // Hoisted to module level so they are created once and are testable.
@@ -52,6 +53,146 @@ interface RawSignalRow {
 interface RawCompiledSignalRow extends CompiledSignalRow {
   reviewed_at: string | null;
   position?: number | null;
+}
+
+interface RawBeatRow {
+  slug: string;
+  name: string;
+  description: string | null;
+  color: string | null;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+  daily_approved_limit: number | null;
+  editor_review_rate_sats: number | null;
+  lifecycle?: string | null;
+  replacement_beats?: string | null;
+  transition_started_at?: string | null;
+  transition_effective_at?: string | null;
+  transition_message?: string | null;
+  transition_docs_url?: string | null;
+  last_signal_at?: string | null;
+}
+
+function normalizeBeatLifecycle(value: unknown, slug: string): BeatLifecycle {
+  if (value === "active" || value === "grace" || value === "retired") {
+    return value;
+  }
+  return getDefaultBeatLifecycle(slug);
+}
+
+function computeBeatActivityStatus(lastSignalAt: string | null | undefined, nowMs = Date.now()): "active" | "inactive" {
+  const expiryMs = BEAT_EXPIRY_DAYS * 24 * 3600 * 1000;
+  return lastSignalAt && nowMs - new Date(lastSignalAt).getTime() < expiryMs
+    ? "active"
+    : "inactive";
+}
+
+function normalizeIsoDateTime(value: string): string {
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? value : parsed.toISOString();
+}
+
+function normalizeNullableIsoDateTime(value: string | null | undefined): string | null {
+  return value ? normalizeIsoDateTime(value) : null;
+}
+
+function rowToBeat(
+  row: Record<string, unknown>,
+  members: Beat["members"] = [],
+  nowMs = Date.now()
+): Beat {
+  const raw = row as unknown as RawBeatRow;
+  const lifecycle = normalizeBeatLifecycle(raw.lifecycle, raw.slug);
+  const flags = deriveBeatLifecycleFlags(lifecycle);
+  return {
+    slug: raw.slug,
+    name: raw.name,
+    description: raw.description ?? null,
+    color: raw.color ?? null,
+    created_by: raw.created_by,
+    created_at: normalizeIsoDateTime(raw.created_at),
+    updated_at: normalizeIsoDateTime(raw.updated_at),
+    daily_approved_limit: raw.daily_approved_limit ?? null,
+    editor_review_rate_sats: raw.editor_review_rate_sats ?? null,
+    status: computeBeatActivityStatus(raw.last_signal_at, nowMs),
+    lifecycle,
+    is_fileable: flags.is_fileable,
+    is_listed_active: flags.is_listed_active,
+    is_assignable_editor: flags.is_assignable_editor,
+    archive_only: flags.archive_only,
+    replacement_beats: parseReplacementBeats(raw.replacement_beats, raw.slug),
+    transition_started_at: normalizeNullableIsoDateTime(raw.transition_started_at),
+    transition_effective_at: normalizeNullableIsoDateTime(raw.transition_effective_at),
+    transition_message: raw.transition_message ?? null,
+    transition_docs_url: raw.transition_docs_url ?? BEAT_TRANSITION_DOCS_URL,
+    members,
+  };
+}
+
+function buildGraceBeatConflict(
+  beat: Beat,
+  action: "join" | "assign_editor"
+): DOResult<never> {
+  const actionLabel =
+    action === "join" ? "new memberships" : "editor assignments";
+  return {
+    ok: false,
+    error: `Beat "${beat.slug}" is in grace and no longer accepts ${actionLabel}`,
+    status: 409,
+  };
+}
+
+function buildRetiredBeatError(
+  beat: Beat,
+  action: "file" | "join" | "assign_editor"
+): DOResult<never> {
+  const replacementBeats = beat.replacement_beats ?? getDefaultReplacementBeats(beat.slug);
+  const docsUrl = beat.transition_docs_url ?? BEAT_TRANSITION_DOCS_URL;
+  return {
+    ok: false,
+    error: `Beat "${beat.slug}" is retired and no longer accepts new ${
+      action === "assign_editor"
+        ? "editor assignments"
+        : action === "join"
+          ? "memberships"
+          : "filings"
+    }`,
+    status: 409,
+    code: "beat_retired",
+    beat_lifecycle: "retired",
+    archive_only: true,
+    replacement_beats: replacementBeats,
+    transition_started_at: beat.transition_started_at ?? null,
+    transition_effective_at: beat.transition_effective_at ?? null,
+    docs_url: docsUrl,
+    message_for_agent:
+      beat.transition_message ??
+      "This beat is archive-only. Choose an active beat and retry.",
+  };
+}
+
+function getBeatBySlug(
+  sql: DurableObjectState["storage"]["sql"],
+  slug: string
+): Beat | null {
+  const rows = sql
+    .exec(
+      `SELECT b.*, MAX(s.created_at) as last_signal_at
+       FROM beats b
+       LEFT JOIN beat_claims bc ON b.slug = bc.beat_slug AND bc.status = 'active'
+       LEFT JOIN signals s ON bc.btc_address = s.btc_address
+         AND s.beat_slug = b.slug
+         AND s.correction_of IS NULL
+       WHERE b.slug = ?
+       GROUP BY b.slug`,
+      slug
+    )
+    .toArray();
+  if (rows.length === 0) {
+    return null;
+  }
+  return rowToBeat(rows[0] as Record<string, unknown>);
 }
 
 /**
@@ -225,6 +366,15 @@ function verifyEditorOrPublisher(
     }
   }
 
+  const beat = getBeatBySlug(sql, beatSlug);
+  if (!beat || !beat.is_assignable_editor) {
+    return {
+      ok: false,
+      error: "Access denied: editor workflow is only available on active beats",
+      status: 403,
+    };
+  }
+
   // Check active editor for the specified beat
   const editorRows = sql
     .exec(
@@ -286,7 +436,8 @@ export class NewsDO extends DurableObject<Env> {
     // 19 = Editor review rate — editor_review_rate_sats column on beats table
     // 20 = Curation cleanup — fix Mar 28-29 inscription IDs + void 312 orphaned earnings (#339)
     // 21 = Leaderboard composite indexes — accelerate 30-day rolling window queries (#319)
-    const CURRENT_MIGRATION_VERSION = 21;
+    // 22 = Beat lifecycle contract — active/grace/retired soft-retire cutover
+    const CURRENT_MIGRATION_VERSION = 22;
     const versionRows = this.ctx.storage.sql
       .exec("SELECT value FROM config WHERE key = 'migration_version'")
       .toArray();
@@ -572,6 +723,19 @@ export class NewsDO extends DurableObject<Env> {
         }
       }
 
+      if (appliedVersion < 22) {
+        for (const stmt of MIGRATION_BEAT_LIFECYCLE_SQL) {
+          try {
+            this.ctx.storage.sql.exec(stmt);
+          } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            if (!msg.includes("duplicate column") && !msg.includes("already exists")) {
+              console.error("Beat lifecycle migration failed:", e);
+            }
+          }
+        }
+      }
+
       // Record current migration version so future cold starts skip all of the above.
       this.ctx.storage.sql.exec(
         "INSERT INTO config (key, value) VALUES ('migration_version', ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = datetime('now')",
@@ -654,12 +818,15 @@ export class NewsDO extends DurableObject<Env> {
         return c.json({ ok: false, error: pubCheck.error } satisfies DOResult<unknown>, pubCheck.status);
       }
 
-      // Verify beat exists
-      const beatRows = this.ctx.storage.sql
-        .exec("SELECT slug FROM beats WHERE slug = ?", beat_slug as string)
-        .toArray();
-      if (beatRows.length === 0) {
+      const beat = getBeatBySlug(this.ctx.storage.sql, beat_slug as string);
+      if (!beat) {
         return c.json({ ok: false, error: `Beat "${beat_slug as string}" not found` } satisfies DOResult<unknown>, 404);
+      }
+      if (!beat.is_assignable_editor) {
+        const lifecycleError = beat.lifecycle === "retired"
+          ? buildRetiredBeatError(beat, "assign_editor")
+          : buildGraceBeatConflict(beat, "assign_editor");
+        return c.json(lifecycleError, lifecycleError.status);
       }
 
       const now = new Date().toISOString();
@@ -733,6 +900,10 @@ export class NewsDO extends DurableObject<Env> {
     // GET /beat-editors/:slug — List active editors for a beat
     this.router.get("/beat-editors/:slug", (c) => {
       const slug = c.req.param("slug");
+      const beat = getBeatBySlug(this.ctx.storage.sql, slug);
+      if (!beat || !beat.is_assignable_editor) {
+        return c.json({ ok: true, data: { beat_slug: slug, editors: [] } } satisfies DOResult<unknown>);
+      }
       const rows = this.ctx.storage.sql
         .exec(
           "SELECT * FROM beat_editors WHERE beat_slug = ? AND status = 'active' ORDER BY registered_at ASC",
@@ -747,7 +918,13 @@ export class NewsDO extends DurableObject<Env> {
       const address = c.req.param("address");
       const rows = this.ctx.storage.sql
         .exec(
-          "SELECT * FROM beat_editors WHERE btc_address = ? AND status = 'active' ORDER BY registered_at ASC",
+          `SELECT be.*
+           FROM beat_editors be
+           JOIN beats b ON be.beat_slug = b.slug
+           WHERE be.btc_address = ?
+             AND be.status = 'active'
+             AND b.lifecycle = 'active'
+           ORDER BY be.registered_at ASC`,
           address
         )
         .toArray();
@@ -1130,8 +1307,15 @@ export class NewsDO extends DurableObject<Env> {
     // Beats CRUD
     // -------------------------------------------------------------------------
 
-    // GET /beats — list all beats ordered by name, with computed status
+    // GET /beats — list beats by lifecycle view
     this.router.get("/beats", (c) => {
+      const view = c.req.query("view") ?? "active";
+      const lifecycleWhere =
+        view === "archive"
+          ? "WHERE b.lifecycle IN ('grace', 'retired')"
+          : view === "all"
+            ? ""
+            : "WHERE b.lifecycle = 'active'";
       const rows = this.ctx.storage.sql
         .exec(
           `SELECT b.*, MAX(s.created_at) as last_signal_at
@@ -1140,6 +1324,7 @@ export class NewsDO extends DurableObject<Env> {
            LEFT JOIN signals s ON bc.btc_address = s.btc_address
              AND s.beat_slug = b.slug
              AND s.correction_of IS NULL
+           ${lifecycleWhere}
            GROUP BY b.slug
            ORDER BY b.name`
         )
@@ -1153,7 +1338,7 @@ export class NewsDO extends DurableObject<Env> {
            ORDER BY claimed_at`
         )
         .toArray();
-      const claimsByBeat = new Map<string, Array<{ btc_address: string; claimed_at: string; status: string }>>();
+      const claimsByBeat = new Map<string, NonNullable<Beat["members"]>>();
       for (const cr of claimRows) {
         const claim = cr as Record<string, unknown>;
         const slug = claim.beat_slug as string;
@@ -1161,32 +1346,22 @@ export class NewsDO extends DurableObject<Env> {
         claimsByBeat.get(slug)!.push({
           btc_address: claim.btc_address as string,
           claimed_at: claim.claimed_at as string,
-          status: claim.status as string,
+          status: claim.status as "active" | "inactive",
         });
       }
 
-      const expiryMs = BEAT_EXPIRY_DAYS * 24 * 3600 * 1000;
       const now = Date.now();
-      const beats = rows.map((r) => {
-        const row = r as Record<string, unknown>;
-        const lastSignalAt = row.last_signal_at as string | null;
-        const status: "active" | "inactive" =
-          lastSignalAt && now - new Date(lastSignalAt).getTime() < expiryMs
-            ? "active"
-            : "inactive";
-        return {
-          slug: row.slug,
-          name: row.name,
-          description: row.description,
-          color: row.color,
-          created_by: row.created_by,
-          created_at: row.created_at,
-          updated_at: row.updated_at,
-          status,
-          members: claimsByBeat.get(row.slug as string) ?? [],
-        } as Beat;
-      });
+      const beats = rows.map((r) =>
+        rowToBeat(r as Record<string, unknown>, claimsByBeat.get((r as Record<string, unknown>).slug as string) ?? [], now)
+      );
       return c.json({ ok: true, data: beats } satisfies DOResult<Beat[]>);
+    });
+
+    this.router.get("/beats/archive", (c) => {
+      const url = new URL(c.req.url);
+      url.pathname = "/beats";
+      url.searchParams.set("view", "archive");
+      return this.router.fetch(new Request(url, c.req.raw));
     });
 
     // GET /beats/membership — query beats joined by a specific agent
@@ -1202,12 +1377,13 @@ export class NewsDO extends DurableObject<Env> {
       // Single JOIN: all beats with membership info for this agent
       const rows = this.ctx.storage.sql
         .exec(
-          `SELECT b.slug, bc.claimed_at, bc.status
+          `SELECT b.slug, b.lifecycle, bc.claimed_at, bc.status
            FROM beats b
            LEFT JOIN beat_claims bc
              ON bc.beat_slug = b.slug
             AND bc.btc_address = ?
             AND bc.status = 'active'
+           WHERE b.lifecycle = 'active'
            ORDER BY b.slug`,
           btcAddress
         )
@@ -1234,32 +1410,13 @@ export class NewsDO extends DurableObject<Env> {
     // GET /beats/:slug — get a single beat by slug, with computed status
     this.router.get("/beats/:slug", (c) => {
       const slug = c.req.param("slug");
-      const rows = this.ctx.storage.sql
-        .exec(
-          `SELECT b.*, MAX(s.created_at) as last_signal_at
-           FROM beats b
-           LEFT JOIN beat_claims bc ON b.slug = bc.beat_slug AND bc.status = 'active'
-           LEFT JOIN signals s ON bc.btc_address = s.btc_address
-             AND s.beat_slug = b.slug
-             AND s.correction_of IS NULL
-           WHERE b.slug = ?
-           GROUP BY b.slug`,
-          slug
-        )
-        .toArray();
-      if (rows.length === 0) {
+      const beat = getBeatBySlug(this.ctx.storage.sql, slug);
+      if (!beat) {
         return c.json(
           { ok: false, error: `Beat "${slug}" not found` } satisfies DOResult<Beat>,
           404
         );
       }
-      const row = rows[0] as Record<string, unknown>;
-      const lastSignalAt = row.last_signal_at as string | null;
-      const expiryMs = BEAT_EXPIRY_DAYS * 24 * 3600 * 1000;
-      const status: "active" | "inactive" =
-        lastSignalAt && Date.now() - new Date(lastSignalAt).getTime() < expiryMs
-          ? "active"
-          : "inactive";
 
       // Fetch members for this beat
       const memberRows = this.ctx.storage.sql
@@ -1272,27 +1429,20 @@ export class NewsDO extends DurableObject<Env> {
         )
         .toArray();
 
-      const beat: Beat = {
-        slug: row.slug as string,
-        name: row.name as string,
-        description: row.description as string | null,
-        color: row.color as string | null,
-        created_by: row.created_by as string,
-        created_at: row.created_at as string,
-        updated_at: row.updated_at as string,
-        daily_approved_limit: row.daily_approved_limit as number | null,
-        editor_review_rate_sats: row.editor_review_rate_sats as number | null,
-        status,
-        members: memberRows.map((r) => {
-          const mr = r as Record<string, unknown>;
-          return {
-            btc_address: mr.btc_address as string,
-            claimed_at: mr.claimed_at as string,
-            status: mr.status as "active" | "inactive",
-          };
-        }),
-      };
-      return c.json({ ok: true, data: beat } satisfies DOResult<Beat>);
+      return c.json({
+        ok: true,
+        data: {
+          ...beat,
+          members: memberRows.map((r) => {
+            const mr = r as Record<string, unknown>;
+            return {
+              btc_address: mr.btc_address as string,
+              claimed_at: mr.claimed_at as string,
+              status: mr.status as "active" | "inactive",
+            };
+          }),
+        },
+      } satisfies DOResult<Beat>);
     });
 
     // POST /beats — create a new beat
@@ -1338,24 +1488,14 @@ export class NewsDO extends DurableObject<Env> {
       }
 
       // Check for existing beat — allow join if active, reclaim if inactive
-      const existing = this.ctx.storage.sql
-        .exec(
-          `SELECT b.*, MAX(s.created_at) as last_signal_at
-           FROM beats b
-           LEFT JOIN beat_claims bc ON b.slug = bc.beat_slug AND bc.status = 'active'
-           LEFT JOIN signals s ON bc.btc_address = s.btc_address
-             AND s.beat_slug = b.slug
-             AND s.correction_of IS NULL
-           WHERE b.slug = ?
-           GROUP BY b.slug`,
-          slug as string
-        )
-        .toArray();
-      if (existing.length > 0) {
-        const row = existing[0] as Record<string, unknown>;
-        const lastSignalAt = row.last_signal_at as string | null;
-        const expiryMs = BEAT_EXPIRY_DAYS * 24 * 3600 * 1000;
-        const isActive = lastSignalAt && Date.now() - new Date(lastSignalAt).getTime() < expiryMs;
+      const existingBeat = getBeatBySlug(this.ctx.storage.sql, slug as string);
+      if (existingBeat) {
+        if (existingBeat.lifecycle !== "active") {
+          const lifecycleError = existingBeat.lifecycle === "retired"
+            ? buildRetiredBeatError(existingBeat, "join")
+            : buildGraceBeatConflict(existingBeat, "join");
+          return c.json(lifecycleError, lifecycleError.status);
+        }
 
         // Check if agent already has an active claim
         const existingClaim = this.ctx.storage.sql
@@ -1375,7 +1515,6 @@ export class NewsDO extends DurableObject<Env> {
           );
         }
 
-        // Active or inactive — agent can join via beat_claims
         const now = new Date().toISOString();
         this.ctx.storage.sql.exec(
           `INSERT INTO beat_claims (beat_slug, btc_address, claimed_at, status)
@@ -1386,8 +1525,7 @@ export class NewsDO extends DurableObject<Env> {
           now
         );
 
-        // If beat was inactive (no active members with recent signals), update updated_at
-        if (!isActive) {
+        if (existingBeat.status !== "active") {
           this.ctx.storage.sql.exec(
             "UPDATE beats SET updated_at = ? WHERE slug = ?",
             now,
@@ -1395,11 +1533,8 @@ export class NewsDO extends DurableObject<Env> {
           );
         }
 
-        const reclaimed = this.ctx.storage.sql
-          .exec("SELECT * FROM beats WHERE slug = ?", slug as string)
-          .toArray();
-        const beat = reclaimed[0] as unknown as Beat;
-        return c.json({ ok: true, data: { ...beat, status: isActive ? "active" as const : "inactive" as const } } satisfies DOResult<Beat>, 200);
+        const refreshed = getBeatBySlug(this.ctx.storage.sql, slug as string);
+        return c.json({ ok: true, data: refreshed! } satisfies DOResult<Beat>, 200);
       }
 
       // Only the Publisher can create new beats
@@ -1421,15 +1556,16 @@ export class NewsDO extends DurableObject<Env> {
       const beatCreatedBy = created_by as string;
 
       this.ctx.storage.sql.exec(
-        `INSERT INTO beats (slug, name, description, color, created_by, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO beats (slug, name, description, color, created_by, created_at, updated_at, lifecycle, replacement_beats, transition_docs_url)
+         VALUES (?, ?, ?, ?, ?, ?, ?, 'active', '[]', ?)`,
         beatSlug,
         beatName,
         beatDescription,
         beatColor,
         beatCreatedBy,
         now,
-        now
+        now,
+        BEAT_TRANSITION_DOCS_URL
       );
 
       // Also create the initial beat_claims entry for the creator
@@ -1441,12 +1577,7 @@ export class NewsDO extends DurableObject<Env> {
         now
       );
 
-      const rows = this.ctx.storage.sql
-        .exec("SELECT * FROM beats WHERE slug = ?", beatSlug)
-        .toArray();
-      const beat = rows[0] as unknown as Beat;
-
-      return c.json({ ok: true, data: beat } satisfies DOResult<Beat>, 201);
+      return c.json({ ok: true, data: getBeatBySlug(this.ctx.storage.sql, beatSlug)! } satisfies DOResult<Beat>, 201);
     });
 
     // DELETE /beats/:slug — delete a beat (Publisher-only)
@@ -1617,12 +1748,86 @@ export class NewsDO extends DurableObject<Env> {
         params.push(reviewRate ?? null);
       }
 
+      if (body.lifecycle !== undefined) {
+        const lifecycle = body.lifecycle as string | null;
+        if (lifecycle !== "active" && lifecycle !== "grace" && lifecycle !== "retired") {
+          return c.json(
+            {
+              ok: false,
+              error: "lifecycle must be one of: active, grace, retired",
+            } satisfies DOResult<Beat>,
+            400
+          );
+        }
+        setClauses.push("lifecycle = ?");
+        params.push(lifecycle);
+      }
+
+      if (body.replacement_beats !== undefined) {
+        const replacementBeats = body.replacement_beats;
+        if (
+          !Array.isArray(replacementBeats) ||
+          replacementBeats.some((slug) => typeof slug !== "string" || !validateSlug(slug))
+        ) {
+          return c.json(
+            {
+              ok: false,
+              error: "replacement_beats must be an array of beat slugs",
+            } satisfies DOResult<Beat>,
+            400
+          );
+        }
+        setClauses.push("replacement_beats = ?");
+        params.push(serializeReplacementBeats(replacementBeats as string[], slug));
+      }
+
+      if (body.transition_started_at !== undefined) {
+        const value = body.transition_started_at as string | null;
+        if (value !== null && Number.isNaN(new Date(value).getTime())) {
+          return c.json(
+            { ok: false, error: "transition_started_at must be a valid ISO-8601 timestamp or null" } satisfies DOResult<Beat>,
+            400
+          );
+        }
+        setClauses.push("transition_started_at = ?");
+        params.push(value);
+      }
+
+      if (body.transition_effective_at !== undefined) {
+        const value = body.transition_effective_at as string | null;
+        if (value !== null && Number.isNaN(new Date(value).getTime())) {
+          return c.json(
+            { ok: false, error: "transition_effective_at must be a valid ISO-8601 timestamp or null" } satisfies DOResult<Beat>,
+            400
+          );
+        }
+        setClauses.push("transition_effective_at = ?");
+        params.push(value);
+      }
+
+      if (body.transition_message !== undefined) {
+        setClauses.push("transition_message = ?");
+        params.push(body.transition_message ? sanitizeString(body.transition_message, 280) : null);
+      }
+
+      if (body.transition_docs_url !== undefined) {
+        const docsUrl = body.transition_docs_url;
+        if (docsUrl !== null && typeof docsUrl !== "string") {
+          return c.json(
+            { ok: false, error: "transition_docs_url must be a string or null" } satisfies DOResult<Beat>,
+            400
+          );
+        }
+        setClauses.push("transition_docs_url = ?");
+        params.push(docsUrl ? sanitizeString(docsUrl, 500) : null);
+      }
+
       if (setClauses.length === 0) {
         return c.json(
           {
             ok: false,
             error:
-              "No updatable fields provided (name, description, color, daily_approved_limit, editor_review_rate_sats)",
+              "No updatable fields provided (name, description, color, daily_approved_limit, editor_review_rate_sats, lifecycle, replacement_beats, transition_started_at, transition_effective_at, transition_message, transition_docs_url)",
           } satisfies DOResult<Beat>,
           400
         );
@@ -1638,12 +1843,7 @@ export class NewsDO extends DurableObject<Env> {
         ...params
       );
 
-      const rows = this.ctx.storage.sql
-        .exec("SELECT * FROM beats WHERE slug = ?", slug)
-        .toArray();
-      const beat = rows[0] as unknown as Beat;
-
-      return c.json({ ok: true, data: beat } satisfies DOResult<Beat>);
+      return c.json({ ok: true, data: getBeatBySlug(this.ctx.storage.sql, slug)! } satisfies DOResult<Beat>);
     });
 
     // -------------------------------------------------------------------------
@@ -1899,15 +2099,16 @@ export class NewsDO extends DurableObject<Env> {
 
       const { beat_slug, btc_address, headline, body: signalBody, sources, tags } = body;
 
-      // Validate beat exists
-      const beatRows = this.ctx.storage.sql
-        .exec("SELECT 1 FROM beats WHERE slug = ?", beat_slug as string)
-        .toArray();
-      if (beatRows.length === 0) {
+      const beat = getBeatBySlug(this.ctx.storage.sql, beat_slug as string);
+      if (!beat) {
         return c.json(
           { ok: false, error: `Beat "${beat_slug as string}" not found` } satisfies DOResult<Signal>,
           404
         );
+      }
+      if (beat.lifecycle === "retired") {
+        const lifecycleError = buildRetiredBeatError(beat, "file");
+        return c.json(lifecycleError, lifecycleError.status);
       }
 
       // Verify agent is a member of this beat
@@ -1919,6 +2120,10 @@ export class NewsDO extends DurableObject<Env> {
         )
         .toArray();
       if (claimRows.length === 0) {
+        if (beat.lifecycle === "grace") {
+          const lifecycleError = buildGraceBeatConflict(beat, "join");
+          return c.json(lifecycleError, lifecycleError.status);
+        }
         return c.json(
           { ok: false, error: `You must claim beat "${beat_slug as string}" before filing signals on it` } satisfies DOResult<Signal>,
           403
@@ -2093,7 +2298,11 @@ export class NewsDO extends DurableObject<Env> {
 
       const signal = rowToSignal(created[0] as Record<string, unknown>);
 
-      return c.json({ ok: true, data: signal } satisfies DOResult<Signal>, 201);
+      return c.json({
+        ok: true,
+        data: signal,
+        transition: buildGraceTransition(beat),
+      } satisfies DOResult<Signal>, 201);
     });
 
     // PATCH /signals/:id — correction: create new signal with correction_of pointing to original
@@ -2767,31 +2976,26 @@ export class NewsDO extends DurableObject<Env> {
            LEFT JOIN signals s ON bc_all.btc_address = s.btc_address
              AND s.beat_slug = b.slug
              AND s.correction_of IS NULL
-           WHERE bc.btc_address = ? AND bc.status = 'active'
+           WHERE bc.btc_address = ? AND bc.status = 'active' AND b.lifecycle = 'active'
            GROUP BY b.slug
            ORDER BY bc.claimed_at`,
           address
         )
         .toArray();
 
-      const expiryMs = BEAT_EXPIRY_DAYS * 24 * 3600 * 1000;
       const agentBeats: Array<Record<string, unknown> & { beatStatus: "active" | "inactive" }> = [];
       for (const r of beatRows) {
-        const row = r as Record<string, unknown>;
-        const lastSignalAt = row.last_signal_at as string | null;
-        const status: "active" | "inactive" =
-          lastSignalAt && now.getTime() - new Date(lastSignalAt).getTime() < expiryMs
-            ? "active"
-            : "inactive";
+        const beatRecord = rowToBeat(r as Record<string, unknown>, [], now.getTime());
         agentBeats.push({
-          slug: row.slug,
-          name: row.name,
-          description: row.description,
-          color: row.color,
-          created_by: row.created_by,
-          created_at: row.created_at,
-          updated_at: row.updated_at,
-          beatStatus: status,
+          slug: beatRecord.slug,
+          name: beatRecord.name,
+          description: beatRecord.description,
+          color: beatRecord.color,
+          created_by: beatRecord.created_by,
+          created_at: beatRecord.created_at,
+          updated_at: beatRecord.updated_at,
+          lifecycle: beatRecord.lifecycle,
+          beatStatus: beatRecord.status ?? "inactive",
         });
       }
 
@@ -2958,9 +3162,15 @@ export class NewsDO extends DurableObject<Env> {
         )
         .toArray();
 
-      // Total beats
+      // Beat counts
       const beatsRows = this.ctx.storage.sql
         .exec("SELECT COUNT(*) as count FROM beats")
+        .toArray();
+      const activeBeatsRows = this.ctx.storage.sql
+        .exec("SELECT COUNT(*) as count FROM beats WHERE lifecycle = 'active'")
+        .toArray();
+      const retiredBeatsRows = this.ctx.storage.sql
+        .exec("SELECT COUNT(*) as count FROM beats WHERE lifecycle = 'retired'")
         .toArray();
 
       // Total signals all time (excluding corrections)
@@ -2989,7 +3199,9 @@ export class NewsDO extends DurableObject<Env> {
         .toArray();
 
       const signalsToday = (signalsTodayRows[0] as Record<string, unknown>)?.count ?? 0;
-      const totalBeats = (beatsRows[0] as Record<string, unknown>)?.count ?? 0;
+      const preservedBeats = (beatsRows[0] as Record<string, unknown>)?.count ?? 0;
+      const totalBeats = (activeBeatsRows[0] as Record<string, unknown>)?.count ?? 0;
+      const retiredBeats = (retiredBeatsRows[0] as Record<string, unknown>)?.count ?? 0;
       const totalSignals = (totalSignalsRows[0] as Record<string, unknown>)?.count ?? 0;
       const activeCorrespondents = (activeRows[0] as Record<string, unknown>)?.count ?? 0;
 
@@ -3001,6 +3213,8 @@ export class NewsDO extends DurableObject<Env> {
           signalsToday,
           totalSignals,
           totalBeats,
+          preservedBeats,
+          retiredBeats,
           activeCorrespondents,
           latestBrief: briefRows[0] ?? null,
           topAgents: topAgentsRows,
@@ -4101,10 +4315,12 @@ export class NewsDO extends DurableObject<Env> {
            LEFT JOIN signals s ON bc.btc_address = s.btc_address
              AND s.beat_slug = b.slug
              AND s.correction_of IS NULL
+           WHERE b.lifecycle = 'active'
            GROUP BY b.slug
            ORDER BY b.name`
         )
-        .toArray();
+        .toArray()
+        .map((row) => rowToBeat(row as Record<string, unknown>));
 
       // Fetch active claims for buildBeatsByAddress
       const claims = this.ctx.storage.sql
@@ -4143,7 +4359,7 @@ export class NewsDO extends DurableObject<Env> {
         .toArray();
       const briefDates = briefDateRows.map((r) => (r as { date: string }).date);
 
-      // Beats (with status computation via beat_claims)
+      // Active beats only for live surfaces
       const beatRows = this.ctx.storage.sql
         .exec(
           `SELECT b.*, MAX(s.created_at) as last_signal_at
@@ -4152,6 +4368,7 @@ export class NewsDO extends DurableObject<Env> {
            LEFT JOIN signals s ON bc.btc_address = s.btc_address
              AND s.beat_slug = b.slug
              AND s.correction_of IS NULL
+           WHERE b.lifecycle = 'active'
            GROUP BY b.slug
            ORDER BY b.name`
         )
@@ -4164,26 +4381,7 @@ export class NewsDO extends DurableObject<Env> {
         )
         .toArray();
 
-      const expiryMs = BEAT_EXPIRY_DAYS * 24 * 3600 * 1000;
-      const now = Date.now();
-      const beats = beatRows.map((r) => {
-        const row = r as Record<string, unknown>;
-        const lastSignalAt = row.last_signal_at as string | null;
-        const status: "active" | "inactive" =
-          lastSignalAt && now - new Date(lastSignalAt).getTime() < expiryMs
-            ? "active"
-            : "inactive";
-        return {
-          slug: row.slug,
-          name: row.name,
-          description: row.description,
-          color: row.color,
-          created_by: row.created_by,
-          created_at: row.created_at,
-          updated_at: row.updated_at,
-          status,
-        } as Beat;
-      });
+      const beats = beatRows.map((r) => rowToBeat(r as Record<string, unknown>));
 
       // Classifieds (active approved only)
       const classifiedRows = this.ctx.storage.sql
@@ -4456,6 +4654,8 @@ export class NewsDO extends DurableObject<Env> {
       }
 
       const inserted: Record<string, number> = {
+        beats: 0,
+        beat_claims: 0,
         signals: 0,
         signal_tags: 0,
         brief_signals: 0,
@@ -4464,6 +4664,55 @@ export class NewsDO extends DurableObject<Env> {
         streaks: 0,
         leaderboard_snapshots: 0,
       };
+
+      if (Array.isArray(body.beats)) {
+        for (const row of body.beats as Array<Record<string, unknown>>) {
+          try {
+            const slug = row.slug as string;
+            this.ctx.storage.sql.exec(
+              `INSERT OR REPLACE INTO beats
+               (slug, name, description, color, created_by, created_at, updated_at, lifecycle, replacement_beats, transition_started_at, transition_effective_at, transition_message, transition_docs_url, daily_approved_limit, editor_review_rate_sats)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+              slug,
+              row.name as string,
+              (row.description as string | null) ?? null,
+              (row.color as string | null) ?? null,
+              (row.created_by as string) ?? "system",
+              (row.created_at as string) ?? new Date().toISOString(),
+              (row.updated_at as string) ?? (row.created_at as string) ?? new Date().toISOString(),
+              normalizeBeatLifecycle(row.lifecycle, slug),
+              serializeReplacementBeats(row.replacement_beats as string[] | undefined, slug),
+              (row.transition_started_at as string | null) ?? null,
+              (row.transition_effective_at as string | null) ?? null,
+              (row.transition_message as string | null) ?? null,
+              (row.transition_docs_url as string | null) ?? BEAT_TRANSITION_DOCS_URL,
+              (row.daily_approved_limit as number | null) ?? null,
+              (row.editor_review_rate_sats as number | null) ?? null
+            );
+            inserted.beats++;
+          } catch {
+            // Skip invalid rows silently
+          }
+        }
+      }
+
+      if (Array.isArray(body.beat_claims)) {
+        for (const row of body.beat_claims as Array<Record<string, unknown>>) {
+          try {
+            this.ctx.storage.sql.exec(
+              `INSERT OR REPLACE INTO beat_claims (beat_slug, btc_address, claimed_at, status)
+               VALUES (?, ?, ?, ?)`,
+              row.beat_slug as string,
+              row.btc_address as string,
+              (row.claimed_at as string) ?? new Date().toISOString(),
+              (row.status as string) ?? "active"
+            );
+            inserted.beat_claims++;
+          } catch {
+            // Skip invalid rows silently
+          }
+        }
+      }
 
       // Seed signals
       if (Array.isArray(body.signals)) {

--- a/src/objects/schema.ts
+++ b/src/objects/schema.ts
@@ -16,7 +16,15 @@ CREATE TABLE IF NOT EXISTS beats (
   color       TEXT,
   created_by  TEXT NOT NULL,
   created_at  TEXT NOT NULL,
-  updated_at  TEXT NOT NULL
+  updated_at  TEXT NOT NULL,
+  lifecycle   TEXT NOT NULL DEFAULT 'active',
+  replacement_beats TEXT NOT NULL DEFAULT '[]',
+  transition_started_at TEXT,
+  transition_effective_at TEXT,
+  transition_message TEXT,
+  transition_docs_url TEXT,
+  daily_approved_limit INTEGER DEFAULT NULL,
+  editor_review_rate_sats INTEGER DEFAULT NULL
 );
 
 CREATE TABLE IF NOT EXISTS signals (
@@ -139,6 +147,7 @@ CREATE INDEX IF NOT EXISTS idx_corrections_address      ON corrections(btc_addre
 CREATE INDEX IF NOT EXISTS idx_referral_scout           ON referral_credits(scout_address);
 CREATE INDEX IF NOT EXISTS idx_referral_recruit         ON referral_credits(recruit_address);
 CREATE INDEX IF NOT EXISTS idx_payment_staging_status   ON payment_staging(stage_status);
+CREATE INDEX IF NOT EXISTS idx_beats_lifecycle          ON beats(lifecycle);
 `;
 
 /**
@@ -621,4 +630,73 @@ export const MIGRATION_LEADERBOARD_INDEXES_SQL = [
   "CREATE INDEX IF NOT EXISTS idx_brief_signals_created_retracted ON brief_signals(created_at, retracted_at)",
   "CREATE INDEX IF NOT EXISTS idx_corrections_status_created ON corrections(status, created_at)",
   "CREATE INDEX IF NOT EXISTS idx_referral_credits_credited ON referral_credits(credited_at)",
+] as const;
+
+/**
+ * Migration 22 — three-beat soft-retire lifecycle contract.
+ *
+ * Adds first-class lifecycle/transition metadata to beats, restores
+ * aibtc-network as a live beat, retires all non-launch beats by default,
+ * and sets the 10-per-day cap on the 3 active beats.
+ */
+export const MIGRATION_BEAT_LIFECYCLE_SQL = [
+  "ALTER TABLE beats ADD COLUMN lifecycle TEXT NOT NULL DEFAULT 'active'",
+  "ALTER TABLE beats ADD COLUMN replacement_beats TEXT NOT NULL DEFAULT '[]'",
+  "ALTER TABLE beats ADD COLUMN transition_started_at TEXT",
+  "ALTER TABLE beats ADD COLUMN transition_effective_at TEXT",
+  "ALTER TABLE beats ADD COLUMN transition_message TEXT",
+  "ALTER TABLE beats ADD COLUMN transition_docs_url TEXT",
+  "CREATE INDEX IF NOT EXISTS idx_beats_lifecycle ON beats(lifecycle)",
+  `INSERT INTO beats (slug, name, description, color, created_by, created_at, updated_at, lifecycle, replacement_beats, transition_docs_url, daily_approved_limit)
+   VALUES (
+     'aibtc-network',
+     'AIBTC Network',
+     'Network-wide AIBTC activity: launches, partnerships, agent coordination, platform milestones, and consequential developments that span the broader newsroom.',
+     '#1E88E5',
+     'system',
+     datetime('now'),
+     datetime('now'),
+     'active',
+     '[]',
+     'https://aibtc.news/about/#beat-lifecycle',
+     10
+   )
+   ON CONFLICT(slug) DO UPDATE SET
+     name = excluded.name,
+     description = excluded.description,
+     color = excluded.color,
+     updated_at = datetime('now'),
+     lifecycle = 'active',
+     replacement_beats = '[]',
+     transition_started_at = NULL,
+     transition_effective_at = NULL,
+     transition_message = NULL,
+     transition_docs_url = 'https://aibtc.news/about/#beat-lifecycle',
+     daily_approved_limit = 10`,
+  `UPDATE beats
+      SET lifecycle = CASE
+        WHEN slug IN ('aibtc-network', 'bitcoin-macro', 'quantum') THEN 'active'
+        ELSE 'retired'
+      END,
+          replacement_beats = CASE
+        WHEN slug IN ('aibtc-network', 'bitcoin-macro', 'quantum') THEN '[]'
+        ELSE '["aibtc-network","bitcoin-macro","quantum"]'
+      END,
+          transition_started_at = CASE
+        WHEN slug IN ('aibtc-network', 'bitcoin-macro', 'quantum') THEN NULL
+        ELSE transition_started_at
+      END,
+          transition_effective_at = CASE
+        WHEN slug IN ('aibtc-network', 'bitcoin-macro', 'quantum') THEN NULL
+        ELSE transition_effective_at
+      END,
+          transition_message = CASE
+        WHEN slug IN ('aibtc-network', 'bitcoin-macro', 'quantum') THEN NULL
+        ELSE COALESCE(transition_message, 'This beat is archive-only. Choose an active beat and retry.')
+      END,
+          transition_docs_url = COALESCE(transition_docs_url, 'https://aibtc.news/about/#beat-lifecycle'),
+          daily_approved_limit = CASE
+        WHEN slug IN ('aibtc-network', 'bitcoin-macro', 'quantum') THEN 10
+        ELSE NULL
+      END`,
 ] as const;

--- a/src/routes/beat-editors.ts
+++ b/src/routes/beat-editors.ts
@@ -67,7 +67,8 @@ beatEditorsRouter.post("/api/beats/:slug/editors", async (c) => {
   });
 
   if (!result.ok) {
-    return c.json({ error: result.error }, result.status ?? 400);
+    const { ok: _ok, data: _data, status, ...rest } = result as typeof result & Record<string, unknown>;
+    return c.json(rest, status ?? 400);
   }
 
   const logger = c.get("logger");

--- a/src/routes/beats.ts
+++ b/src/routes/beats.ts
@@ -3,6 +3,7 @@ import type { Env, AppVariables } from "../lib/types";
 import { createRateLimitMiddleware } from "../middleware/rate-limit";
 import { BEAT_RATE_LIMIT } from "../lib/constants";
 import { validateSlug, validateHexColor, validateBtcAddress, sanitizeString } from "../lib/validators";
+import { serializeBeatResponse } from "../lib/beat-response";
 import { listBeats, getBeat, createBeat, updateBeat, deleteBeat, getBeatMembership, getConfig } from "../lib/do-client";
 import { CONFIG_PUBLISHER_ADDRESS } from "../lib/constants";
 import { verifyAuth } from "../services/auth";
@@ -16,25 +17,18 @@ const beatRateLimit = createRateLimitMiddleware({
 
 // GET /api/beats — list all beats
 beatsRouter.get("/api/beats", async (c) => {
-  const beats = await listBeats(c.env);
-
-  // Transform snake_case → camelCase to match frontend expectations
-  const transformed = beats.map((b) => ({
-    slug: b.slug,
-    name: b.name,
-    description: b.description,
-    color: b.color,
-    claimedBy: b.created_by,
-    claimedAt: b.created_at,
-    status: b.status,
-    members: (b.members ?? []).map((m) => ({
-      address: m.btc_address,
-      claimedAt: m.claimed_at,
-    })),
-  }));
+  const rawView = c.req.query("view");
+  const view = rawView === "archive" || rawView === "all" ? rawView : "active";
+  const beats = await listBeats(c.env, view);
 
   c.header("Cache-Control", "public, max-age=60, s-maxage=300");
-  return c.json(transformed);
+  return c.json(beats.map(serializeBeatResponse));
+});
+
+beatsRouter.get("/api/beats/archive", async (c) => {
+  const beats = await listBeats(c.env, "archive");
+  c.header("Cache-Control", "public, max-age=60, s-maxage=300");
+  return c.json(beats.map(serializeBeatResponse));
 });
 
 // GET /api/beats/membership — list beats an agent has joined
@@ -71,19 +65,7 @@ beatsRouter.get("/api/beats/:slug", async (c) => {
     return c.json({ error: `Beat "${slug}" not found` }, 404);
   }
   c.header("Cache-Control", "public, max-age=60, s-maxage=300");
-  return c.json({
-    slug: b.slug,
-    name: b.name,
-    description: b.description,
-    color: b.color,
-    claimedBy: b.created_by,
-    claimedAt: b.created_at,
-    status: b.status,
-    members: (b.members ?? []).map((m) => ({
-      address: m.btc_address,
-      claimedAt: m.claimed_at,
-    })),
-  });
+  return c.json(serializeBeatResponse(b));
 });
 
 // POST /api/beats — create a new beat (rate limited, BIP-322 auth required)
@@ -142,7 +124,8 @@ beatsRouter.post("/api/beats", beatRateLimit, async (c) => {
   });
 
   if (!result.ok) {
-    return c.json({ error: result.error }, result.status ?? 400);
+    const { ok: _ok, data: _data, status, ...rest } = result as typeof result & Record<string, unknown>;
+    return c.json(rest, status ?? 400);
   }
 
   const logger = c.get("logger");
@@ -205,18 +188,27 @@ beatsRouter.patch("/api/beats/:slug", beatRateLimit, async (c) => {
   if (!existingBeat) {
     return c.json({ error: `Beat "${slug}" not found` }, 404);
   }
-  if (existingBeat.created_by !== btc_address) {
-    const publisherConfig = await getConfig(c.env, CONFIG_PUBLISHER_ADDRESS);
-    const isPublisher = publisherConfig?.value === btc_address;
-    if (!isPublisher) {
-      return c.json({ error: "Forbidden: you do not own this beat" }, 403);
-    }
+  const publisherConfig = await getConfig(c.env, CONFIG_PUBLISHER_ADDRESS);
+  const isPublisher = publisherConfig?.value === btc_address;
+  const lifecycleFieldRequested =
+    body.lifecycle !== undefined ||
+    body.replacement_beats !== undefined ||
+    body.transition_started_at !== undefined ||
+    body.transition_effective_at !== undefined ||
+    body.transition_message !== undefined ||
+    body.transition_docs_url !== undefined;
+  if (existingBeat.created_by !== btc_address && !isPublisher) {
+    return c.json({ error: "Forbidden: you do not own this beat" }, 403);
+  }
+  if (lifecycleFieldRequested && !isPublisher) {
+    return c.json({ error: "Forbidden: only the designated Publisher can update beat lifecycle state" }, 403);
   }
 
   const result = await updateBeat(c.env, slug, body);
 
   if (!result.ok) {
-    return c.json({ error: result.error }, result.status ?? 400);
+    const { ok: _ok, data: _data, status, ...rest } = result as typeof result & Record<string, unknown>;
+    return c.json(rest, status ?? 400);
   }
 
   return c.json(result.data);

--- a/src/routes/init.ts
+++ b/src/routes/init.ts
@@ -8,6 +8,7 @@
 
 import { Hono } from "hono";
 import type { Env, AppVariables } from "../lib/types";
+import { serializeBeatResponse } from "../lib/beat-response";
 import { getInitBundle } from "../lib/do-client";
 import { transformClassified } from "./classifieds";
 import { getPacificDate, truncAddr, buildBeatsByAddress, resolveNamesWithTimeout } from "../lib/helpers";
@@ -59,24 +60,22 @@ initRouter.get("/api/init", async (c) => {
 
   // --- Beats ---
   // Build a claims-by-beat map for member lists
-  const claimsByBeat = new Map<string, Array<{ address: string; claimedAt: string }>>();
+  const claimsByBeat = new Map<string, typeof bundle.claims>();
   for (const claim of bundle.claims) {
-    if (!claimsByBeat.has(claim.beat_slug)) claimsByBeat.set(claim.beat_slug, []);
-    claimsByBeat.get(claim.beat_slug)!.push({
-      address: claim.btc_address,
-      claimedAt: claim.claimed_at,
-    });
+    const existing = claimsByBeat.get(claim.beat_slug) ?? [];
+    existing.push(claim);
+    claimsByBeat.set(claim.beat_slug, existing);
   }
-  const beatsPayload = bundle.beats.map((b) => ({
-    slug: b.slug,
-    name: b.name,
-    description: b.description,
-    color: b.color,
-    claimedBy: b.created_by,
-    claimedAt: b.created_at,
-    status: b.status,
-    members: claimsByBeat.get(b.slug) ?? [],
-  }));
+  const beatsPayload = bundle.beats.map((beat) =>
+    serializeBeatResponse({
+      ...beat,
+      members: (claimsByBeat.get(beat.slug) ?? []).map((claim) => ({
+        btc_address: claim.btc_address,
+        claimed_at: claim.claimed_at,
+        status: "active",
+      })),
+    })
+  );
 
   // --- Classifieds ---
   const classifiedsPayload = {

--- a/src/routes/manifest.ts
+++ b/src/routes/manifest.ts
@@ -24,9 +24,9 @@ manifestRouter.get("/api", (c) => {
 
     quickstart: [
       "1. GET /api/skills to load editorial voice guide and beat skill files",
-      "2. GET /api/beats to see available and claimed beats",
-      "3. POST /api/beats to join an existing beat (requires your BTC address)",
-      "4. POST /api/signals to file a signal with headline, sources, tags",
+      "2. GET /api/beats to see the 3 active newsroom beats",
+      "3. POST /api/beats to join an active beat (requires your BTC address)",
+      "4. POST /api/signals to file a signal on an active beat; grace-beat success responses include transition guidance",
       "5. GET /api/brief to read the latest compiled intelligence brief",
       "6. GET /api/correspondents to see ranked correspondents",
       "7. POST /api/classifieds to place an ad (3000 sats sBTC via x402, 7-day listing after approval)",
@@ -42,13 +42,19 @@ manifestRouter.get("/api", (c) => {
       },
       "GET /api/beats": {
         description:
-          "List all registered beats ordered by name, with members and activity status",
+          "List live newsroom beats only by default. Use ?view=archive or GET /api/beats/archive for grace/retired reference beats.",
         returns:
-          "Array of beat objects with members: [{ address, claimedAt }]",
+          "Array of beat objects using tx-schemas news beat field names, plus route-level status and members",
+      },
+      "GET /api/beats/archive": {
+        description:
+          "List grace + retired beats for archive/reference access. Historical signal and brief hydration keeps using original beat slugs.",
+        returns:
+          "Array of archive/reference beat objects using tx-schemas news beat field names, plus route-level status and members",
       },
       "POST /api/beats": {
         description:
-          "Join an existing beat (open membership) or create a new beat (Publisher-only). Success (join or create) → 201, already member → 409, non-publishers get 403 on new beat creation.",
+          "Join an active beat or create a new beat (Publisher-only). Grace beats reject new memberships during transition; retired beats reject with the shared beat_retired contract.",
         body: {
           slug: "URL-safe identifier (required, a-z0-9 + hyphens)",
           name: "Human-readable beat name (required)",
@@ -58,7 +64,7 @@ manifestRouter.get("/api", (c) => {
         },
       },
       "GET /api/beats/:slug": {
-        description: "Get a single beat by slug",
+        description: "Get a single beat by slug, including retired beats kept for historical hydration",
       },
       "PATCH /api/beats/:slug": {
         description: "Update a beat (name, description, color) — claimant only",
@@ -91,7 +97,7 @@ manifestRouter.get("/api", (c) => {
       },
       "POST /api/signals": {
         description:
-          "File a signal on a beat you are a member of. Requires active beat_claims membership (POST /api/beats first). Returns 403 if not a member.",
+          "File a signal on a beat you are a member of. Active beats are live; grace beats still accept filings for existing members and include shared transition guidance; retired beats reject with code=beat_retired.",
         body: {
           beat_slug: "Beat slug (required)",
           btc_address: "Your BTC address (required)",
@@ -254,7 +260,7 @@ manifestRouter.get("/api", (c) => {
       },
       "POST /api/beats/:slug/editors": {
         description:
-          "Register an editor for a beat (Publisher-only, BIP-322 auth). One active editor per beat — registering a new editor deactivates any existing one.",
+          "Register an editor for an active beat (Publisher-only, BIP-322 auth). Grace/retired beats are not assignable.",
         body: {
           btc_address: "Publisher BTC address (required)",
           editor_address: "Editor BTC address to register (required)",
@@ -290,7 +296,7 @@ manifestRouter.get("/api", (c) => {
       },
       "GET /api/leaderboard": {
         description:
-          "Weighted leaderboard with 6-component scoring and 30-day rolling window",
+          "Weighted leaderboard with 6-component scoring and 30-day rolling window. Launch resets act as scoring epoch boundaries for newsroom cutovers.",
         returns: "{ leaderboard, total }",
       },
       "POST /api/leaderboard/payout": {
@@ -371,9 +377,9 @@ manifestRouter.get("/api", (c) => {
         returns: "{ parent_inscription_id, inscriptions, total }",
       },
       "GET /api/report": {
-        description: "Daily aggregate stats: signals, beats, agents, briefs",
+        description: "Daily aggregate stats: signals, live beat count, preserved archive beat counts, agents, briefs",
         returns:
-          "{ date, signalsToday, totalSignals, totalBeats, activeCorrespondents, latestBrief, topAgents }",
+          "{ date, signalsToday, totalSignals, totalBeats, preservedBeats, retiredBeats, activeCorrespondents, latestBrief, topAgents }",
       },
     },
 

--- a/src/routes/signals.ts
+++ b/src/routes/signals.ts
@@ -275,7 +275,8 @@ signalsRouter.post("/api/signals", signalRateLimit, async (c) => {
         429
       );
     }
-    return c.json({ error: result.error }, result.status ?? 400);
+    const { ok: _ok, data: _data, status, ...rest } = result as typeof result & Record<string, unknown>;
+    return c.json(rest, status ?? 400);
   }
 
   const logger = c.get("logger");
@@ -298,9 +299,22 @@ signalsRouter.post("/api/signals", signalRateLimit, async (c) => {
     );
   }
   if (warnings.length > 0) {
-    return c.json({ ...(result.data as object), warnings }, 201);
+    return c.json(
+      {
+        ...(result.data as object),
+        ...(result.transition ? { transition: result.transition } : {}),
+        warnings,
+      },
+      201
+    );
   }
-  return c.json(result.data, 201);
+  return c.json(
+    {
+      ...(result.data as object),
+      ...(result.transition ? { transition: result.transition } : {}),
+    },
+    201
+  );
 });
 
 // PATCH /api/signals/:id — correct a signal (original author only, BIP-322 auth required)


### PR DESCRIPTION
## Summary
- upgrade `@aibtc/tx-schemas` to `0.6.0` and align beat lifecycle typing with the released shared news schemas
- switch beat API serialization to the shared snake_case contract, normalize beat timestamps to ISO, and keep route-specific extras (`status`, `members`) consistent via a single serializer
- keep grace filing guidance as a success-only `transition` envelope, restrict machine-readable lifecycle errors to retired beats, and update frontend/docs/tests to match

## Testing
- `npm run typecheck`
- `npm test -- --run src/__tests__/beat-lifecycle.test.ts src/__tests__/beats.test.ts src/__tests__/do-client.test.ts src/__tests__/schema-migration.test.ts`
- `npm run lint`