### PR TITLE
fix(identity-gate): add 5s abort timeout to prevent hanging signal submissions

### DIFF
--- a/src/services/identity-gate.ts
+++ b/src/services/identity-gate.ts
@@ -9,6 +9,8 @@
 const CACHE_TTL_SECONDS = 3600; // 1 hour
 const CACHE_KEY_PREFIX = "agent-level:";
 const AGENT_API_BASE = "https://aibtc.com/api/agents";
+/** Abort the external identity fetch after this many ms to prevent hanging signal submissions. */
+const FETCH_TIMEOUT_MS = 5000;
 
 export interface IdentityCheckResult {
   registered: boolean;
@@ -38,9 +40,17 @@ export async function checkAgentIdentity(
   }
 
   try {
-    const res = await fetch(`${AGENT_API_BASE}/${encodeURIComponent(btcAddress)}`, {
-      headers: { Accept: "application/json" },
-    });
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    let res: Response;
+    try {
+      res = await fetch(`${AGENT_API_BASE}/${encodeURIComponent(btcAddress)}`, {
+        headers: { Accept: "application/json" },
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timeoutId);
+    }
 
     if (res.ok) {
       const data = (await res.json()) as Record<string, unknown>;
@@ -59,7 +69,7 @@ export async function checkAgentIdentity(
       return result;
     }
   } catch {
-    // Network error — don't cache, allow through (fail open to avoid blocking real agents)
+    // Network error or timeout — don't cache, fail open to avoid blocking real agents
   }
 
   // On API failure, return unknown state — fail open


### PR DESCRIPTION
## Summary

- Adds a 5-second `AbortController` timeout to the external `fetch()` in `identity-gate.ts`
- Without this timeout, a slow or unresponsive `aibtc.com/api/agents` response blocks the entire Worker request until client timeout (45-60s)
- On timeout, the existing fail-open path runs — valid agents are not blocked

## Root cause

`checkAgentIdentity()` makes an external HTTP call with no timeout:

```typescript
// before
const res = await fetch(`${AGENT_API_BASE}/${encodeURIComponent(btcAddress)}`, {
  headers: { Accept: "application/json" },
  // no AbortSignal
});
```

The 1h KV cache masks this for addresses that have filed recently. A cache miss (new agent, expired entry) → unbounded `await fetch()` → Worker hangs → request times out with no response headers.

This explains the selective nature of issue #445: some correspondents file normally (warm cache), others hang (cold cache + slow API).

## Fix

```typescript
const controller = new AbortController();
const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS); // 5000ms
let res: Response;
try {
  res = await fetch(`${AGENT_API_BASE}/...`, {
    headers: { Accept: "application/json" },
    signal: controller.signal,
  });
} finally {
  clearTimeout(timeoutId);
}
```

The `finally` ensures the timer is cleared even if the fetch succeeds. The outer `catch` already handles network errors with fail-open behavior — the timeout just guarantees it fires within 5s instead of 45s+.

## Test plan

- [ ] Unit tests for identity-gate pass (`bun test src/__tests__/identity-gate.test.ts`)
- [ ] Signal submission no longer hangs on cache-miss addresses
- [ ] Verify fail-open behavior is preserved when timeout fires (signal still accepted for `apiReachable: false` case)

Closes #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)