### PR TITLE
fix(review): align approval cap bucketing with compile on created_at

### DIFF
--- a/src/__tests__/brief-compile-reconciliation.test.ts
+++ b/src/__tests__/brief-compile-reconciliation.test.ts
@@ -97,10 +97,9 @@ describe("brief compile reconciliation", () => {
     expect(includedBody.signals).toHaveLength(3);
   });
 
-  it("enforces the 30-signal cap and reconciles replaced status, brief_signals, and payouts on recompile", async () => {
+  it("rejects compilation when approved signals exceed the brief cap (invariant violation)", async () => {
     const date = "2026-04-11";
     const signals = [];
-    const briefSignals = [];
     for (let i = 0; i < 31; i++) {
       const id = `over-cap-${i.toString().padStart(2, "0")}`;
       signals.push({
@@ -110,95 +109,21 @@ describe("brief compile reconciliation", () => {
         headline: `Overflow candidate ${i}`,
         sources: "[]",
         created_at: `2026-04-11T12:${i.toString().padStart(2, "0")}:00Z`,
-        status: "brief_included",
+        status: "approved",
         reviewed_at: `2026-04-11T23:${i.toString().padStart(2, "0")}:00Z`,
-      });
-      briefSignals.push({
-        brief_date: date,
-        signal_id: id,
-        btc_address: i % 2 === 0 ? REPORTER_A : REPORTER_B,
-        position: i,
-        created_at: "2026-04-11T23:59:00Z",
       });
     }
 
-    await seed({
-      signals,
-      brief_signals: briefSignals,
-      earnings: [
-        {
-          id: "earning-overflow-00",
-          btc_address: REPORTER_A,
-          amount_sats: 30000,
-          reason: "brief_inclusion",
-          reference_id: "over-cap-00",
-          created_at: "2026-04-11T23:59:30Z",
-        },
-      ],
-    });
+    await seed({ signals });
 
-    const firstCompileRes = await compile(date);
-    expect(firstCompileRes.status).toBe(201);
-    const firstCompile = await firstCompileRes.json<{
-      brief: {
-        included_signal_ids: string[];
-        included_signals: Array<{ signal_id: string; position: number }>;
-        roster: { candidate_count: number; selected_count: number; overflow_count: number };
-      };
-      payouts: { paid: number; skipped: number; revived: number; voided: number };
-    }>();
-
-    // Simplified compile orders by reviewed_at DESC — most recently reviewed first.
-    // With 31 signals (reviewed_at 23:00-23:30), signal 30 (latest) is first,
-    // signal 00 (earliest) is the overflow candidate dropped at the 30-signal cap.
-    expect(firstCompile.brief.included_signal_ids).toHaveLength(30);
-    expect(firstCompile.brief.included_signal_ids[0]).toBe("over-cap-30");
-    expect(firstCompile.brief.included_signal_ids[29]).toBe("over-cap-01");
-    expect(firstCompile.brief.roster).toEqual(expect.objectContaining({
-      candidate_count: 31,
-      selected_count: 30,
-      overflow_count: 1,
-    }));
-    expect(firstCompile.payouts).toEqual({
-      paid: 30,
-      skipped: 0,
-      revived: 0,
-      voided: 1,
-    });
-
-    const briefSignalsRes = await SELF.fetch(`http://example.com/api/test/brief-signals/${date}`);
-    expect(briefSignalsRes.status).toBe(200);
-    const briefSignalsBody = await briefSignalsRes.json<{ ok: true; data: Array<{ signal_id: string }> }>();
-    expect(briefSignalsBody.data).toHaveLength(30);
-    expect(briefSignalsBody.data.some((row) => row.signal_id === "over-cap-00")).toBe(false);
-
-    const replacedRes = await SELF.fetch(`http://example.com/api/signals?date=${date}&status=replaced`);
-    expect(replacedRes.status).toBe(200);
-    const replacedBody = await replacedRes.json<{ signals: Array<{ id: string }> }>();
-    expect(replacedBody.signals.map((signal) => signal.id)).toContain("over-cap-00");
-
-    const curatedRes = await SELF.fetch("http://example.com/api/front-page");
-    expect(curatedRes.status).toBe(200);
-    const curatedBody = await curatedRes.json<{ signals: Array<{ id: string }> }>();
-    expect(curatedBody.signals.some((signal) => signal.id === "over-cap-00")).toBe(false);
-
-    const secondCompileRes = await compile(date);
-    expect(secondCompileRes.status).toBe(201);
-    const secondCompile = await secondCompileRes.json<{
-      brief: { included_signal_ids: string[]; roster: { candidate_count: number; overflow_count: number } };
-      payouts: { paid: number; skipped: number; revived: number; voided: number };
-    }>();
-    expect(secondCompile.brief.included_signal_ids).toEqual(firstCompile.brief.included_signal_ids);
-    expect(secondCompile.brief.roster).toEqual(expect.objectContaining({
-      candidate_count: 30,
-      overflow_count: 0,
-    }));
-    expect(secondCompile.payouts).toEqual({
-      paid: 0,
-      skipped: 30,
-      revived: 0,
-      voided: 0,
-    });
+    // Compile should reject: 31 approved signals exceeds MAX_INCLUDED_SIGNALS_PER_BRIEF (30).
+    // After review-time caps were aligned to created_at, this overflow should be unreachable
+    // in normal operation — this test verifies the compile-time safety net surfaces the error.
+    const compileRes = await compile(date);
+    expect(compileRes.status).toBe(409);
+    const body = await compileRes.json<{ error: string }>();
+    expect(body.error).toContain("invariant violated");
+    expect(body.error).toContain("31");
   }, 40000);
 
   it("blocks subtractive recompile after inscription", async () => {

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -980,14 +980,14 @@ export class NewsDO extends DurableObject<Env> {
 
       // Verify signal exists first so we know its beat_slug and author for auth check
       const signalRows = this.ctx.storage.sql
-        .exec("SELECT id, status, beat_slug, btc_address FROM signals WHERE id = ?", id)
+        .exec("SELECT id, status, beat_slug, btc_address, created_at FROM signals WHERE id = ?", id)
         .toArray();
       if (signalRows.length === 0) {
         return c.json({ ok: false, error: `Signal "${id}" not found` } satisfies DOResult<Signal>, 404);
       }
 
       // State machine: prevent editorial regressions
-      const signalRow = signalRows[0] as { id: string; status: SignalStatus; beat_slug: string; btc_address: string };
+      const signalRow = signalRows[0] as { id: string; status: SignalStatus; beat_slug: string; btc_address: string; created_at: string };
       const currentStatus = signalRow.status;
       const newStatus = status as SignalStatus; // validated above against SIGNAL_STATUSES
       const allowed = SIGNAL_VALID_TRANSITIONS[currentStatus] ?? [];
@@ -1036,6 +1036,23 @@ export class NewsDO extends DurableObject<Env> {
         }
       }
 
+      // ── Inscription guard for approvals ─────────────────────────────
+      // Prevent approving a signal whose brief day is already inscribed on-chain.
+      // The retract path has a mirror guard (brief_included → replaced/rejected).
+      if (newStatus === "approved") {
+        const signalDate = getUTCDate(new Date(signalRow.created_at));
+        const briefRows = this.ctx.storage.sql
+          .exec("SELECT inscription_id FROM briefs WHERE date = ?", signalDate)
+          .toArray();
+        const inscription = briefRows[0] as { inscription_id: string | null } | undefined;
+        if (inscription?.inscription_id) {
+          return c.json({
+            ok: false,
+            error: `Cannot approve a signal whose brief (${signalDate}) is already inscribed on-chain. The brief is immutable; submit a correction signal for a future brief instead.`,
+          } satisfies DOResult<Signal>, 409);
+        }
+      }
+
       // ── Daily approval cap ────────────────────────────────────────────
       // When approving, enforce MAX_APPROVED_SIGNALS_PER_DAY. If at cap,
       // require displace_signal_id to atomically swap one out.
@@ -1043,9 +1060,12 @@ export class NewsDO extends DurableObject<Env> {
       const nowDate = new Date();
 
       if (newStatus === "approved") {
-        const today = getUTCDate(nowDate);
-        const dayStart = getUTCDayStart(today);
-        const dayEnd = getUTCDayEnd(today);
+        // Bucket by the signal's created_at day to match brief compilation
+        // (POST /briefs/compile). reviewed_at is updated on every status change,
+        // which would mis-count historical re-approvals against the wrong day.
+        const signalDay = getUTCDate(new Date(signalRow.created_at));
+        const dayStart = getUTCDayStart(signalDay);
+        const dayEnd = getUTCDayEnd(signalDay);
 
         // Determine the effective cap: use beat's daily_approved_limit if set.
         // NULL = no per-beat cap (unlimited). The global MAX_APPROVED_SIGNALS_PER_DAY
@@ -1062,7 +1082,7 @@ export class NewsDO extends DurableObject<Env> {
           .exec(
             `SELECT COUNT(*) as count FROM signals
              WHERE status IN ('approved', 'brief_included')
-               AND reviewed_at >= ? AND reviewed_at < ?`,
+               AND created_at >= ? AND created_at < ?`,
             dayStart, dayEnd
           )
           .toArray();
@@ -1078,7 +1098,7 @@ export class NewsDO extends DurableObject<Env> {
             .exec(
               `SELECT COUNT(*) as count FROM signals
                WHERE beat_slug = ? AND status IN ('approved', 'brief_included')
-                 AND reviewed_at >= ? AND reviewed_at < ?`,
+                 AND created_at >= ? AND created_at < ?`,
               signalRow.beat_slug, dayStart, dayEnd
             )
             .toArray();
@@ -1110,22 +1130,22 @@ export class NewsDO extends DurableObject<Env> {
 
           // Validate displacement target
           const displaceRows = this.ctx.storage.sql
-            .exec("SELECT id, status, reviewed_at, beat_slug FROM signals WHERE id = ?", displaceId)
+            .exec("SELECT id, status, created_at, beat_slug FROM signals WHERE id = ?", displaceId)
             .toArray();
           if (displaceRows.length === 0) {
             return c.json({ ok: false, error: `Displace target "${displaceId}" not found` } satisfies DOResult<Signal>, 404);
           }
-          const displaceRow = displaceRows[0] as { id: string; status: string; reviewed_at: string | null; beat_slug: string };
+          const displaceRow = displaceRows[0] as { id: string; status: string; created_at: string; beat_slug: string };
           if (displaceRow.status !== "approved") {
             return c.json({
               ok: false,
               error: `Displace target must have status "approved", got "${displaceRow.status}". Only "approved" signals can be displaced (not "brief_included" or other statuses).`,
             } satisfies DOResult<Signal>, 400);
           }
-          if (!displaceRow.reviewed_at || displaceRow.reviewed_at < dayStart || displaceRow.reviewed_at >= dayEnd) {
+          if (displaceRow.created_at < dayStart || displaceRow.created_at >= dayEnd) {
             return c.json({
               ok: false,
-              error: `Displace target was not approved today. Only today's approved signals can be displaced.`,
+              error: `Displace target was not created on the same day as this signal (${signalDay}). Only same-bucket approved signals can be displaced.`,
             } satisfies DOResult<Signal>, 400);
           }
           // When per-beat cap triggered the displacement, target must be on the same beat
@@ -2419,24 +2439,28 @@ export class NewsDO extends DurableObject<Env> {
         .toArray()
         .map((row) => rowToCompiledSignal(row as Record<string, unknown>));
 
-      // Safety cap at MAX_INCLUDED_SIGNALS_PER_BRIEF. Candidates are already ordered by
-      // reviewed_at DESC, created_at DESC, id ASC above, so compilation deterministically
-      // includes the first N approved candidates for the day. This is the effective
-      // selection behavior whenever approvals exceed the brief limit.
-      // Note: fetches all candidates to preserve candidate_count accuracy; revisit
-      // with SQL LIMIT + separate COUNT if daily volumes grow significantly.
-      const selectedSignals = candidateSignals.slice(0, MAX_INCLUDED_SIGNALS_PER_BRIEF);
-      const includedSignals = buildIncludedSignalMetadata(selectedSignals);
+      // Enforce MAX_INCLUDED_SIGNALS_PER_BRIEF as an invariant. Review-time caps
+      // (aligned on created_at) should prevent exceeding this. If we get more
+      // candidates than the cap, a cap-enforcement gap exists — surface it loudly
+      // rather than silently dropping signals that would never appear in any brief.
+      if (candidateSignals.length > MAX_INCLUDED_SIGNALS_PER_BRIEF) {
+        return c.json({
+          ok: false,
+          error: `Brief compilation invariant violated: ${candidateSignals.length} approved signals for ${date} exceeds MAX_INCLUDED_SIGNALS_PER_BRIEF (${MAX_INCLUDED_SIGNALS_PER_BRIEF}). This indicates a cap-enforcement gap in the review path. Retract ${candidateSignals.length - MAX_INCLUDED_SIGNALS_PER_BRIEF} excess approval(s) before compiling.`,
+        } satisfies DOResult<CompiledBriefData>, 409);
+      }
+
+      const includedSignals = buildIncludedSignalMetadata(candidateSignals);
 
       const compiledAt = now.toISOString();
       const data: CompiledBriefData = {
         date,
         compiled_at: compiledAt,
-        signals: selectedSignals,
+        signals: candidateSignals,
         included_signal_ids: includedSignals.map((signal) => signal.signal_id),
         included_signals: includedSignals,
         candidate_count: candidateSignals.length,
-        overflow_count: Math.max(0, candidateSignals.length - MAX_INCLUDED_SIGNALS_PER_BRIEF),
+        overflow_count: 0,
       };
 
       return c.json({ ok: true, data } satisfies DOResult<CompiledBriefData>);

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -2420,6 +2420,9 @@ export class NewsDO extends DurableObject<Env> {
       // Simplified compile: the roster IS the set of approved signals for the day.
       // All curation happened at review time via cap-enforced approval.
       // Include both 'approved' (new) and 'brief_included' (recompile) signals.
+      // ORDER BY uses reviewed_at DESC intentionally: bucketing is on created_at
+      // (which day's brief a signal belongs to), but position within a brief is
+      // driven by editorial recency — most recently reviewed signal ranks highest.
       const candidateSignals = this.ctx.storage.sql
         .exec(
           `SELECT s.id, s.beat_slug, s.btc_address, s.headline, s.body, s.sources,
@@ -2446,7 +2449,7 @@ export class NewsDO extends DurableObject<Env> {
       if (candidateSignals.length > MAX_INCLUDED_SIGNALS_PER_BRIEF) {
         return c.json({
           ok: false,
-          error: `Brief compilation invariant violated: ${candidateSignals.length} approved signals for ${date} exceeds MAX_INCLUDED_SIGNALS_PER_BRIEF (${MAX_INCLUDED_SIGNALS_PER_BRIEF}). This indicates a cap-enforcement gap in the review path. Retract ${candidateSignals.length - MAX_INCLUDED_SIGNALS_PER_BRIEF} excess approval(s) before compiling.`,
+          error: `Brief compilation invariant violated: ${candidateSignals.length} approved/brief_included signals for ${date} exceeds MAX_INCLUDED_SIGNALS_PER_BRIEF (${MAX_INCLUDED_SIGNALS_PER_BRIEF}). This indicates a cap-enforcement gap in the review path. Retract ${candidateSignals.length - MAX_INCLUDED_SIGNALS_PER_BRIEF} excess approval(s) before compiling.`,
         } satisfies DOResult<CompiledBriefData>, 409);
       }
 
@@ -2460,6 +2463,8 @@ export class NewsDO extends DurableObject<Env> {
         included_signal_ids: includedSignals.map((signal) => signal.signal_id),
         included_signals: includedSignals,
         candidate_count: candidateSignals.length,
+        // Invariant: review-time cap enforcement (aligned on created_at) prevents
+        // overflow from reaching compile. The guard above rejects if violated.
         overflow_count: 0,
       };
 

--- a/src/routes/brief-compile.ts
+++ b/src/routes/brief-compile.ts
@@ -79,7 +79,7 @@ async function handleBriefCompile(
   // Compile raw signal + beat + streak data from the Durable Object
   const compileResult = await compileBriefData(c.env, date);
   if (!compileResult.ok || !compileResult.data) {
-    return c.json({ error: compileResult.error ?? "Failed to compile brief data" }, 500);
+    return c.json({ error: compileResult.error ?? "Failed to compile brief data" }, compileResult.status ?? 500);
   }
 
   const { signals, compiled_at, included_signal_ids, included_signals, candidate_count, overflow_count } = compileResult.data;


### PR DESCRIPTION
## Summary

Fixes the dimension mismatch between review-time approval caps (bucketed by `reviewed_at`) and brief compilation (bucketed by `created_at`). This caused historical re-approvals to consume today's cap budget, blocking editors and the publisher agent from normal operations.

- **Cap queries**: bucket by signal `created_at` instead of `reviewed_at` to match compile
- **Displacement validation**: target must share the same `created_at` day, not "reviewed today"
- **Inscription guard**: block approvals for signals whose brief is already inscribed on-chain
- **Compile invariant**: reject overflow instead of silently trimming via `.slice()`
- **Status propagation**: forward DO error status through the brief-compile route

## Test plan

- [x] Typecheck passes (`npm run typecheck`)
- [x] Lint passes (`npm run check`)
- [x] Signal review tests pass (11/11)
- [x] Compile reconciliation tests updated and pass (overflow → 409, under-cap → 201)
- [ ] Manual: restore a backdated signal (created_at != today) and confirm it counts against the signal's day, not today
- [ ] Manual: attempt to approve a signal for an inscribed brief day → expect 409

Closes #499

🤖 Generated with [Claude Code](https://claude.com/claude-code)