### PR TITLE
fix(signals): expose quality_score and score_breakdown on GET endpoints

### DIFF
--- a/src/routes/signals.ts
+++ b/src/routes/signals.ts
@@ -116,6 +116,8 @@ signalsRouter.get("/api/signals", signalReadRateLimit, async (c) => {
       status: s.status,
       publisherFeedback: s.publisher_feedback,
       disclosure: s.disclosure,
+      quality_score: s.quality_score ?? null,
+      score_breakdown: s.score_breakdown ?? null,
     };
   });
 
@@ -166,6 +168,8 @@ signalsRouter.get("/api/signals/:id", signalReadRateLimit, async (c) => {
     publisherFeedback: s.publisher_feedback,
     reviewedAt: s.reviewed_at,
     disclosure: s.disclosure,
+    quality_score: s.quality_score ?? null,
+    score_breakdown: s.score_breakdown ?? null,
   });
 });
 


### PR DESCRIPTION
## Summary

#343 shipped the auto-scoring middleware — `quality_score` and `score_breakdown` are computed at submission time and persisted on every signal. But the public `GET` projections in `src/routes/signals.ts` explicitly project a subset of DO Signal fields and **drop these two** on the way out.

Net effect: the submitting agent sees their score in the POST 201 response, but nobody else can. Public feed readers, archive renderers, and the UI work queued on \`feat/design-refresh\` all get \`undefined\` when they reach for \`s.quality_score\`.

#559 (merged earlier today) documents the two fields as part of the Signal response shape in \`public/llms.txt\`. This PR makes the route projections match that docs contract.

## Changes

Four lines in \`src/routes/signals.ts\`:

- \`GET /api/signals\` list projection: add \`quality_score\` + \`score_breakdown\` after \`disclosure\`
- \`GET /api/signals/:id\` single projection: same two fields after \`disclosure\`

Both use \`?? null\` to fall back gracefully for legacy rows (pre-migration-24, nullable columns).

## Non-changes

- No schema change — columns already exist from migration 24
- No DO-side change — \`rowToSignal\` already surfaces the fields on DO Signal objects
- No type change — \`Signal\` interface already declares them
- POST response unchanged (passes \`result.data\` through verbatim and always surfaced them)

## Verification

- \`npm run typecheck\` — passes locally
- Diff is ~4 lines, additive, no behavior change for any existing field
- Unlocks: quality-pill UI on Wire / Signals list / signal modal (planned in \`feat/design-refresh\` branch discussion)

## Out of scope

- UI consumers of the newly-exposed fields (separate work in \`feat/design-refresh\`)
- Score formula sanity-check against \`SCORING_WEIGHTS\` in \`constants.ts\` (flagged in #559 PR body)