### PR TITLE
feat(corrections): add route-level validation for editorial review fields

### DIFF
--- a/src/__tests__/corrections.test.ts
+++ b/src/__tests__/corrections.test.ts
@@ -41,6 +41,134 @@ describe("POST /api/signals/:id/corrections — validation", () => {
     const body = await res.json<{ error: string }>();
     expect(body.error).toContain("BTC address");
   });
+
+  it("returns 400 for invalid type value", async () => {
+    const res = await SELF.fetch(
+      "http://example.com/api/signals/test-id/corrections",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "CF-Connecting-IP": "10.0.0.4" },
+        body: JSON.stringify({
+          btc_address: "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
+          type: "bogus",
+        }),
+      }
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toContain("Invalid type");
+  });
+});
+
+describe("POST /api/signals/:id/corrections — editorial_review validation", () => {
+  const url = "http://example.com/api/signals/test-id/corrections";
+  const base = {
+    btc_address: "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
+    type: "editorial_review",
+  };
+
+  let ipCounter = 0;
+  const post = (body: Record<string, unknown>) =>
+    SELF.fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "CF-Connecting-IP": `10.0.1.${++ipCounter}`,
+      },
+      body: JSON.stringify({ ...base, ...body }),
+    });
+
+  it("returns 400 when score is not an integer", async () => {
+    const res = await post({ score: 55.5 });
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toContain("score must be an integer between 0 and 100");
+  });
+
+  it("returns 400 when score is below 0", async () => {
+    const res = await post({ score: -1 });
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toContain("score must be an integer between 0 and 100");
+  });
+
+  it("returns 400 when score is above 100", async () => {
+    const res = await post({ score: 101 });
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toContain("score must be an integer between 0 and 100");
+  });
+
+  it("returns 400 when score is not a number", async () => {
+    const res = await post({ score: "high" });
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toContain("score must be an integer between 0 and 100");
+  });
+
+  it("returns 400 when factcheck_passed is not a boolean", async () => {
+    const res = await post({ factcheck_passed: 1 });
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toContain("factcheck_passed must be a boolean");
+  });
+
+  it("returns 400 when beat_relevance is not an integer", async () => {
+    const res = await post({ beat_relevance: 42.7 });
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toContain("beat_relevance must be an integer between 0 and 100");
+  });
+
+  it("returns 400 when beat_relevance is out of range", async () => {
+    const res = await post({ beat_relevance: 200 });
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toContain("beat_relevance must be an integer between 0 and 100");
+  });
+
+  it("returns 400 when recommendation is not a valid enum value", async () => {
+    const res = await post({ recommendation: "maybe" });
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toContain("recommendation must be one of");
+  });
+
+  it("returns 400 when recommendation is not a string", async () => {
+    const res = await post({ recommendation: 42 });
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toContain("recommendation must be one of");
+  });
+
+  it("returns 400 when feedback is not a string", async () => {
+    const res = await post({ feedback: 123 });
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toContain("feedback must be a string");
+  });
+
+  it("passes validation with valid editorial_review fields", async () => {
+    const res = await post({
+      score: 85,
+      factcheck_passed: true,
+      beat_relevance: 70,
+      recommendation: "approve",
+      feedback: "Solid sourcing, well-structured signal.",
+    });
+    // Should pass route validation and reach auth layer (401) or DO
+    expect(res.status).not.toBe(400);
+  });
+
+  it("passes validation with only some editorial fields", async () => {
+    const res = await post({ recommendation: "needs_revision" });
+    expect(res.status).not.toBe(400);
+  });
+
+  it("passes validation with no editorial fields (all optional)", async () => {
+    const res = await post({});
+    expect(res.status).not.toBe(400);
+  });
 });
 
 describe("GET /api/signals/:id/corrections", () => {

--- a/src/lib/do-client.ts
+++ b/src/lib/do-client.ts
@@ -862,7 +862,7 @@ export interface CreateCorrectionInput {
   /** Relevance score 0–100 for how well the signal fits the beat (editorial_review only) */
   beat_relevance?: number;
   /** Editorial disposition: "approve", "reject", or "needs_revision" (editorial_review only) */
-  recommendation?: string;
+  recommendation?: "approve" | "reject" | "needs_revision";
   /** Free-text reviewer notes for the correspondent (editorial_review only) */
   feedback?: string;
 }

--- a/src/lib/do-client.ts
+++ b/src/lib/do-client.ts
@@ -827,20 +827,43 @@ export async function getBriefSignals(env: Env, date: string): Promise<unknown[]
 }
 
 // ---------------------------------------------------------------------------
-// Corrections (fact-checker)
+// Corrections (fact-checker) & Editorial Reviews (beat editor)
 // ---------------------------------------------------------------------------
 
+/**
+ * Input for creating a correction or editorial review on a signal.
+ *
+ * When `type` is `"correction"` (default), `claim` and `correction` are required.
+ * When `type` is `"editorial_review"`, the editorial fields are used instead:
+ * - `score`: 0–100 integer quality score
+ * - `factcheck_passed`: whether factual claims verified
+ * - `beat_relevance`: 0–100 integer relevance to the beat
+ * - `recommendation`: editorial disposition — `"approve"`, `"reject"`, or `"needs_revision"`
+ * - `feedback`: free-text reviewer notes for the correspondent
+ *
+ * Editorial reviews require the caller to be an active beat editor for the
+ * signal's beat or the designated Publisher (enforced by the DO).
+ */
 export interface CreateCorrectionInput {
   signal_id: string;
   btc_address: string;
+  /** The factual claim being corrected (required for type "correction") */
   claim?: string;
+  /** The correction text (required for type "correction") */
   correction?: string;
+  /** Supporting source URLs (optional, type "correction" only) */
   sources?: string | null;
+  /** Entry type — "correction" (default) or "editorial_review" */
   type?: "correction" | "editorial_review";
+  /** Quality score 0–100 (editorial_review only) */
   score?: number;
+  /** Whether factual claims in the signal were verified (editorial_review only) */
   factcheck_passed?: boolean;
+  /** Relevance score 0–100 for how well the signal fits the beat (editorial_review only) */
   beat_relevance?: number;
+  /** Editorial disposition: "approve", "reject", or "needs_revision" (editorial_review only) */
   recommendation?: string;
+  /** Free-text reviewer notes for the correspondent (editorial_review only) */
   feedback?: string;
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -307,8 +307,9 @@ export interface BeatEditor {
  * A fact-checker correction or editorial review filed against a signal.
  *
  * When `type` is `"editorial_review"`, the editorial fields (`score`,
- * `factcheck_passed`, `beat_relevance`, `recommendation`) are populated
- * instead of the standard `claim`/`correction` fields.
+ * `factcheck_passed`, `beat_relevance`, `recommendation`) are populated.
+ * Note: the DO stores the type marker in `claim` and reviewer feedback
+ * in `correction`, so those fields are still present in the response.
  */
 export interface Correction {
   readonly id: string;
@@ -326,7 +327,7 @@ export interface Correction {
   /** Quality score 0–100 (editorial_review only) */
   readonly score: number | null;
   /** Whether factual claims were verified (editorial_review only, stored as 0/1 in SQLite) */
-  readonly factcheck_passed: number | null;
+  readonly factcheck_passed: 0 | 1 | null;
   /** Beat relevance score 0–100 (editorial_review only) */
   readonly beat_relevance: number | null;
   /** Editorial disposition (editorial_review only) */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -304,7 +304,11 @@ export interface BeatEditor {
 }
 
 /**
- * A fact-checker correction filed against a signal
+ * A fact-checker correction or editorial review filed against a signal.
+ *
+ * When `type` is `"editorial_review"`, the editorial fields (`score`,
+ * `factcheck_passed`, `beat_relevance`, `recommendation`) are populated
+ * instead of the standard `claim`/`correction` fields.
  */
 export interface Correction {
   readonly id: string;
@@ -317,6 +321,16 @@ export interface Correction {
   readonly reviewed_by: string | null;
   readonly reviewed_at: string | null;
   readonly created_at: string;
+  /** Entry type — "correction" (default) or "editorial_review" */
+  readonly type: "correction" | "editorial_review";
+  /** Quality score 0–100 (editorial_review only) */
+  readonly score: number | null;
+  /** Whether factual claims were verified (editorial_review only, stored as 0/1 in SQLite) */
+  readonly factcheck_passed: number | null;
+  /** Beat relevance score 0–100 (editorial_review only) */
+  readonly beat_relevance: number | null;
+  /** Editorial disposition (editorial_review only) */
+  readonly recommendation: "approve" | "reject" | "needs_revision" | null;
 }
 
 /**

--- a/src/routes/corrections.ts
+++ b/src/routes/corrections.ts
@@ -84,6 +84,36 @@ correctionsRouter.post("/api/signals/:id/corrections", correctionRateLimit, asyn
     if (typeof correction !== "string" || correction.trim().length === 0) {
       return c.json({ error: "correction must be a non-empty string" }, 400);
     }
+  } else {
+    // Editorial review fields — validate at route level before forwarding to DO
+    const { score, factcheck_passed, beat_relevance, recommendation, feedback } = body;
+
+    if (score !== undefined) {
+      if (typeof score !== "number" || !Number.isInteger(score) || score < 0 || score > 100) {
+        return c.json({ error: "score must be an integer between 0 and 100" }, 400);
+      }
+    }
+    if (factcheck_passed !== undefined) {
+      if (typeof factcheck_passed !== "boolean") {
+        return c.json({ error: "factcheck_passed must be a boolean" }, 400);
+      }
+    }
+    if (beat_relevance !== undefined) {
+      if (typeof beat_relevance !== "number" || !Number.isInteger(beat_relevance) || beat_relevance < 0 || beat_relevance > 100) {
+        return c.json({ error: "beat_relevance must be an integer between 0 and 100" }, 400);
+      }
+    }
+    if (recommendation !== undefined) {
+      const validRecs = ["approve", "reject", "needs_revision"] as const;
+      if (typeof recommendation !== "string" || !validRecs.includes(recommendation as typeof validRecs[number])) {
+        return c.json({ error: `recommendation must be one of: ${validRecs.join(", ")}` }, 400);
+      }
+    }
+    if (feedback !== undefined) {
+      if (typeof feedback !== "string") {
+        return c.json({ error: "feedback must be a string" }, 400);
+      }
+    }
   }
 
   // BIP-322 auth
@@ -109,40 +139,12 @@ correctionsRouter.post("/api/signals/:id/corrections", correctionRateLimit, asyn
     input.correction = body.correction as string;
     input.sources = body.sources ? String(body.sources) : null;
   } else {
-    // Editorial review fields — validate at route level before forwarding to DO
-    const { score, factcheck_passed, beat_relevance, recommendation, feedback } = body;
-
-    if (score !== undefined) {
-      if (typeof score !== "number" || !Number.isInteger(score) || score < 0 || score > 100) {
-        return c.json({ error: "score must be an integer between 0 and 100" }, 400);
-      }
-      input.score = score;
-    }
-    if (factcheck_passed !== undefined) {
-      if (typeof factcheck_passed !== "boolean") {
-        return c.json({ error: "factcheck_passed must be a boolean" }, 400);
-      }
-      input.factcheck_passed = factcheck_passed;
-    }
-    if (beat_relevance !== undefined) {
-      if (typeof beat_relevance !== "number" || !Number.isInteger(beat_relevance) || beat_relevance < 0 || beat_relevance > 100) {
-        return c.json({ error: "beat_relevance must be an integer between 0 and 100" }, 400);
-      }
-      input.beat_relevance = beat_relevance;
-    }
-    if (recommendation !== undefined) {
-      const validRecs = ["approve", "reject", "needs_revision"];
-      if (typeof recommendation !== "string" || !validRecs.includes(recommendation)) {
-        return c.json({ error: `recommendation must be one of: ${validRecs.join(", ")}` }, 400);
-      }
-      input.recommendation = recommendation;
-    }
-    if (feedback !== undefined) {
-      if (typeof feedback !== "string") {
-        return c.json({ error: "feedback must be a string" }, 400);
-      }
-      input.feedback = feedback;
-    }
+    // Assign validated editorial fields to input
+    if (body.score !== undefined) input.score = body.score as number;
+    if (body.factcheck_passed !== undefined) input.factcheck_passed = body.factcheck_passed as boolean;
+    if (body.beat_relevance !== undefined) input.beat_relevance = body.beat_relevance as number;
+    if (body.recommendation !== undefined) input.recommendation = body.recommendation as "approve" | "reject" | "needs_revision";
+    if (body.feedback !== undefined) input.feedback = body.feedback as string;
   }
 
   const result = await createCorrection(c.env, input);

--- a/src/routes/corrections.ts
+++ b/src/routes/corrections.ts
@@ -109,12 +109,40 @@ correctionsRouter.post("/api/signals/:id/corrections", correctionRateLimit, asyn
     input.correction = body.correction as string;
     input.sources = body.sources ? String(body.sources) : null;
   } else {
-    // Editorial review fields — DO handles validation
-    if (body.score !== undefined) input.score = body.score as number;
-    if (body.factcheck_passed !== undefined) input.factcheck_passed = body.factcheck_passed as boolean;
-    if (body.beat_relevance !== undefined) input.beat_relevance = body.beat_relevance as number;
-    if (body.recommendation !== undefined) input.recommendation = body.recommendation as string;
-    if (body.feedback !== undefined) input.feedback = body.feedback as string;
+    // Editorial review fields — validate at route level before forwarding to DO
+    const { score, factcheck_passed, beat_relevance, recommendation, feedback } = body;
+
+    if (score !== undefined) {
+      if (typeof score !== "number" || !Number.isInteger(score) || score < 0 || score > 100) {
+        return c.json({ error: "score must be an integer between 0 and 100" }, 400);
+      }
+      input.score = score;
+    }
+    if (factcheck_passed !== undefined) {
+      if (typeof factcheck_passed !== "boolean") {
+        return c.json({ error: "factcheck_passed must be a boolean" }, 400);
+      }
+      input.factcheck_passed = factcheck_passed;
+    }
+    if (beat_relevance !== undefined) {
+      if (typeof beat_relevance !== "number" || !Number.isInteger(beat_relevance) || beat_relevance < 0 || beat_relevance > 100) {
+        return c.json({ error: "beat_relevance must be an integer between 0 and 100" }, 400);
+      }
+      input.beat_relevance = beat_relevance;
+    }
+    if (recommendation !== undefined) {
+      const validRecs = ["approve", "reject", "needs_revision"];
+      if (typeof recommendation !== "string" || !validRecs.includes(recommendation)) {
+        return c.json({ error: `recommendation must be one of: ${validRecs.join(", ")}` }, 400);
+      }
+      input.recommendation = recommendation;
+    }
+    if (feedback !== undefined) {
+      if (typeof feedback !== "string") {
+        return c.json({ error: "feedback must be a string" }, 400);
+      }
+      input.feedback = feedback;
+    }
   }
 
   const result = await createCorrection(c.env, input);

--- a/src/routes/manifest.ts
+++ b/src/routes/manifest.ts
@@ -308,12 +308,18 @@ manifestRouter.get("/api", (c) => {
       },
       "POST /api/signals/:id/corrections": {
         description:
-          "File a fact-check correction on a signal (BIP-322 auth required, max 3/day)",
+          "File a fact-check correction or editorial review on a signal (BIP-322 auth required, max 3/day)",
         body: {
           btc_address: "Your BTC address (required)",
-          claim: "The claim being corrected (required)",
-          correction: "The correction text (required)",
-          sources: "Supporting sources (optional)",
+          type: "Entry type: 'correction' (default) or 'editorial_review'",
+          claim: "The claim being corrected (required for type correction)",
+          correction: "The correction text (required for type correction)",
+          sources: "Supporting sources (optional, type correction only)",
+          score: "Quality score 0–100 integer (editorial_review only)",
+          factcheck_passed: "Whether factual claims verified — boolean (editorial_review only)",
+          beat_relevance: "Beat relevance score 0–100 integer (editorial_review only)",
+          recommendation: "Editorial disposition: 'approve', 'reject', or 'needs_revision' (editorial_review only)",
+          feedback: "Free-text reviewer notes for the correspondent (editorial_review only)",
         },
       },
       "GET /api/signals/:id/corrections": {


### PR DESCRIPTION
## Summary

Adds route-level input validation for editorial review fields on \POST /api/signals/:id/corrections\ and updates types, JSDoc, and manifest to fully document the editorial review payload shape.

**Closes #412**

## Changes

### \src/routes/corrections.ts\
- Replace pass-through \else\ branch with full route-level validation for \editorial_review\ type:
  - \score\: integer 0–100
  - \actcheck_passed\: boolean
  - \eat_relevance\: integer 0–100
  - \ecommendation\: enum (\pprove\ | \eject\ | \
eeds_revision\)
  - \eedback\: string
- Returns \400\ with descriptive messages for invalid inputs before reaching the DO

### \src/lib/types.ts\
- Extend \Correction\ interface with editorial review fields: \	ype\, \score\, \actcheck_passed\, \eat_relevance\, \ecommendation\

### \src/lib/do-client.ts\
- Add JSDoc to \CreateCorrectionInput\ documenting both \correction\ and \editorial_review\ modes
- Add per-field JSDoc for all editorial review fields

### \src/routes/manifest.ts\
- Update \POST /api/signals/:id/corrections\ entry to describe all editorial review fields (\	ype\, \score\, \actcheck_passed\, \eat_relevance\, \ecommendation\, \eedback\)

## Verification

- \
px tsc --noEmit\ — zero type errors
- \
pm run check\ (typecheck + biome lint) — all passing, no new warnings
- \
pm test\ — 245/246 pass; one pre-existing timeout in \rief-compile-reconciliation.test.ts\ (unrelated to this PR)