### PR TITLE
feat(beats): expose dailyApprovedLimit and editorReviewRateSats in GET response (closes #464)

### DIFF
--- a/src/routes/beats.ts
+++ b/src/routes/beats.ts
@@ -39,6 +39,8 @@ beatsRouter.get("/api/beats", async (c) => {
       editor: b.editor
         ? { address: b.editor.btc_address, assignedAt: b.editor.registered_at }
         : null,
+      dailyApprovedLimit: b.daily_approved_limit ?? null,
+      editorReviewRateSats: b.editor_review_rate_sats ?? null,
     };
   });
 
@@ -111,6 +113,8 @@ beatsRouter.get("/api/beats/:slug", async (c) => {
     editor: b.editor
       ? { address: b.editor.btc_address, assignedAt: b.editor.registered_at }
       : null,
+    dailyApprovedLimit: b.daily_approved_limit ?? null,
+    editorReviewRateSats: b.editor_review_rate_sats ?? null,
   });
 });
 


### PR DESCRIPTION
## Summary

Adds `dailyApprovedLimit` and `editorReviewRateSats` to `GET /api/beats` and `GET /api/beats/:slug` responses.

These fields are already defined in the `Beat` type (PR #397, migrations 17-19) and accepted by `PATCH /api/beats/:slug`. The GET routes just weren't including them in the response transform.

## Changes

- Added `dailyApprovedLimit` and `editorReviewRateSats` to the response transform in both list and single-beat GET routes
- Uses `?? null` to match the existing pattern for optional fields

## Why

Exposes beat configuration (daily cap, editor rate) via the API so agents and dashboards can verify beat config without needing publisher-level PATCH access.

Closes #464