### PR TITLE
fix: enforce cooldown and domain match on correction_of submissions

### DIFF
--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -2091,7 +2091,7 @@ export class NewsDO extends DurableObject<Env> {
         );
       }
 
-      // Global cooldown per agent — applies to ALL signals including corrections
+      // 4-hour global cooldown per agent — applies to ALL signals including corrections
       // (Previously excluded correction_of, allowing unlimited rapid corrections)
       const lastSignalRows = this.ctx.storage.sql
         .exec(
@@ -2324,11 +2324,32 @@ export class NewsDO extends DurableObject<Env> {
         }
       }
 
-      // 2. Correction depth limit: max 2 corrections per root signal
+      // 2. Walk correction chain to root — detects loops AND resolves root for depth check
+      const ancestors: string[] = [];
+      const visited = new Set<string>([originalId]);
+      let cursor: string | null = original.correction_of as string | null;
+      while (cursor && ancestors.length < 10) {
+        if (visited.has(cursor)) {
+          return c.json(
+            { ok: false, error: "Circular correction chain detected" } satisfies DOResult<Signal>,
+            400
+          );
+        }
+        visited.add(cursor);
+        ancestors.push(cursor);
+        const rows = this.ctx.storage.sql
+          .exec("SELECT correction_of FROM signals WHERE id = ?", cursor)
+          .toArray();
+        if (rows.length === 0) break;
+        cursor = rows[0].correction_of as string | null;
+      }
+      const rootId = ancestors.length > 0 ? ancestors[ancestors.length - 1] : originalId;
+
+      // 3. Correction depth limit: max 2 direct corrections per root signal
       const correctionCount = this.ctx.storage.sql
         .exec(
           `SELECT COUNT(*) as count FROM signals WHERE correction_of = ?`,
-          originalId
+          rootId
         )
         .toArray();
       const depth = (correctionCount[0] as Record<string, unknown>).count as number;
@@ -2340,26 +2361,6 @@ export class NewsDO extends DurableObject<Env> {
           } satisfies DOResult<Signal>,
           429
         );
-      }
-
-      // 3. Detect chain loops: walk correction_of ancestors to prevent circular references
-      let ancestorId: string | null = original.correction_of as string | null;
-      let chainLength = 1;
-      const visited = new Set<string>([originalId]);
-      while (ancestorId && chainLength < 10) {
-        if (visited.has(ancestorId)) {
-          return c.json(
-            { ok: false, error: "Circular correction chain detected" } satisfies DOResult<Signal>,
-            400
-          );
-        }
-        visited.add(ancestorId);
-        const ancestorRows = this.ctx.storage.sql
-          .exec("SELECT correction_of FROM signals WHERE id = ?", ancestorId)
-          .toArray();
-        if (ancestorRows.length === 0) break;
-        ancestorId = ancestorRows[0].correction_of as string | null;
-        chainLength++;
       }
 
       const now = new Date();

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -2091,11 +2091,12 @@ export class NewsDO extends DurableObject<Env> {
         );
       }
 
-      // 4-hour global cooldown per agent (separate from IP rate limiting)
+      // Global cooldown per agent — applies to ALL signals including corrections
+      // (Previously excluded correction_of, allowing unlimited rapid corrections)
       const lastSignalRows = this.ctx.storage.sql
         .exec(
           `SELECT created_at FROM signals
-           WHERE btc_address = ? AND correction_of IS NULL
+           WHERE btc_address = ?
            ORDER BY created_at DESC LIMIT 1`,
           btc_address as string
         )
@@ -2125,11 +2126,12 @@ export class NewsDO extends DurableObject<Env> {
       const yesterday = getUTCYesterday(now);
       const todayStart = getUTCDayStart(today);
 
-      // Daily signal cap per agent
+      // Daily signal cap per agent — counts ALL signals including corrections
+      // (Previously excluded correction_of, allowing unlimited daily corrections)
       const dailyCountRows = this.ctx.storage.sql
         .exec(
           `SELECT COUNT(*) as count FROM signals
-           WHERE btc_address = ? AND correction_of IS NULL AND created_at >= ?`,
+           WHERE btc_address = ? AND created_at >= ?`,
           btc_address as string,
           todayStart
         )
@@ -2294,6 +2296,70 @@ export class NewsDO extends DurableObject<Env> {
           { ok: false, error: "Only the original author can correct this signal" } satisfies DOResult<Signal>,
           403
         );
+      }
+
+      // ── Correction integrity checks (fixes #551) ──
+
+      // 1. Domain match: correction must share primary source domain with original
+      if (sources) {
+        try {
+          const originalSources = JSON.parse(original.sources as string) as { url?: string }[];
+          const origUrl = originalSources?.[0]?.url;
+          const newUrl = (sources as { url?: string }[])?.[0]?.url;
+          if (origUrl && newUrl) {
+            const origDomain = new URL(origUrl).hostname;
+            const newDomain = new URL(newUrl).hostname;
+            if (origDomain !== newDomain) {
+              return c.json(
+                {
+                  ok: false,
+                  error: `Correction source domain "${newDomain}" does not match original "${origDomain}". A correction must refine the same claim.`,
+                } satisfies DOResult<Signal>,
+                400
+              );
+            }
+          }
+        } catch {
+          // If URL parsing fails, let the existing source validation handle it downstream
+        }
+      }
+
+      // 2. Correction depth limit: max 2 corrections per root signal
+      const correctionCount = this.ctx.storage.sql
+        .exec(
+          `SELECT COUNT(*) as count FROM signals WHERE correction_of = ?`,
+          originalId
+        )
+        .toArray();
+      const depth = (correctionCount[0] as Record<string, unknown>).count as number;
+      if (depth >= 2) {
+        return c.json(
+          {
+            ok: false,
+            error: "Correction depth limit reached (max 2 per root). File a new signal instead.",
+          } satisfies DOResult<Signal>,
+          429
+        );
+      }
+
+      // 3. Detect chain loops: walk correction_of ancestors to prevent circular references
+      let ancestorId: string | null = original.correction_of as string | null;
+      let chainLength = 1;
+      const visited = new Set<string>([originalId]);
+      while (ancestorId && chainLength < 10) {
+        if (visited.has(ancestorId)) {
+          return c.json(
+            { ok: false, error: "Circular correction chain detected" } satisfies DOResult<Signal>,
+            400
+          );
+        }
+        visited.add(ancestorId);
+        const ancestorRows = this.ctx.storage.sql
+          .exec("SELECT correction_of FROM signals WHERE id = ?", ancestorId)
+          .toArray();
+        if (ancestorRows.length === 0) break;
+        ancestorId = ancestorRows[0].correction_of as string | null;
+        chainLength++;
       }
 
       const now = new Date();


### PR DESCRIPTION
## Fixes #551

Three changes to `src/objects/news-do.ts`:

### 1. Cooldown applies to all submissions

**Before:** `WHERE btc_address = ? AND correction_of IS NULL`
**After:** `WHERE btc_address = ?`

Correction signals (created via `PATCH /signals/:id`) previously bypassed the 1-hour cooldown entirely. The shortest observed gap between corrections was **28 seconds**. Now all submissions respect the cooldown.

### 2. Daily cap counts all submissions

**Before:** `WHERE btc_address = ? AND correction_of IS NULL AND created_at >= ?`
**After:** `WHERE btc_address = ? AND created_at >= ?`

Corrections previously didn't count toward the 6/day cap. One agent filed **14 correction signals in a single day** with zero clean submissions. Now corrections are counted.

### 3. PATCH integrity checks (new)

Three validations added to the `PATCH /signals/:id` handler:

| Check | What it does | Error code |
|-------|-------------|-----------|
| **Domain match** | Correction's primary source domain must match original | 400 |
| **Depth limit** | Max 2 corrections per root signal | 429 |
| **Loop detection** | Walks `correction_of` ancestors to prevent circular chains | 400 |

The existing cross-agent check (`btc_address` must match original author) was already in place and is unchanged.

### Impact on legitimate corrections

Control group analysis (5 agents using `correction_of` correctly): all file same-domain, 1-2 link corrections. **None of these fixes affect legitimate correction behavior.**

### Testing

- No schema changes — uses existing `correction_of` column and `sources` JSON field
- Domain check gracefully degrades if URL parsing fails (falls through to existing source validation)
- Depth limit query is indexed by `correction_of` column (existing foreign key)

Closes #551

@whoabuddy @rising-leviathan @biwasxyz @tearful-saw @giwaov @ThankNIXlater @secret-mars @Robotbot69 — tagging for review.