### PR TITLE
fix(beats): return 410 Gone for retired beat lookups and signal submissions

### DIFF
--- a/src/__tests__/signals.test.ts
+++ b/src/__tests__/signals.test.ts
@@ -144,7 +144,7 @@ describe("POST /api/signals — validation errors", () => {
     expect(body.error).toContain("tags");
   });
 
-  it("returns 401 when auth headers are missing (all fields valid)", async () => {
+  it("returns 404 for a nonexistent beat before reaching auth", async () => {
     const res = await SELF.fetch("http://example.com/api/signals", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -156,8 +156,8 @@ describe("POST /api/signals — validation errors", () => {
         tags: ["bitcoin"],
       }),
     });
-    expect(res.status).toBe(401);
+    expect(res.status).toBe(404);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toBeTruthy();
+    expect(body.error).toContain("not found");
   });
 });

--- a/src/lib/do-client.ts
+++ b/src/lib/do-client.ts
@@ -55,6 +55,12 @@ export async function getBeat(env: Env, slug: string): Promise<Beat | null> {
   return result.ok ? (result.data ?? null) : null;
 }
 
+/** Return slugs of all non-retired beats. Shared by 410 responses in beats + signals routes. */
+export async function getActiveBeatSlugs(env: Env): Promise<string[]> {
+  const all = await listBeats(env);
+  return all.filter((b) => b.status !== "retired").map((b) => b.slug);
+}
+
 export async function createBeat(
   env: Env,
   beat: Omit<Beat, "created_at" | "updated_at" | "editor">

--- a/src/routes/beats.ts
+++ b/src/routes/beats.ts
@@ -3,7 +3,7 @@ import type { Env, AppVariables } from "../lib/types";
 import { createRateLimitMiddleware } from "../middleware/rate-limit";
 import { BEAT_RATE_LIMIT } from "../lib/constants";
 import { validateSlug, validateHexColor, validateBtcAddress, sanitizeString } from "../lib/validators";
-import { listBeats, getBeat, createBeat, updateBeat, deleteBeat, getBeatMembership, getConfig } from "../lib/do-client";
+import { getBeat, createBeat, updateBeat, deleteBeat, getBeatMembership, getConfig, getActiveBeatSlugs, listBeats } from "../lib/do-client";
 import { CONFIG_PUBLISHER_ADDRESS } from "../lib/constants";
 import { verifyAuth } from "../services/auth";
 
@@ -80,10 +80,7 @@ beatsRouter.get("/api/beats/:slug", async (c) => {
   }
 
   if (b.status === "retired") {
-    const allBeats = await listBeats(c.env);
-    const activeBeats = allBeats
-      .filter((beat) => beat.status !== "retired")
-      .map((beat) => beat.slug);
+    const activeBeats = await getActiveBeatSlugs(c.env);
     return c.json(
       {
         error: `Beat "${slug}" is retired and no longer accepts signals.`,

--- a/src/routes/beats.ts
+++ b/src/routes/beats.ts
@@ -78,6 +78,21 @@ beatsRouter.get("/api/beats/:slug", async (c) => {
   if (!b) {
     return c.json({ error: `Beat "${slug}" not found` }, 404);
   }
+
+  if (b.status === "retired") {
+    const allBeats = await listBeats(c.env);
+    const activeBeats = allBeats
+      .filter((beat) => beat.status !== "retired")
+      .map((beat) => beat.slug);
+    return c.json(
+      {
+        error: `Beat "${slug}" is retired and no longer accepts signals.`,
+        active_beats: activeBeats,
+      },
+      410
+    );
+  }
+
   const members = b.members ?? [];
   const includeMembers = c.req.query("include") === "members";
   c.header("Cache-Control", "public, max-age=60, s-maxage=300");

--- a/src/routes/signals.ts
+++ b/src/routes/signals.ts
@@ -16,7 +16,7 @@ import {
   createSignal,
   correctSignal,
   getBeat,
-  listBeats,
+  getActiveBeatSlugs,
 } from "../lib/do-client";
 import { verifyAuth } from "../services/auth";
 import { checkAgentIdentity } from "../services/identity-gate";
@@ -232,10 +232,7 @@ signalsRouter.post("/api/signals", signalRateLimit, async (c) => {
     return c.json({ error: `Beat "${beat_slug}" not found` }, 404);
   }
   if (beat.status === "retired") {
-    const allBeats = await listBeats(c.env);
-    const activeBeats = allBeats
-      .filter((b) => b.status !== "retired")
-      .map((b) => b.slug);
+    const activeBeats = await getActiveBeatSlugs(c.env);
     return c.json(
       {
         error: `Beat "${beat_slug}" is retired and no longer accepts signals.`,

--- a/src/routes/signals.ts
+++ b/src/routes/signals.ts
@@ -15,6 +15,8 @@ import {
   getSignal,
   createSignal,
   correctSignal,
+  getBeat,
+  listBeats,
 } from "../lib/do-client";
 import { verifyAuth } from "../services/auth";
 import { checkAgentIdentity } from "../services/identity-gate";
@@ -221,6 +223,25 @@ signalsRouter.post("/api/signals", signalRateLimit, async (c) => {
     return c.json(
       { error: "Invalid tags (array of lowercase slugs, 1-10 items, 2-30 chars each)" },
       400
+    );
+  }
+
+  // Reject signals filed against retired beats with 410 Gone
+  const beat = await getBeat(c.env, beat_slug as string);
+  if (!beat) {
+    return c.json({ error: `Beat "${beat_slug}" not found` }, 404);
+  }
+  if (beat.status === "retired") {
+    const allBeats = await listBeats(c.env);
+    const activeBeats = allBeats
+      .filter((b) => b.status !== "retired")
+      .map((b) => b.slug);
+    return c.json(
+      {
+        error: `Beat "${beat_slug}" is retired and no longer accepts signals.`,
+        active_beats: activeBeats,
+      },
+      410
     );
   }
 


### PR DESCRIPTION
## Summary

Closes #461

- `GET /api/beats/:slug` now returns **410 Gone** when the beat has `status=retired`, with an `active_beats` list so agents know where to reclaim
- `POST /api/signals` rejects submissions to retired beats with **410 Gone** and the same `active_beats` list, placed after input validation but before auth/identity checks
- Agents parsing the 410 can self-correct onto an active beat instead of wasting compute on dead beats

## Test plan

- [ ] `GET /api/beats/agent-economy` returns 410 with `active_beats` array
- [ ] `GET /api/beats/aibtc-network` returns 200 as before
- [ ] `POST /api/signals` with `beat_slug: "agent-economy"` returns 410
- [ ] `POST /api/signals` with `beat_slug: "aibtc-network"` proceeds through auth as before
- [ ] Input validation (bad slug, bad btc address, etc.) still returns 400 before the beat check

🤖 Generated with [Claude Code](https://claude.com/claude-code)