### PR TITLE
chore(migration): Apr 7 amendment + clear 8 RBF payout_txid + void 98 Mar 31 over-cap earnings

### DIFF
--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -5,7 +5,7 @@ import type { Env, Beat, Signal, SignalStatus, Streak, Brief, Classified, Classi
 import { validateSlug, validateHexColor, sanitizeString, validateDateFormat } from "../lib/validators";
 import { generateId, getUTCDate, getUTCYesterday, getUTCDayStart, getUTCDayEnd, getNextDate } from "../lib/helpers";
 import { CLASSIFIED_DURATION_DAYS, CLASSIFIED_BRIEF_SLOTS, CLASSIFIED_BRIEF_MAX_CHARS, CLASSIFIED_STATUSES, SIGNAL_COOLDOWN_HOURS, BEAT_EXPIRY_DAYS, MAX_SIGNALS_PER_DAY, MAX_INCLUDED_SIGNALS_PER_BRIEF, MAX_APPROVED_SIGNALS_PER_DAY, SIGNAL_STATUSES, REVIEWABLE_SIGNAL_STATUSES, CONFIG_PUBLISHER_ADDRESS, BRIEF_INCLUSION_PAYOUT_SATS, WEEKLY_PRIZE_1ST_SATS, WEEKLY_PRIZE_2ND_SATS, WEEKLY_PRIZE_3RD_SATS, SCORING_WEIGHTS, PAYMENT_STAGE_TTL_MS } from "../lib/constants";
-import { SCHEMA_SQL, MIGRATION_PHASE0_SQL, MIGRATION_PAYMENTS_SQL, MIGRATION_BEAT_RESTRUCTURE_SQL, MIGRATION_SBTC_TRACKING_SQL, MIGRATION_CLASSIFIEDS_CLEANUP_SQL, MIGRATION_CLASSIFIEDS_REVIEW_SQL, MIGRATION_SNAPSHOTS_SQL, MIGRATION_BEAT_CLAIMS_SQL, MIGRATION_RETRACTION_SQL, MIGRATION_BEAT_NETWORK_FOCUS_SQL, MIGRATION_BITCOIN_MACRO_SQL, MIGRATION_QUANTUM_BEAT_SQL, MIGRATION_PAYMENT_STAGING_SQL, MIGRATION_APPROVAL_CAP_INDEX_SQL, MIGRATION_BEAT_EDITORS_SQL, MIGRATION_EDITORIAL_REVIEWS_SQL, MIGRATION_EDITOR_REVIEW_RATE_SQL, MIGRATION_CURATION_CLEANUP_SQL, MIGRATION_LEADERBOARD_INDEXES_SQL, MIGRATION_BEAT_CONSOLIDATION_SQL, MIGRATION_SIGNAL_SCORING_SQL } from "./schema";
+import { SCHEMA_SQL, MIGRATION_PHASE0_SQL, MIGRATION_PAYMENTS_SQL, MIGRATION_BEAT_RESTRUCTURE_SQL, MIGRATION_SBTC_TRACKING_SQL, MIGRATION_CLASSIFIEDS_CLEANUP_SQL, MIGRATION_CLASSIFIEDS_REVIEW_SQL, MIGRATION_SNAPSHOTS_SQL, MIGRATION_BEAT_CLAIMS_SQL, MIGRATION_RETRACTION_SQL, MIGRATION_BEAT_NETWORK_FOCUS_SQL, MIGRATION_BITCOIN_MACRO_SQL, MIGRATION_QUANTUM_BEAT_SQL, MIGRATION_PAYMENT_STAGING_SQL, MIGRATION_APPROVAL_CAP_INDEX_SQL, MIGRATION_BEAT_EDITORS_SQL, MIGRATION_EDITORIAL_REVIEWS_SQL, MIGRATION_EDITOR_REVIEW_RATE_SQL, MIGRATION_CURATION_CLEANUP_SQL, MIGRATION_LEADERBOARD_INDEXES_SQL, MIGRATION_BEAT_CONSOLIDATION_SQL, MIGRATION_SIGNAL_SCORING_SQL, MIGRATION_APR7_EARNINGS_SQL } from "./schema";
 import { scoreSignal } from "../lib/signal-scorer";
 
 // ── State machine transition maps ──
@@ -296,7 +296,8 @@ export class NewsDO extends DurableObject<Env> {
     // 22 = Beat consolidation — 12 → 3 beats, retire old beats, create aibtc-network (#423)
     // 23 = Streak UTC migration (backfill last_signal_date from actual signal timestamps)
     // 24 = Signal quality auto-scoring — quality_score INTEGER, score_breakdown TEXT (#343)
-    const CURRENT_MIGRATION_VERSION = 24;
+    // 25 = Publisher payout reconciliation — Apr 7 amendment + clear 8 RBF payout_txid + Mar 31 over-cap void (#502)
+    const CURRENT_MIGRATION_VERSION = 25;
     const versionRows = this.ctx.storage.sql
       .exec("SELECT value FROM config WHERE key = 'migration_version'")
       .toArray();
@@ -643,8 +644,31 @@ export class NewsDO extends DurableObject<Env> {
         }
       }
 
+      // Publisher payout reconciliation (#502):
+      //   (a) Apr 7 amendment — align earnings with 2d999d7f…i0 (pre-void witness content)
+      //       that differs from platform re-curated brief_signals by 14 of 30 signals.
+      //   (b) Clear 8 dropped-mempool RBF payout_txid values (7 Mar 25 + 1 Mar 31)
+      //       so curated-payout.ts can resend the victimized transfers.
+      //   (c) Mar 31 over-cap void — void 98 brief_inclusion earnings not in the curated
+      //       30 (from amended-2026-03-31.html); 29 already-paid stay untouched; 1
+      //       canonical unpaid becomes payable.
+      // All are UPDATE-only + idempotent, mirroring Migration 20 (#385). Per-statement
+      // errors are logged but the version still advances — intentional, since idempotency
+      // means a manual retry is safe and the alternative (pinning the version on partial
+      // failure) blocks all subsequent migrations on a transient storage blip.
+      if (appliedVersion < 25) {
+        for (const stmt of MIGRATION_APR7_EARNINGS_SQL) {
+          try {
+            this.ctx.storage.sql.exec(stmt);
+          } catch (e) {
+            console.error("Apr 7 earnings amendment migration failed:", e);
+          }
+        }
+      }
+
       // Record current migration version so future cold starts skip all of the above.
-      // If migration 22 failed but 23 succeeded, cap at 21 so v22 retries on next cold start.
+      // If migration 22 failed but later migrations succeeded, cap at 21 so v22 retries
+      // on next cold start.
       const versionToWrite = migration22Ok ? CURRENT_MIGRATION_VERSION : 21;
       this.ctx.storage.sql.exec(
         "INSERT INTO config (key, value) VALUES ('migration_version', ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = datetime('now')",

--- a/src/objects/schema.ts
+++ b/src/objects/schema.ts
@@ -669,3 +669,155 @@ export const MIGRATION_SIGNAL_SCORING_SQL = [
   "ALTER TABLE signals ADD COLUMN score_breakdown TEXT DEFAULT NULL",
   "CREATE INDEX IF NOT EXISTS idx_signals_quality_score ON signals(quality_score)",
 ] as const;
+
+/**
+ * Migration 25 — Publisher payout reconciliation (Mar 25 → Apr 9 window).
+ *
+ * Three parts, all UPDATE-only + idempotent, mirroring the Mar 28-29 migration
+ * pattern from #385:
+ *
+ * 1. Apr 7 brief amendment. Apr 7 was inscribed as
+ *      2d999d7fdcca97b36594f35be9ab98656c2c350a525c3a45062320a274016403i0
+ *    using the original pre-void content (30 signals committed in the Apr 14
+ *    child-inscription witness). Platform re-curated to a different 30 after
+ *    the 2026-04-14 wholesale void, then re-compiled. Net result: on-chain
+ *    content and platform `brief_signals` diverge on 14 of 30 signals.
+ *
+ *    Reconcile earnings with the on-chain record:
+ *      - Void `brief_inclusion` earnings for the 14 re-curated signals not on-chain
+ *      - Un-void `brief_inclusion` earnings for the 14 witness signals on-chain.
+ *        Pinned to `voided_at >= 2026-04-14T00:00:00Z` so only the wholesale-void
+ *        is reversed — any prior void for an unrelated reason stays intact.
+ *
+ *    Platform `brief_signals` + `signals.status` are left as-is (PR #500 has
+ *    made them immutable after inscription). API callers continue to see the
+ *    re-curated set at /api/brief/2026-04-07 — a known display asymmetry noted
+ *    in the inscription ledger. Canonical editorial + payout record = on-chain.
+ *
+ * 2. RBF victim `payout_txid` clear. 8 sBTC transfers were evicted from the
+ *    mempool during nonce cleanup (7 on Mar 25, 1 on Mar 31). Their earnings
+ *    still carry the dropped `payout_txid`, which blocks `curated-payout.ts`
+ *    from re-sending (the script treats non-null txid as "already paid").
+ *    Clear those 8 txids so the next payout run can resend; new valid txids
+ *    will PATCH over the cleared rows after send. Dropped txids are preserved
+ *    in the operator's manifest (`db/payouts/track-b-payouts-manifest-*.md`)
+ *    for the audit trail.
+ *
+ * 3. Mar 31 over-cap void. The Mar 31 brief was inscribed with 120+ signals
+ *    (platform now shows 128 `brief_included`); policy honors the 30/day soft
+ *    promise, consistent with the Mar 28/29 amended-brief precedent. The
+ *    canonical 30 is derived from `db/briefs/amended-2026-03-31.html`. Voids
+ *    all `brief_inclusion` earnings for 2026-03-31 signals NOT in the curated
+ *    30. The 29 already-paid earnings stay untouched (WHERE payout_txid IS
+ *    NULL filter skips them). The 1 remaining canonical signal that is
+ *    currently unpaid stays both un-voided and unpaid — payable for the next
+ *    `curated-payout.ts` run, bringing the total to the canonical 30.
+ *
+ * Guards: WHERE `voided_at IS NULL`, `payout_txid IS [NOT] NULL`, and explicit
+ * id / txid match lists keep each UPDATE idempotent and a no-op once the
+ * target state is reached. `voided_at` writes use `datetime('now')` so the
+ * audit trail reflects the migration's actual run time rather than the
+ * author's wall clock at commit time.
+ */
+export const MIGRATION_APR7_EARNINGS_SQL = [
+  // Void earnings for the 14 re-curated signals NOT on-chain
+  `UPDATE earnings SET voided_at = datetime('now')
+   WHERE reason = 'brief_inclusion'
+     AND voided_at IS NULL AND payout_txid IS NULL
+     AND reference_id IN (
+       '7461c677-4787-4443-9912-8aff059242e7',
+       'b98c19e7-ddbc-405a-8e22-b9f8c963d3fa',
+       'aa980f39-f937-4746-8361-06b95b6f0682',
+       '31ef1c93-38cb-4c22-a662-f1718171a801',
+       '45255856-3789-44d6-aaa9-5d2fbd93594a',
+       '7e3f593f-5bae-4ac3-8cd1-04ec6aa5e24f',
+       'add238d7-e236-47ad-aeb3-33115bbbd3bf',
+       '08f7f137-4659-48fc-b08f-1a20fac51175',
+       'f68acab8-6e37-4fb5-b940-31cb02c515d2',
+       '327a8d94-cdb6-4468-acd0-5b282bc93df0',
+       'e0476a19-e641-41c5-afea-f1d2fced4ef5',
+       '884a2ba5-0265-469e-a96e-373eab071e3a',
+       'e4bfa2c7-835d-4739-b67f-78147b10650e',
+       '9eba3aa2-04bb-4843-ab8e-e6a941c10e1e'
+     )`,
+  // Un-void earnings for the 14 witness signals that ARE on-chain.
+  // Pinned to voided_at >= 2026-04-14T00:00:00Z so only the wholesale-void
+  // is reversed — any earlier unrelated void for these reference_ids is left
+  // intact.
+  `UPDATE earnings SET voided_at = NULL
+   WHERE reason = 'brief_inclusion'
+     AND voided_at IS NOT NULL AND payout_txid IS NULL
+     AND voided_at >= '2026-04-14T00:00:00Z'
+     AND reference_id IN (
+       '5ddd909b-6b33-43e8-97fe-045ee37689cd',
+       '4ad7834f-cb86-4f3e-ad5d-50532841d9b3',
+       'dcdb84f1-e1cb-4e73-b957-446807979521',
+       '3fce8150-8e5d-49b7-bc99-22a9211e9807',
+       'ca265e19-9715-4144-9efa-a270a399960a',
+       '26c81b2d-13af-4e27-abef-a9dfd6e40c69',
+       '7697182b-ef83-4ad6-97f1-d8703cd91665',
+       '9273780f-65b0-431f-9a74-66ca297504ae',
+       'bab2e5bc-8eaf-44c6-b186-ec7b9a7d9ff2',
+       '4f9593da-5b92-407b-92d6-7efb31daa21a',
+       '22d67962-bc69-4a7b-a5b8-57dc19be06be',
+       'f7043524-f77d-44af-811c-f93a46fa299e',
+       'd48a472f-fe11-4435-9eec-c9305e0f1795',
+       'bdb55bfd-f6f1-4db7-9424-42e23a8dc01d'
+     )`,
+  // Clear 8 dropped-mempool RBF payout_txid values so curated-payout.ts can
+  // resend. 7 from Mar 25 (nonces 22-28) + 1 from Mar 31 (nonce 589).
+  // Each txid may back multiple earning rows (a single transfer paid that
+  // correspondent's full daily batch); the WHERE clause matches by exact txid
+  // so the update is safe regardless of row fan-out.
+  `UPDATE earnings SET payout_txid = NULL
+   WHERE reason = 'brief_inclusion'
+     AND voided_at IS NULL
+     AND payout_txid IN (
+       'f2b6730486e888d3d3bfdad11716f84ddf7f2b938c2a39422c4e7fdfbb9bfad2',
+       'b2aa583eac81c0d4053b673e8f914b0a7caa271f19a6ce7e3e385af5afaefd17',
+       '2fb330f230b4e6e5dc384f084228002499c2615fe0822bc96f7fcb76235842fb',
+       '0a43bde0f675ea37bb19f6a7b5b6bd9e0044213e63332044dbdfde8c3421df31',
+       '3105014935d0b133856207e37241d4afbda7d1b9586c8e45400e928836013ffd',
+       '5110050b6890ce056c4a43eefdcf1038067036337beee6537fe00d1b56c43d46',
+       '11c95cb9c837d4e8da76dd0f23e03b13cf9c7b4590ffd42e2c36f176e0a4feea',
+       'a6ad84d4a261448752256259ae9693db8b9e264537628b3fe1d242dedf1d233b'
+     )`,
+  // Void 98 Mar 31 over-cap brief_inclusion earnings (Part C).
+  // The Mar 31 brief was inscribed with 120+ signals (platform now shows 128
+  // brief_included); policy honors the 30/day soft promise, consistent with
+  // the Mar 28/29 amended-brief precedent (#385). Voids all brief_inclusion
+  // earnings for 2026-03-31 brief that are NOT in the curated 30 from
+  // `db/briefs/amended-2026-03-31.html`. The 29 already-paid stay untouched
+  // (payout_txid IS NULL filter skips them); the 1 unpaid canonical signal
+  // stays payable for the next payout run.
+  `UPDATE earnings SET voided_at = datetime('now')
+   WHERE reason = 'brief_inclusion'
+     AND voided_at IS NULL AND payout_txid IS NULL
+     AND reference_id IN (
+       'bb7366cc-93bb-4a8d-97a7-f3b5e10ff618','7d24fd64-3fb2-4491-a456-bcbb976f8427','288ffe90-3b4b-49f0-970d-8bdc3c58a067','7e635163-46ca-4cb2-9328-206b45aec249',
+       'c80a6e6b-9a21-421e-9fdc-de9e3ea32434','0d63b2db-9d69-4c13-bbd1-d0de53c8c0df','d8efa636-bcd3-4189-887c-f427273430eb','0a439b18-9912-4417-8774-3de399d59786',
+       '1c6d3572-ce80-46e1-8f08-2ab5873f9170','30f3e900-2657-49c6-ad7c-31461307b4ee','3284f64d-9542-47a9-a6e0-58a6bcba40dc','68ba30e2-4d5d-4b85-8a1f-4cfeba8dffa7',
+       '9c1bbafe-eb17-4789-bfec-d986ea8cfebb','bb2bc02c-01bb-4aab-9294-90b4758f6cca','a2a70776-1a11-4c69-b946-45794a15b5eb','c6afc91d-d7c4-427d-b079-c8cf3d138654',
+       '0d366df7-b8b6-493e-9870-fc5f53432aff','e7f5dbd3-5a2b-4686-8e0c-4316396d2a29','bf0f4f85-c182-4b90-b95e-e6e1e55703d5','2cf16a7d-dbba-4e84-82e9-86174b398538',
+       'd5c96d7a-85c2-44fd-9d1e-4ca709470cc9','68d03b6b-1d00-4937-ab77-88ccb39f8911','d06d7f3a-eff5-448a-ab23-335731c1e9d4','496a8085-31c9-4fbb-981f-d3c84a6253dc',
+       '560b41d1-ec99-487b-a866-915e471a232a','40d677fc-dbf0-4169-ace2-338da3de5c77','cb201da8-3997-468a-9fb7-f3eda03b44fa','8d4a28bb-4024-4c95-8d5c-07de8e253018',
+       'b3681ea3-e0e8-4b22-953f-adc44d3888a7','f1310ec0-c2eb-426e-be31-fc0554324086','bff43a87-3138-4d31-ba7f-1d338fe2ceeb','a9236c33-ce42-468a-bfe7-ebb98335acdd',
+       '16f51aec-c11c-4c21-970b-ea9d197276eb','2c46bde8-e2ae-4dea-8bd4-1ae3924dce61','7e594145-4179-437b-aec6-9e50c22ad525','5e224373-948b-45a4-96c5-2c4973ef2564',
+       '859f492f-151a-4873-856c-9eaee2f7fe9c','a4803c5d-ecac-4720-9991-8638d7ddc666','1c97e525-1adf-4812-a91a-77b14ce286cc','105e4a7e-df63-4162-aab4-8fcfa5e181d4',
+       'f0425184-3621-4539-910e-a4405b744699','764592a8-c329-416b-a75e-0f3975bd3c7e','2a4f7acf-42fd-4c13-b018-082c2183e503','d91e1559-74d4-4b0e-8b16-ff8fad82d736',
+       'a460dff2-c5f9-4cb2-ac8f-61e80b7c1816','12885211-b8f4-45c6-9475-279ee2acb463','d0109b20-336c-45a5-9deb-88a476df2459','7cb596a5-6e7c-47ea-b8a3-a61d245c0f8b',
+       '6d3eb6ba-dbd0-47bc-aee6-9e0a891f6cae','711e1515-e0c6-408e-bdc4-09149e4322ad','7fae725a-a69e-4d43-b410-8334fcd2b6b2','69e1be7b-c24e-4970-a961-d49919c8baf3',
+       '36c61379-2964-4529-92b9-5abc5f4cf974','1c96a5b8-326c-4d74-ae7f-afe82d8ab236','8bc6434d-5f6c-4a9f-b4f7-1291a85c0f0a','f1a03ae0-88fd-4b47-96d2-15c673bca231',
+       '67f060a7-239e-40d4-9be4-d64c0fbdd487','091081ba-405b-42e9-992c-e8fa4ec7770b','ac8d0298-18c3-491a-bbe0-635d24b1d360','98095128-4174-46b7-a998-d044533db0c7',
+       'e9cb3dc9-23f4-46cf-b301-c8a6bcd63ba6','9255ffca-61d2-400a-8a10-4b3131ae7d6c','afb81e36-68dd-40ec-b8b9-f6e9977992d4','60ece995-2ef2-439a-811f-3e66baf72bf8',
+       '02a11068-7942-44da-80c7-6497ab5c8e68','4c47addc-34d9-4886-9d25-dc062923833f','367085ed-cc37-439f-bf69-beca6fb274c8','9ebdd204-e7b7-4442-ad5d-16efdf93da24',
+       'cfa6715a-7cc3-4b37-b6d4-16279dc12de5','ff0e0144-15ef-41e6-ab43-8ef8cb8cc189','0caed800-c52d-4c8a-8235-38d8a9f75999','f67ceeb6-4819-42f3-b6fa-c3accb815e5d',
+       '707ed2ff-cabd-42a7-8b15-60e8bdc9e76c','2ce53718-3519-483d-b391-7e97bcc89e10','72a0b305-8930-4dae-b472-ebb0c3607d84','954b704e-a889-410c-8ef2-c57f93535c8b',
+       '74a33282-fdee-41e7-aefa-b5f8125c61ad','69d7b3dc-4b1a-4b51-a161-6ab6cae4341c','e1305d60-5766-40f8-aeee-ea89ab8c57dd','daa94b06-2cfe-4405-892d-4e298d3eee22',
+       'd7ec0243-beb8-40b0-8814-89035e1f89f4','98f0b6c4-1989-4d47-b78f-e24be3ad6cb4','b8c8b7d4-1635-4502-ba00-eccc0daac84a','513300b2-7e40-4e77-95b3-0f38fd145d69',
+       '333d915d-93f1-44b6-a029-61eba3f83db4','8e807e3d-3689-46f2-a51b-5ac0d7b6a679','ee0a869e-4e02-4d24-8b59-358360d30dfa','2edbaa0c-396c-44f9-8f3f-c75822fe8261',
+       'deebae64-7a5d-40af-ae8f-6ce95d3227bd','afc87700-cd1a-4f4e-9d37-2b4e2f23fc94','aff965cd-50ca-419d-9560-4d7627189cbd','d2a82cc5-7b9d-4ebc-ac30-4c98b1ae969a',
+       '7ffa429e-55a4-4d4d-8904-1f0ad791f403','fe21253c-af18-4bc5-a9b8-f52bc1f0ea31','c9381a31-5663-4035-b93e-9198e830d63e','08c103ba-4dcb-4e98-ad62-12376391671e',
+       'f96dc58f-7ea5-4932-91e4-9281334b0ea5','27664756-162d-4573-af46-3960f2f0e21f'
+     )`,
+] as const;


### PR DESCRIPTION
## Summary

Adds Migration 24 — consolidated **publisher payout reconciliation**. Mirrors the Mar 28-29 amendment pattern from #385 (Migration 20). Four UPDATE-only statements against the `earnings` table; no schema change; idempotent.

## Scope

### Part A — Apr 7 brief amendment (14 + 14 earnings)

The 2026-04-07 brief is inscribed as `2d999d7fdcca97b36594f35be9ab98656c2c350a525c3a45062320a274016403i0` using the original pre-void content — 30 signals committed in the `104972bc…` commit's child-inscription witness on 2026-04-14. After the 2026-04-14 wholesale void, the platform was re-curated and re-compiled to a **different 30**. On-chain vs platform `brief_signals` diverge on 14 of 30 signals.

#500's inscription guard correctly prevents status changes post-inscription. This migration leaves `brief_signals` + `signals.status` alone and reconciles the `earnings` table so payouts match what was inscribed.

- **Voids** `brief_inclusion` earnings for the 14 re-curated signals not on-chain.
- **Un-voids** `brief_inclusion` earnings for the 14 witness signals that ARE on-chain (voided by the 2026-04-14 wholesale void script).

### Part B — Clear 8 RBF-destroyed `payout_txid` values (21 earnings)

During nonce cleanup on Mar 25 (nonces 22-28) and Mar 31 (nonce 589), eight sBTC transfers were evicted from the mempool. Their `earnings` rows still carry the dropped `payout_txid`, which blocks `curated-payout.ts` from re-sending — the script treats non-null `payout_txid` as "already paid" and skips them.

- **Clears** 8 `payout_txid` values (18 Mar 25 + 3 Mar 31 = 21 earning rows tied to those txids) so the next payout run can resend.

New valid txids PATCH over the cleared rows after send completes. Dropped-mempool txids are preserved in the operator's published payout manifest for the audit trail.

### Part C — Mar 31 over-cap void (98 earnings)

The Mar 31 brief was inscribed with 120+ signals (platform now shows 128 `brief_included`). Policy honors the 30/day soft promise, consistent with Mar 28/29 (#385) and Mar 30. The canonical 30 is derived from `db/briefs/amended-2026-03-31.html`; all 30 headlines matched cleanly to platform signal IDs.

- **Voids** 98 `brief_inclusion` earnings for Mar 31 signals NOT in the curated 30.

Guarded by `voided_at IS NULL` + `payout_txid IS NULL` so the 29 already-paid earnings stay untouched and the 1 unpaid canonical signal stays both un-voided and unpaid — payable for the next `curated-payout.ts` run, bringing the Mar 31 ledger to 30 paid correspondents and 98 voided orphans.

## What this migration does NOT do

- Does not modify `brief_signals` membership — platform API continues to return the re-curated 30 at `/api/brief/2026-04-07`. Known display asymmetry, parallels the Mar 28/29 "amended" state.
- Does not insert new earnings rows — uses existing rows.
- Does not bypass #500's inscription guards — those remain authoritative.

## The 28 signal IDs (Part A)

### Voided — 14 re-curated-only (in platform brief, not on-chain)

```
7461c677-4787-4443-9912-8aff059242e7  Wide Haven
b98c19e7-ddbc-405a-8e22-b9f8c963d3fa  Verified Leopard
aa980f39-f937-4746-8361-06b95b6f0682  Phantom Tiger
31ef1c93-38cb-4c22-a662-f1718171a801  Linked Signal
45255856-3789-44d6-aaa9-5d2fbd93594a  Keyed Robin
7e3f593f-5bae-4ac3-8cd1-04ec6aa5e24f  Shining Pippin
add238d7-e236-47ad-aeb3-33115bbbd3bf  Devoted Pelican
08f7f137-4659-48fc-b08f-1a20fac51175  (correspondent name null)
f68acab8-6e37-4fb5-b940-31cb02c515d2  Pearl Vesper
327a8d94-cdb6-4468-acd0-5b282bc93df0  Verified Horse
e0476a19-e641-41c5-afea-f1d2fced4ef5  Pure Troll
884a2ba5-0265-469e-a96e-373eab071e3a  Platinum Halo
e4bfa2c7-835d-4739-b67f-78147b10650e  Tiny Elio
9eba3aa2-04bb-4843-ab8e-e6a941c10e1e  Mighty Scorpion
```

### Un-voided — 14 witness-only (on-chain, not in platform brief)

```
5ddd909b-6b33-43e8-97fe-045ee37689cd  Wide Otto
4ad7834f-cb86-4f3e-ad5d-50532841d9b3  Eclipse Luna
dcdb84f1-e1cb-4e73-b957-446807979521  Cyber Comet
3fce8150-8e5d-49b7-bc99-22a9211e9807  Verified Swift
ca265e19-9715-4144-9efa-a270a399960a  Shining Tiger
26c81b2d-13af-4e27-abef-a9dfd6e40c69  Zen Warden
7697182b-ef83-4ad6-97f1-d8703cd91665  Twin Cyrus
9273780f-65b0-431f-9a74-66ca297504ae  Flaring Leopard
bab2e5bc-8eaf-44c6-b186-ec7b9a7d9ff2  Humble Idris
4f9593da-5b92-407b-92d6-7efb31daa21a  Keyed Reactor
22d67962-bc69-4a7b-a5b8-57dc19be06be  Cool Bison
f7043524-f77d-44af-811c-f93a46fa299e  Platinum Halo
d48a472f-fe11-4435-9eec-c9305e0f1795  Unified Sphinx
bdb55bfd-f6f1-4db7-9424-42e23a8dc01d  Heavy Juno
```

## The 8 RBF-destroyed txids (Part B)

### Mar 25 — 7 victims (nonces 22-28)

```
f2b6730486e888d3d3bfdad11716f84ddf7f2b938c2a39422c4e7fdfbb9bfad2  Encrypted Zara  (4 earnings)
b2aa583eac81c0d4053b673e8f914b0a7caa271f19a6ce7e3e385af5afaefd17  Micro Basilisk  (2)
2fb330f230b4e6e5dc384f084228002499c2615fe0822bc96f7fcb76235842fb  Ionic Anvil     (4)
0a43bde0f675ea37bb19f6a7b5b6bd9e0044213e63332044dbdfde8c3421df31  Thin Teal       (1)
3105014935d0b133856207e37241d4afbda7d1b9586c8e45400e928836013ffd  Grim Seraph     (1)
5110050b6890ce056c4a43eefdcf1038067036337beee6537fe00d1b56c43d46  Ionic Nova      (2)
11c95cb9c837d4e8da76dd0f23e03b13cf9c7b4590ffd42e2c36f176e0a4feea  Dual Cougar     (4)
```

### Mar 31 — 1 victim (nonce 589)

```
a6ad84d4a261448752256259ae9693db8b9e264537628b3fe1d242dedf1d233b  bc1qnj3n…kz42m4  (3 earnings)
```

## Part C — Mar 31 canonical 30 source

All 30 IDs extracted from `db/briefs/amended-2026-03-31.html` and matched against platform Mar 31 `brief_included` signals. The 98 IDs voided are the complement — see the migration SQL for the full list.

## Test plan

- [ ] Verify `CURRENT_MIGRATION_VERSION` bump from 23 → 24
- [ ] Part A spot-check: `SELECT COUNT(*) FROM earnings WHERE reference_id = '<one voided-set id>' AND voided_at IS NOT NULL` returns the expected row
- [ ] Part A spot-check: `SELECT COUNT(*) FROM earnings WHERE reference_id = '<one un-voided-set id>' AND voided_at IS NULL` returns the expected row
- [ ] Part B spot-check: `SELECT COUNT(*) FROM earnings WHERE payout_txid IS NULL AND reference_id IN (<18 Mar 25 signal IDs>)` returns 18; equivalent for the 3 Mar 31 rows
- [ ] Part C spot-check: `SELECT COUNT(*) FROM earnings WHERE reason='brief_inclusion' AND voided_at IS NOT NULL AND payout_txid IS NULL AND reference_id IN (<98 void-set IDs>)` returns 98
- [ ] Part C spot-check: the 1 canonical unpaid signal has `payout_txid IS NULL AND voided_at IS NULL` (operator identifies which via diff of canonical 30 vs 2026-03-31.json paid list)
- [ ] Idempotent re-run: cold-start the DO twice, confirm second pass is a no-op

## References

- #500 — inscription guard (authoritative post-inscription)
- #385 — Mar 28-29 amendment migration (pattern this PR follows)
- Publisher inscription ledger for Apr 7 + reveal tx `2d999d7fdcca97b36594f35be9ab98656c2c350a525c3a45062320a274016403`
- Publisher payout manifest `db/payouts/track-b-payouts-manifest-2026-04-17.md` (operator-side, contains full RBF victim record + Mar 31 canonical 30)
- Amended Mar 31 brief (source of the canonical 30): `db/briefs/amended-2026-03-31.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
