### PR TITLE
feat(beats): expose dailyApprovedLimit and editorReviewRateSats in GET responses (closes #464)

### DIFF
--- a/src/__tests__/beats.test.ts
+++ b/src/__tests__/beats.test.ts
@@ -12,6 +12,21 @@ describe("GET /api/beats", () => {
     const body = await res.json<unknown[]>();
     expect(Array.isArray(body)).toBe(true);
   });
+
+  it("exposes dailyApprovedLimit and editorReviewRateSats on each beat (issue #464)", async () => {
+    const res = await SELF.fetch("http://example.com/api/beats");
+    expect(res.status).toBe(200);
+    const body = await res.json<Array<Record<string, unknown>>>();
+    for (const beat of body) {
+      expect(beat).toHaveProperty("dailyApprovedLimit");
+      expect(beat).toHaveProperty("editorReviewRateSats");
+      // Nullable numeric fields: null when unset, integer when configured
+      const daily = beat.dailyApprovedLimit;
+      expect(daily === null || typeof daily === "number").toBe(true);
+      const rate = beat.editorReviewRateSats;
+      expect(rate === null || typeof rate === "number").toBe(true);
+    }
+  });
 });
 
 describe("GET /api/beats/:slug — not found", () => {

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -1292,6 +1292,8 @@ export class NewsDO extends DurableObject<Env> {
           created_by: row.created_by,
           created_at: row.created_at,
           updated_at: row.updated_at,
+          daily_approved_limit: row.daily_approved_limit as number | null,
+          editor_review_rate_sats: row.editor_review_rate_sats as number | null,
           status,
           members: claimsByBeat.get(row.slug as string) ?? [],
           editor: editorByBeat.get(row.slug as string) ?? null,

--- a/src/routes/beats.ts
+++ b/src/routes/beats.ts
@@ -31,6 +31,8 @@ beatsRouter.get("/api/beats", async (c) => {
       claimedBy: b.created_by,
       claimedAt: b.created_at,
       status: b.status,
+      dailyApprovedLimit: b.daily_approved_limit ?? null,
+      editorReviewRateSats: b.editor_review_rate_sats ?? null,
       ...(includeMembers
         ? { members: members.map((m) => ({ address: m.btc_address, claimedAt: m.claimed_at })) }
         : { memberCount: members.length }),
@@ -101,6 +103,8 @@ beatsRouter.get("/api/beats/:slug", async (c) => {
     claimedBy: b.created_by,
     claimedAt: b.created_at,
     status: b.status,
+    dailyApprovedLimit: b.daily_approved_limit ?? null,
+    editorReviewRateSats: b.editor_review_rate_sats ?? null,
     ...(includeMembers
       ? { members: members.map((m) => ({ address: m.btc_address, claimedAt: m.claimed_at })) }
       : { memberCount: members.length }),


### PR DESCRIPTION
Closes #464.

## What
The per-beat config columns `daily_approved_limit` (added in migration 17, PR #397) and `editor_review_rate_sats` (migration 19) are stored and accepted by PATCH but were not exposed in `GET /api/beats` or `GET /api/beats/:slug`.

## Changes
- `src/objects/news-do.ts` — include both fields in the `/beats` list-handler Beat mapping (they were already in `getBeat` at line 1412-1413 but missing in `listBeats`)
- `src/routes/beats.ts` — expose as camelCase (`dailyApprovedLimit`, `editorReviewRateSats`) on both list and single-beat GET responses, consistent with existing snake_case → camelCase transform
- Both fields are nullable (`null` when unset, integer when configured)
- `src/__tests__/beats.test.ts` — new test asserts both fields are present on every beat in the list response

## Verification
- `npm run typecheck` — clean
- `vitest run src/__tests__/beats.test.ts` — 12/12 pass (11 existing + 1 new)

## Expected response shape (matches issue #464)
```json
{
  "slug": "quantum",
  "editor": { "address": "bc1q...", "assignedAt": "..." },
  "memberCount": 197,
  "dailyApprovedLimit": 10,
  "editorReviewRateSats": 175000
}
```

cc @rising-leviathan @arc0btc