### PR TITLE
fix(do-client): add 10s timeout guard to doFetch to surface hung DO event loops

### DIFF
--- a/src/lib/do-client.ts
+++ b/src/lib/do-client.ts
@@ -4,34 +4,55 @@ import { CLASSIFIED_BRIEF_SLOTS } from "./constants";
 /** Singleton DO stub ID — single instance manages all news data */
 const DO_ID_NAME = "news-singleton";
 
+/**
+ * Maximum time to wait for a DO response before returning a 503.
+ * Cloudflare Workers have a 30s wall-clock limit; 10s leaves headroom for
+ * the caller to handle the error and still respond within the CF window.
+ */
+const DO_FETCH_TIMEOUT_MS = 10_000;
+
 /** Get a stub for the news DO */
 function getStub(env: Env): DurableObjectStub {
   const id = env.NEWS_DO.idFromName(DO_ID_NAME);
   return env.NEWS_DO.get(id);
 }
 
-/** Type-safe fetch helper */
+/** Type-safe fetch helper — includes a timeout guard against hung DO event loops (see #390) */
 async function doFetch<T>(
   stub: DurableObjectStub,
   path: string,
   init?: RequestInit
 ): Promise<DOResult<T>> {
-  const res = await stub.fetch(`https://do${path}`, init);
-  if (!res.ok) {
-    // Try to parse error JSON; fall back to status text for non-JSON responses
-    // (e.g. CF infrastructure 502/503 returning HTML)
-    try {
-      const data = (await res.json()) as DOResult<T>;
-      return { ...data, status: res.status as DOErrorStatus };
-    } catch {
-      return {
-        ok: false,
-        error: `DO request failed: ${res.status} ${res.statusText}`,
-        status: res.status as DOErrorStatus,
-      } as DOResult<T>;
+  const timeoutPromise = new Promise<DOResult<T>>((_, reject) => {
+    setTimeout(() => reject(new Error("DO_TIMEOUT")), DO_FETCH_TIMEOUT_MS);
+  });
+
+  const fetchPromise = (async (): Promise<DOResult<T>> => {
+    const res = await stub.fetch(`https://do${path}`, init);
+    if (!res.ok) {
+      // Try to parse error JSON; fall back to status text for non-JSON responses
+      // (e.g. CF infrastructure 502/503 returning HTML)
+      try {
+        const data = (await res.json()) as DOResult<T>;
+        return { ...data, status: res.status as DOErrorStatus };
+      } catch {
+        return {
+          ok: false,
+          error: `DO request failed: ${res.status} ${res.statusText}`,
+          status: res.status as DOErrorStatus,
+        } as DOResult<T>;
+      }
     }
-  }
-  return (await res.json()) as DOResult<T>;
+    return (await res.json()) as DOResult<T>;
+  })();
+
+  return Promise.race([fetchPromise, timeoutPromise]).catch((err: Error) => ({
+    ok: false,
+    error: err.message === "DO_TIMEOUT"
+      ? `Durable Object request timed out after ${DO_FETCH_TIMEOUT_MS}ms — the storage event loop may be overloaded. Retry shortly.`
+      : err.message,
+    status: 503 as DOErrorStatus,
+  } as DOResult<T>));
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -369,7 +369,7 @@ export interface CompiledBriefData {
  * Generic result type for Durable Object operations
  */
 /** HTTP error status codes returned by DO handlers */
-export type DOErrorStatus = 400 | 401 | 403 | 404 | 409 | 429 | 500;
+export type DOErrorStatus = 400 | 401 | 403 | 404 | 409 | 429 | 500 | 503;
 
 export interface ApprovalCapInfo {
   limit: number;


### PR DESCRIPTION
## Summary

- Wraps every `doFetch()` call with a 10-second `Promise.race()` guard
- On timeout, returns a structured `DOResult { ok: false, status: 503 }` instead of hanging until CF Worker wall-clock limit
- Adds `503` to `DOErrorStatus` (CF infrastructure already emits it; callers need to handle it cleanly)

## Fixes

Closes #390

## Root cause

On 2026-04-06 the DO event loop stalled (likely due to a hanging alarm or storage contention from the approval-cap `put()` added in #382). Every write request queued behind the blocked loop and hung for 45-60s before the client timed out with HTTP 000 / 0 bytes.

The fix doesn't prevent the stall — that requires a separate DO-side investigation — but it surfaces a proper `503 "retry shortly"` error within 10s so:
1. Correspondents get a meaningful error instead of a silent hang
2. The CF Worker request slot is released faster, reducing memory pressure on the worker
3. Callers can implement retry logic with proper backoff

## Test plan

- [ ] Signal POST returns 503 with descriptive message when DO hangs (can be verified with a test stub that never resolves)
- [ ] Normal DO reads/writes under 10s are unaffected
- [ ] `status: 503` propagates through `result.status ?? 400` in `signals.ts` (already handles `result.status`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)