### PR TITLE
feat(beats): expose editor field and lean member responses

### DIFF
--- a/src/lib/do-client.ts
+++ b/src/lib/do-client.ts
@@ -57,7 +57,7 @@ export async function getBeat(env: Env, slug: string): Promise<Beat | null> {
 
 export async function createBeat(
   env: Env,
-  beat: Omit<Beat, "created_at" | "updated_at">
+  beat: Omit<Beat, "created_at" | "updated_at" | "editor">
 ): Promise<DOResult<Beat>> {
   const stub = getStub(env);
   return doFetch<Beat>(stub, "/beats", {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -142,6 +142,8 @@ export interface Beat {
   readonly status?: "active" | "inactive" | "retired";
   /** Active members from beat_claims — populated when joined */
   readonly members?: BeatMember[];
+  /** Active editor for this beat (one per beat, nullable) */
+  readonly editor?: { btc_address: string; registered_at: string } | null;
 }
 
 /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -142,8 +142,8 @@ export interface Beat {
   readonly status?: "active" | "inactive" | "retired";
   /** Active members from beat_claims — populated when joined */
   readonly members?: BeatMember[];
-  /** Active editor for this beat (one per beat, nullable) */
-  readonly editor?: { btc_address: string; registered_at: string } | null;
+  /** Active editor for this beat (one per beat, null when unassigned) */
+  readonly editor: { btc_address: string; registered_at: string } | null;
 }
 
 /**

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -1252,6 +1252,22 @@ export class NewsDO extends DurableObject<Env> {
         });
       }
 
+      // Fetch active editor per beat (one per beat enforced by registration logic)
+      const editorRows = this.ctx.storage.sql
+        .exec(
+          `SELECT beat_slug, btc_address, registered_at
+           FROM beat_editors WHERE status = 'active'`
+        )
+        .toArray();
+      const editorByBeat = new Map<string, { btc_address: string; registered_at: string }>();
+      for (const er of editorRows) {
+        const e = er as Record<string, unknown>;
+        editorByBeat.set(e.beat_slug as string, {
+          btc_address: e.btc_address as string,
+          registered_at: e.registered_at as string,
+        });
+      }
+
       const expiryMs = BEAT_EXPIRY_DAYS * 24 * 3600 * 1000;
       const now = Date.now();
       const beats = rows.map((r) => {
@@ -1277,6 +1293,7 @@ export class NewsDO extends DurableObject<Env> {
           updated_at: row.updated_at,
           status,
           members: claimsByBeat.get(row.slug as string) ?? [],
+          editor: editorByBeat.get(row.slug as string) ?? null,
         } as Beat;
       });
       return c.json({ ok: true, data: beats } satisfies DOResult<Beat[]>);
@@ -1370,6 +1387,18 @@ export class NewsDO extends DurableObject<Env> {
         )
         .toArray();
 
+      // Fetch active editor for this beat
+      const editorRows = this.ctx.storage.sql
+        .exec(
+          `SELECT btc_address, registered_at
+           FROM beat_editors
+           WHERE beat_slug = ? AND status = 'active'
+           LIMIT 1`,
+          slug
+        )
+        .toArray();
+      const editorRow = editorRows.length > 0 ? editorRows[0] as Record<string, unknown> : null;
+
       const beat: Beat = {
         slug: row.slug as string,
         name: row.name as string,
@@ -1389,6 +1418,9 @@ export class NewsDO extends DurableObject<Env> {
             status: mr.status as "active" | "inactive",
           };
         }),
+        editor: editorRow
+          ? { btc_address: editorRow.btc_address as string, registered_at: editorRow.registered_at as string }
+          : null,
       };
       return c.json({ ok: true, data: beat } satisfies DOResult<Beat>);
     });

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -1256,7 +1256,8 @@ export class NewsDO extends DurableObject<Env> {
       const editorRows = this.ctx.storage.sql
         .exec(
           `SELECT beat_slug, btc_address, registered_at
-           FROM beat_editors WHERE status = 'active'`
+           FROM beat_editors WHERE status = 'active'
+           ORDER BY registered_at DESC`
         )
         .toArray();
       const editorByBeat = new Map<string, { btc_address: string; registered_at: string }>();
@@ -1393,6 +1394,7 @@ export class NewsDO extends DurableObject<Env> {
           `SELECT btc_address, registered_at
            FROM beat_editors
            WHERE beat_slug = ? AND status = 'active'
+           ORDER BY registered_at DESC
            LIMIT 1`,
           slug
         )

--- a/src/routes/beats.ts
+++ b/src/routes/beats.ts
@@ -15,23 +15,30 @@ const beatRateLimit = createRateLimitMiddleware({
 });
 
 // GET /api/beats — list all beats
+// Supports ?include=members to expand full members array (default: memberCount only)
 beatsRouter.get("/api/beats", async (c) => {
   const beats = await listBeats(c.env);
+  const includeMembers = c.req.query("include") === "members";
 
   // Transform snake_case → camelCase to match frontend expectations
-  const transformed = beats.map((b) => ({
-    slug: b.slug,
-    name: b.name,
-    description: b.description,
-    color: b.color,
-    claimedBy: b.created_by,
-    claimedAt: b.created_at,
-    status: b.status,
-    members: (b.members ?? []).map((m) => ({
-      address: m.btc_address,
-      claimedAt: m.claimed_at,
-    })),
-  }));
+  const transformed = beats.map((b) => {
+    const members = b.members ?? [];
+    return {
+      slug: b.slug,
+      name: b.name,
+      description: b.description,
+      color: b.color,
+      claimedBy: b.created_by,
+      claimedAt: b.created_at,
+      status: b.status,
+      ...(includeMembers
+        ? { members: members.map((m) => ({ address: m.btc_address, claimedAt: m.claimed_at })) }
+        : { memberCount: members.length }),
+      editor: b.editor
+        ? { address: b.editor.btc_address, assignedAt: b.editor.registered_at }
+        : null,
+    };
+  });
 
   c.header("Cache-Control", "public, max-age=60, s-maxage=300");
   return c.json(transformed);
@@ -64,12 +71,15 @@ beatsRouter.get("/api/beats/membership", async (c) => {
 });
 
 // GET /api/beats/:slug — get a single beat by slug
+// Supports ?include=members to expand full members array (default: memberCount only)
 beatsRouter.get("/api/beats/:slug", async (c) => {
   const slug = c.req.param("slug");
   const b = await getBeat(c.env, slug);
   if (!b) {
     return c.json({ error: `Beat "${slug}" not found` }, 404);
   }
+  const members = b.members ?? [];
+  const includeMembers = c.req.query("include") === "members";
   c.header("Cache-Control", "public, max-age=60, s-maxage=300");
   return c.json({
     slug: b.slug,
@@ -79,10 +89,12 @@ beatsRouter.get("/api/beats/:slug", async (c) => {
     claimedBy: b.created_by,
     claimedAt: b.created_at,
     status: b.status,
-    members: (b.members ?? []).map((m) => ({
-      address: m.btc_address,
-      claimedAt: m.claimed_at,
-    })),
+    ...(includeMembers
+      ? { members: members.map((m) => ({ address: m.btc_address, claimedAt: m.claimed_at })) }
+      : { memberCount: members.length }),
+    editor: b.editor
+      ? { address: b.editor.btc_address, assignedAt: b.editor.registered_at }
+      : null,
   });
 });
 


### PR DESCRIPTION
## Summary

- Add `editor` field (address + assignedAt) inline on `GET /api/beats` and `GET /api/beats/:slug` responses — eliminates the need for a separate `/api/beats/:slug/editors` call per beat
- Default to `memberCount` (integer) instead of the full `members` array for leaner responses
- Support `?include=members` query param to opt-in to the full members array when needed

Closes #455

## Breaking change

The default response shape for `GET /api/beats` and `GET /api/beats/:slug` no longer includes a `members` array. Instead, it returns `memberCount` (integer). To get the full members array, add `?include=members` to the request.

**Before:** `{ ..., members: [{ address, claimedAt }] }`
**After:** `{ ..., memberCount: 3 }` (default) or `{ ..., members: [...] }` (with `?include=members`)

Internal consumers (leaderboard) call `listBeats()` via the DO client directly and are unaffected.

## Details

**DO layer** (`news-do.ts`): Batch-fetches active editors in one query (list) or a single `ORDER BY registered_at DESC LIMIT 1` query (detail), no N+1. Attaches `editor` to each beat object returned to callers.

**Route layer** (`beats.ts`): Transforms `editor` to camelCase (`{ address, assignedAt }`), switches `members` → `memberCount` by default, respects `?include=members`.

**Type layer** (`types.ts`): Adds required nullable `editor` field to `Beat` interface.

## Test plan

- [ ] `GET /api/beats` returns `memberCount` and `editor` fields
- [ ] `GET /api/beats?include=members` returns full `members` array
- [ ] `GET /api/beats/:slug` returns `memberCount` and `editor` fields
- [ ] `GET /api/beats/:slug?include=members` returns full `members` array
- [ ] Beat with no editor returns `editor: null`
- [ ] Leaderboard page still works (internal consumer unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)