### PR TITLE
fix(review): enforce global daily approval cap at review time

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -374,6 +374,10 @@ export interface ApprovalCapInfo {
   approved_today: number;
   remaining: number;
   reset_at: string;
+  /** Present when per-beat cap is active — global cap details */
+  global_limit?: number;
+  global_approved_today?: number;
+  global_remaining?: number;
 }
 
 export interface DOResult<T> {

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -1007,6 +1007,63 @@ export class NewsDO extends DurableObject<Env> {
           ? (beatCapRows[0] as { daily_approved_limit: number | null }).daily_approved_limit
           : null;
 
+        // ── Global daily cap (MAX_APPROVED_SIGNALS_PER_DAY across all beats) ──
+        const globalCountRows = this.ctx.storage.sql
+          .exec(
+            `SELECT COUNT(*) as count FROM signals
+             WHERE status IN ('approved', 'brief_included')
+               AND reviewed_at >= ? AND reviewed_at < ?`,
+            dayStart, dayEnd
+          )
+          .toArray();
+        const globalRaw = (globalCountRows[0] as Record<string, unknown> | undefined)?.count;
+        const globalApprovedToday = Number.isFinite(Number(globalRaw)) ? Number(globalRaw) : 0;
+
+        if (globalApprovedToday >= MAX_APPROVED_SIGNALS_PER_DAY) {
+          const displaceId = body.displace_signal_id as string | undefined;
+
+          if (!displaceId) {
+            return c.json({
+              ok: false,
+              error: `Global daily approval cap reached (${MAX_APPROVED_SIGNALS_PER_DAY}). Provide displace_signal_id to swap.`,
+              approval_cap: {
+                limit: MAX_APPROVED_SIGNALS_PER_DAY,
+                approved_today: globalApprovedToday,
+                remaining: 0,
+                reset_at: dayEnd,
+              },
+            } satisfies DOResult<Signal>, 409);
+          }
+
+          // Validate displacement target
+          const displaceRows = this.ctx.storage.sql
+            .exec("SELECT id, status, reviewed_at FROM signals WHERE id = ?", displaceId)
+            .toArray();
+          if (displaceRows.length === 0) {
+            return c.json({ ok: false, error: `Displace target "${displaceId}" not found` } satisfies DOResult<Signal>, 404);
+          }
+          const displaceRow = displaceRows[0] as { id: string; status: string; reviewed_at: string | null };
+          if (displaceRow.status !== "approved") {
+            return c.json({
+              ok: false,
+              error: `Displace target must have status "approved", got "${displaceRow.status}". Only "approved" signals can be displaced (not "brief_included" or other statuses).`,
+            } satisfies DOResult<Signal>, 400);
+          }
+          if (!displaceRow.reviewed_at || displaceRow.reviewed_at < dayStart || displaceRow.reviewed_at >= dayEnd) {
+            return c.json({
+              ok: false,
+              error: `Displace target was not approved today. Only today's approved signals can be displaced.`,
+            } satisfies DOResult<Signal>, 400);
+          }
+
+          // Atomically displace: set old signal to 'replaced'
+          this.ctx.storage.sql.exec(
+            `UPDATE signals SET status = 'replaced', updated_at = ? WHERE id = ?`,
+            nowDate.toISOString(), displaceId
+          );
+        }
+
+        // ── Per-beat cap (daily_approved_limit, only when set) ──
         // Skip per-beat cap enforcement when daily_approved_limit is NULL (unlimited)
         const enforceCapCheck = beatCap !== null;
         let approvedToday = 0;
@@ -1069,13 +1126,24 @@ export class NewsDO extends DurableObject<Env> {
           );
         }
 
-        // Build cap info for response (only when beat has a configured cap)
+        // Build cap info for response — always include global cap
+        const globalCountAfter = globalApprovedToday >= MAX_APPROVED_SIGNALS_PER_DAY ? globalApprovedToday : globalApprovedToday + 1;
         if (enforceCapCheck) {
           const countAfter = approvedToday >= beatCap ? approvedToday : approvedToday + 1;
           approvalCap = {
             limit: beatCap,
             approved_today: countAfter,
             remaining: Math.max(0, beatCap - countAfter),
+            reset_at: dayEnd,
+            global_limit: MAX_APPROVED_SIGNALS_PER_DAY,
+            global_approved_today: globalCountAfter,
+            global_remaining: Math.max(0, MAX_APPROVED_SIGNALS_PER_DAY - globalCountAfter),
+          };
+        } else {
+          approvalCap = {
+            limit: MAX_APPROVED_SIGNALS_PER_DAY,
+            approved_today: globalCountAfter,
+            remaining: Math.max(0, MAX_APPROVED_SIGNALS_PER_DAY - globalCountAfter),
             reset_at: dayEnd,
           };
         }


### PR DESCRIPTION
## Summary

- Enforce `MAX_APPROVED_SIGNALS_PER_DAY` (30) as a hard gate at signal review/approval time
- Previously the 30-signal cap only applied during brief compilation (silently dropping overflow), allowing unlimited approvals
- Today 42 signals were approved on production despite the intended 30-signal limit

## Background

PR #355 added a 30-signal cap at the brief compilation layer (DB-level cutoff with earliest-approved-first ordering). PR #418 reverted it because "signal selection is editorial" — the Publisher should curate which signals make the brief, not an automated DB-layer cutoff.

However, the revert removed the cap entirely without replacing it with enforcement at the approval step. This left zero cap enforcement anywhere in the pipeline, allowing the publisher to approve unlimited signals per day.

This PR restores the 30-signal cap at the **correct layer** — approval time instead of compilation time. The publisher retains full editorial control over *which* 30 signals to approve, but cannot approve signal #31 without displacing an existing one.

## Problem

The approval endpoint (\`PATCH /api/signals/{id}/review\`) only checked per-beat \`daily_approved_limit\`, which is \`NULL\` (unlimited) on all 12 beats. The global constant \`MAX_APPROVED_SIGNALS_PER_DAY = 30\` was imported but never enforced at approval time — it only applied at brief compilation via \`candidateSignals.slice(0, MAX_INCLUDED_SIGNALS_PER_BRIEF)\`.

With editors not yet operational (only 1 editor registered on quantum, no per-beat caps configured, publisher integration #413 still open), the publisher is approving all signals directly with zero cap enforcement.

## Changes

### \`src/objects/news-do.ts\`
- Add global daily approval count query (all beats, all \`approved\` + \`brief_included\` signals for the Pacific day)
- When global cap is reached without \`displace_signal_id\`: return 409 with cap info (same UX as per-beat caps)
- When global cap is reached with \`displace_signal_id\`: validate and atomically displace the target signal
- Global cap check runs **before** the per-beat cap check — it's the outermost gate
- Always include global cap info in the \`approval_cap\` response field

### \`src/lib/types.ts\`
- Add optional \`global_limit\`, \`global_approved_today\`, \`global_remaining\` fields to \`ApprovalCapInfo\`

## How the two caps interact

| Scenario | Global cap (30) | Per-beat cap | Result |
|----------|----------------|--------------|--------|
| No editors, all beats NULL | Enforced | Skipped | Publisher limited to 30/day total |
| Editors active, per-beat caps set | Enforced | Enforced | Both gates apply; global is outer |
| Beat at cap, global has room | Passes | Blocks (409) | Per-beat cap prevents over-concentration |
| Global at cap, beat has room | Blocks (409) | Not reached | Global cap prevents >30 approvals |

## Future considerations

Once editor delegation (#413) and beat consolidation (#423) are operational, the per-beat \`daily_approved_limit\` values should be configured so they naturally sum to ~30. The global cap serves as a safety net regardless.

## Test plan

- [x] \`npx tsc --noEmit\` passes
- [x] \`npx vitest run\` passes (246 tests, 27 files)
- [ ] Verify publisher gets 409 when approving signal #31 without \`displace_signal_id\`
- [ ] Verify displacement works: approve #31 with \`displace_signal_id\` pointing to an existing approved signal
- [ ] Verify \`approval_cap\` response includes global cap info on every approval

Closes #423 (partial — cap enforcement piece)
Related: #355, #418, #360, #413