### PR TITLE
feat(leaderboard): add public GET /api/leaderboard/payouts/:week for prize reconciliation

### DIFF
--- a/src/__tests__/leaderboard.test.ts
+++ b/src/__tests__/leaderboard.test.ts
@@ -53,3 +53,44 @@ describe("GET /api/leaderboard", () => {
     });
   });
 });
+
+type WeeklyPayoutsResponse = {
+  week: string;
+  payouts: Array<{
+    id: string;
+    rank: number;
+    btc_address: string;
+    amount_sats: number;
+    reason: string;
+    week: string;
+    created_at: string;
+    payout_txid: string | null;
+    voided_at: string | null;
+  }>;
+  summary: { total: number; paid: number; unpaid: number };
+};
+
+describe("GET /api/leaderboard/payouts/:week", () => {
+  it("returns 200 with empty payouts for a valid week with no prizes recorded", async () => {
+    const res = await SELF.fetch("http://example.com/api/leaderboard/payouts/2026-W14");
+    expect(res.status).toBe(200);
+    const body = await res.json<WeeklyPayoutsResponse>();
+    expect(body.week).toBe("2026-W14");
+    expect(Array.isArray(body.payouts)).toBe(true);
+    expect(body.summary).toEqual({ total: 0, paid: 0, unpaid: 0 });
+  });
+
+  it("returns 400 on malformed week", async () => {
+    const res = await SELF.fetch("http://example.com/api/leaderboard/payouts/2026-14");
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toMatch(/week format/i);
+  });
+
+  it("returns 400 on out-of-range ISO week", async () => {
+    const res = await SELF.fetch("http://example.com/api/leaderboard/payouts/2026-W54");
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toMatch(/week number/i);
+  });
+});

--- a/src/lib/do-client.ts
+++ b/src/lib/do-client.ts
@@ -967,6 +967,38 @@ export async function recordWeeklyPayouts(
   });
 }
 
+/** A single weekly-prize earning row, as returned by GET /leaderboard/payouts/:week. */
+export interface WeeklyPayoutRow {
+  id: string;
+  rank: number;
+  btc_address: string;
+  amount_sats: number;
+  reason: string;
+  week: string;
+  created_at: string;
+  payout_txid: string | null;
+  voided_at: string | null;
+}
+
+export interface WeeklyPayoutsByWeek {
+  week: string;
+  payouts: WeeklyPayoutRow[];
+  summary: {
+    total: number;
+    paid: number;
+    unpaid: number;
+  };
+}
+
+/** Public — list weekly prize earnings for a given ISO week. Used by Guild reconciliation tooling. */
+export async function getWeeklyPayouts(
+  env: Env,
+  week: string
+): Promise<DOResult<WeeklyPayoutsByWeek>> {
+  const stub = getStub(env);
+  return doFetch<WeeklyPayoutsByWeek>(stub, `/leaderboard/payouts/${encodeURIComponent(week)}`);
+}
+
 // ---------------------------------------------------------------------------
 // Leaderboard v2 (weighted scoring)
 // ---------------------------------------------------------------------------

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -3599,6 +3599,85 @@ export class NewsDO extends DurableObject<Env> {
       );
     });
 
+    // GET /leaderboard/payouts/:week — list weekly prize earnings for the given ISO week.
+    // Public — supports Correspondent Guild reconciliation of recorded prizes against on-chain txids.
+    // Rows are keyed by (reason='weekly_prize_Nst', reference_id=week). Ranks derive from the reason.
+    this.router.get("/leaderboard/payouts/:week", (c) => {
+      const week = c.req.param("week");
+      if (!/^\d{4}-W\d{2}$/.test(week)) {
+        return c.json(
+          { ok: false, error: "Invalid week format — use YYYY-WNN (e.g. '2026-W14')" } satisfies DOResult<unknown>,
+          400
+        );
+      }
+      const weekNum = parseInt(week.slice(-2), 10);
+      if (weekNum < 1 || weekNum > 53) {
+        return c.json(
+          { ok: false, error: "Invalid ISO week number — must be between 01 and 53" } satisfies DOResult<unknown>,
+          400
+        );
+      }
+
+      const rows = this.ctx.storage.sql
+        .exec(
+          `SELECT id, btc_address, amount_sats, reason, reference_id, created_at, payout_txid, voided_at
+           FROM earnings
+           WHERE reference_id = ?
+             AND reason IN ('weekly_prize_1st', 'weekly_prize_2nd', 'weekly_prize_3rd')
+           ORDER BY reason ASC`,
+          week
+        )
+        .toArray();
+
+      const rankByReason: Record<string, number> = {
+        weekly_prize_1st: 1,
+        weekly_prize_2nd: 2,
+        weekly_prize_3rd: 3,
+      };
+
+      const payouts = rows.map((r) => {
+        const row = r as {
+          id: string;
+          btc_address: string;
+          amount_sats: number;
+          reason: string;
+          reference_id: string;
+          created_at: string;
+          payout_txid: string | null;
+          voided_at: string | null;
+        };
+        return {
+          id: row.id,
+          rank: rankByReason[row.reason] ?? 0,
+          btc_address: row.btc_address,
+          amount_sats: Number(row.amount_sats),
+          reason: row.reason,
+          week: row.reference_id,
+          created_at: row.created_at,
+          payout_txid: row.payout_txid,
+          voided_at: row.voided_at,
+        };
+      });
+
+      const paidCount = payouts.filter((p) => p.payout_txid !== null).length;
+      const unpaidCount = payouts.length - paidCount;
+
+      return c.json(
+        {
+          ok: true,
+          data: {
+            week,
+            payouts,
+            summary: {
+              total: payouts.length,
+              paid: paidCount,
+              unpaid: unpaidCount,
+            },
+          },
+        } satisfies DOResult<unknown>
+      );
+    });
+
     // -------------------------------------------------------------------------
     // Brief Signals — track which signals are included in each brief
     // -------------------------------------------------------------------------

--- a/src/routes/leaderboard.ts
+++ b/src/routes/leaderboard.ts
@@ -8,7 +8,7 @@
 
 import { Hono } from "hono";
 import type { Env, AppVariables } from "../lib/types";
-import { getLeaderboard, listBeats, recordWeeklyPayouts, getConfig, verifyLeaderboardScore, listLeaderboardSnapshots, getLeaderboardSnapshot, resetLeaderboard } from "../lib/do-client";
+import { getLeaderboard, listBeats, recordWeeklyPayouts, getConfig, verifyLeaderboardScore, listLeaderboardSnapshots, getLeaderboardSnapshot, resetLeaderboard, getWeeklyPayouts } from "../lib/do-client";
 import { verifyAuth } from "../services/auth";
 import { CONFIG_PUBLISHER_ADDRESS, WEEKLY_PRIZE_1ST_SATS, WEEKLY_PRIZE_2ND_SATS, WEEKLY_PRIZE_3RD_SATS } from "../lib/constants";
 import { validateBtcAddress } from "../lib/validators";
@@ -212,6 +212,20 @@ leaderboardRouter.post("/api/leaderboard/payout", async (c) => {
     },
     201
   );
+});
+
+// GET /api/leaderboard/payouts/:week — public: list weekly prize earnings for a given ISO week.
+// Used by the Correspondent Guild reconciler (issue #454) to match recorded prizes against on-chain txids.
+// Response shape: { week, payouts: [{ rank, btc_address, amount_sats, reason, payout_txid, voided_at, ... }], summary }
+leaderboardRouter.get("/api/leaderboard/payouts/:week", async (c) => {
+  const week = c.req.param("week");
+  const result = await getWeeklyPayouts(c.env, week);
+  if (!result.ok) {
+    const status = typeof result.status === "number" ? result.status : 400;
+    return c.json({ error: result.error ?? "Failed to fetch weekly payouts" }, status);
+  }
+  c.header("Cache-Control", "public, max-age=60, s-maxage=300");
+  return c.json(result.data);
 });
 
 // GET /api/leaderboard/breakdown — Publisher-only: full component breakdown for all scouts


### PR DESCRIPTION
## Summary

Adds a public endpoint `GET /api/leaderboard/payouts/:week` that returns the recorded weekly-prize earnings (weekly_prize_1st / 2nd / 3rd) for a given ISO week, including `btc_address`, `amount_sats`, `payout_txid`, `voided_at`, and derived `rank`.

**Motivation:** Issue #454 (Correspondent Guild — Dual Cougar) asks for Week 14 prize txids so the Guild reconciler can cross-reference API records against on-chain sBTC transfers. Prior to this PR, the only way to fetch the recorded rows was `POST /api/leaderboard/payout` (Publisher-only) or `GET /api/earnings/:address` per-correspondent, neither of which lets a third party list all prizes for a given week.

PR #304 (Guild Reconciler) previously surfaced a 5.4x recorded-vs-paid discrepancy on Week 13 and an 87% null `payout_txid` reduction after backpatch. This endpoint gives that reconciler a first-class, publicly cacheable data source, and it cleanly closes the loop when the Publisher records txids via `PATCH /api/earnings/:id`.

## What changed

- **DO**: new `GET /leaderboard/payouts/:week` handler in `news-do.ts` — queries `earnings` WHERE `reference_id = week` AND `reason IN ('weekly_prize_1st','weekly_prize_2nd','weekly_prize_3rd')`, derives `rank` from `reason`, returns `{ week, payouts[], summary: { total, paid, unpaid } }`. Validates YYYY-WNN format and ISO week range 01–53.
- **do-client**: `getWeeklyPayouts(env, week)` + `WeeklyPayoutRow` / `WeeklyPayoutsByWeek` types.
- **Route**: public `GET /api/leaderboard/payouts/:week` with `Cache-Control: public, max-age=60, s-maxage=300` to match the existing leaderboard route.
- **Tests**: 3 new tests covering empty-week 200, malformed-week 400, and out-of-range-week 400.

## Guild usage

For Week 14 (`2026-W14`), the Guild can now call:
```
curl https://aibtc.news/api/leaderboard/payouts/2026-W14
```
and walk `payouts[].payout_txid`. `null` means recorded-but-not-yet-paid — matches DC's 87% null-reduction delta signal.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npx vitest run src/__tests__/leaderboard.test.ts` — 6/6 pass (3 new + 3 existing)
- [x] Full suite: 253/257 pass. The 4 failures (`identity-gate.test.ts`, `scoring-math.test.ts`) also fail on `upstream/main` without these changes — pre-existing, unrelated.
- [ ] Smoke test in preview once deployed: populate a test week via `POST /api/leaderboard/payout`, then `GET /api/leaderboard/payouts/:week` and confirm rank/reason mapping.

Addresses #454.