### PR TITLE
fix(payments): backend-owned sweep for staged x402 payments

### DIFF
--- a/src/__tests__/payment-stage-alarm-sweep.test.ts
+++ b/src/__tests__/payment-stage-alarm-sweep.test.ts
@@ -1,0 +1,138 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { SELF } from "cloudflare:test";
+
+const BTC_ADDRESS = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+
+async function stageClassified(paymentId: string, classifiedId: string) {
+  const res = await SELF.fetch("http://example.com/api/test/payment-stage", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      paymentId,
+      payload: {
+        kind: "classified_submission",
+        classified_id: classifiedId,
+        btc_address: BTC_ADDRESS,
+        category: "services",
+        headline: "Staged via sweep test",
+        body: "Delivered without client poll",
+        payment_txid: null,
+      },
+    }),
+  });
+  expect(res.status).toBe(201);
+}
+
+async function runSweep(
+  results: Record<string, { status: string; txid?: string; terminalReason?: string }>,
+  graceMs = 0
+): Promise<number> {
+  const res = await SELF.fetch("http://example.com/api/test/sweep-staged-payments", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ graceMs, limit: 10, results }),
+  });
+  expect(res.status).toBe(200);
+  const body = await res.json<{ data: { reconciled: number } }>();
+  return body.data.reconciled;
+}
+
+describe("payment staging alarm sweep (#572)", () => {
+  // Warm the worker + DO before the first real assertion so the 15s testTimeout
+  // isn't eaten by cold-start. Mirrors the pattern used in payment-staging.test.ts's
+  // passing cases which always warm via an earlier test in the same file.
+  beforeAll(async () => {
+    await SELF.fetch("http://example.com/api/health");
+  });
+
+  it("finalizes a confirmed staged payment without any client poll", async () => {
+    const paymentId = "pay_sweep_confirmed_001";
+    const classifiedId = "cl-sweep-confirmed-001";
+    await stageClassified(paymentId, classifiedId);
+
+    const reconciled = await runSweep({
+      [paymentId]: { status: "confirmed", txid: "a".repeat(64) },
+    });
+    expect(reconciled).toBe(1);
+
+    const stageRes = await SELF.fetch(`http://example.com/api/test/payment-stage/${paymentId}`);
+    const stageBody = await stageRes.json<{ data: { stageStatus: string; finalizedAt: string | null } }>();
+    expect(stageBody.data.stageStatus).toBe("finalized");
+    expect(stageBody.data.finalizedAt).not.toBeNull();
+  });
+
+  it("discards a staged payment when the relay reports a terminal failure", async () => {
+    const paymentId = "pay_sweep_failed_001";
+    const classifiedId = "cl-sweep-failed-001";
+    await stageClassified(paymentId, classifiedId);
+
+    const reconciled = await runSweep({
+      [paymentId]: { status: "failed", terminalReason: "sender_nonce_stale" },
+    });
+    expect(reconciled).toBe(1);
+
+    const stageRes = await SELF.fetch(`http://example.com/api/test/payment-stage/${paymentId}`);
+    const stageBody = await stageRes.json<{
+      data: { stageStatus: string; terminalStatus: string | null; terminalReason: string | null };
+    }>();
+    expect(stageBody.data.stageStatus).toBe("discarded");
+    expect(stageBody.data.terminalStatus).toBe("failed");
+    expect(stageBody.data.terminalReason).toBe("sender_nonce_stale");
+  });
+
+  it("leaves a still-pending staged payment untouched for the next tick", async () => {
+    const paymentId = "pay_sweep_pending_001";
+    const classifiedId = "cl-sweep-pending-001";
+    await stageClassified(paymentId, classifiedId);
+
+    const reconciled = await runSweep({
+      [paymentId]: { status: "mempool", txid: "b".repeat(64) },
+    });
+    expect(reconciled).toBe(0);
+
+    const stageRes = await SELF.fetch(`http://example.com/api/test/payment-stage/${paymentId}`);
+    const stageBody = await stageRes.json<{ data: { stageStatus: string } }>();
+    expect(stageBody.data.stageStatus).toBe("staged");
+  });
+
+  it("skips rows still inside the grace window to avoid racing the POST reconcile", async () => {
+    const paymentId = "pay_sweep_grace_001";
+    const classifiedId = "cl-sweep-grace-001";
+    await stageClassified(paymentId, classifiedId);
+
+    // Default grace is 30s; row just staged should be ignored when graceMs large.
+    const reconciledWithGrace = await runSweep(
+      { [paymentId]: { status: "confirmed", txid: "c".repeat(64) } },
+      60_000
+    );
+    expect(reconciledWithGrace).toBe(0);
+
+    // With graceMs=0, sweep picks it up.
+    const reconciledNow = await runSweep(
+      { [paymentId]: { status: "confirmed", txid: "c".repeat(64) } },
+      0
+    );
+    expect(reconciledNow).toBe(1);
+  });
+
+  it("no-ops when X402_RELAY has no checkPayment and no stub is provided", async () => {
+    const paymentId = "pay_sweep_no_relay_001";
+    const classifiedId = "cl-sweep-no-relay-001";
+    await stageClassified(paymentId, classifiedId);
+
+    // No `results` field — DO falls back to this.env.X402_RELAY, which in the
+    // test miniflare config is a plain Fetcher (no checkPayment method).
+    const res = await SELF.fetch("http://example.com/api/test/sweep-staged-payments", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ graceMs: 0 }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json<{ data: { reconciled: number } }>();
+    expect(body.data.reconciled).toBe(0);
+
+    const stageRes = await SELF.fetch(`http://example.com/api/test/payment-stage/${paymentId}`);
+    const stageBody = await stageRes.json<{ data: { stageStatus: string } }>();
+    expect(stageBody.data.stageStatus).toBe("staged");
+  });
+});

--- a/src/__tests__/payment-stage-alarm-sweep.test.ts
+++ b/src/__tests__/payment-stage-alarm-sweep.test.ts
@@ -95,6 +95,55 @@ describe("payment staging alarm sweep (#572)", () => {
     expect(stageBody.data.stageStatus).toBe("staged");
   });
 
+  it("recovers an expired row when the relay finally confirms (late settlement)", async () => {
+    // Rows that cross the 24h TTL are marked 'expired' but kept in the table
+    // precisely so late on-chain confirmations can still deliver. Confirmed by
+    // #572's repro comment — jingswap.btc classifieds sat staged for days.
+    const paymentId = "pay_sweep_expired_001";
+    const classifiedId = "cl-sweep-expired-001";
+    await stageClassified(paymentId, classifiedId);
+
+    const expireRes = await SELF.fetch(
+      `http://example.com/api/test/payment-stage/${paymentId}/force-expire`,
+      { method: "POST" }
+    );
+    expect(expireRes.status).toBe(200);
+    const expireBody = await expireRes.json<{ data: { stageStatus: string } }>();
+    expect(expireBody.data.stageStatus).toBe("expired");
+
+    const reconciled = await runSweep({
+      [paymentId]: { status: "confirmed", txid: "f".repeat(64) },
+    });
+    expect(reconciled).toBe(1);
+
+    const stageRes = await SELF.fetch(`http://example.com/api/test/payment-stage/${paymentId}`);
+    const stageBody = await stageRes.json<{ data: { stageStatus: string } }>();
+    expect(stageBody.data.stageStatus).toBe("finalized");
+  });
+
+  it("bumps updated_at on non-terminal sweeps so rows rotate instead of starve", async () => {
+    // A pending row left in 'staged' must have its updated_at advanced on each
+    // check. Without this, ORDER BY updated_at ASC would pin the same rows at
+    // the front of the queue forever and starve newer stagings.
+    const paymentId = "pay_sweep_rotate_bump";
+    await stageClassified(paymentId, "cl-sweep-rotate-bump");
+
+    const before = await SELF.fetch(`http://example.com/api/test/payment-stage/${paymentId}`);
+    const beforeBody = await before.json<{ data: { updatedAt: string; stageStatus: string } }>();
+    expect(beforeBody.data.stageStatus).toBe("staged");
+    const originalUpdatedAt = beforeBody.data.updatedAt;
+
+    // A non-terminal response — row stays 'staged' but updated_at should advance.
+    await new Promise((r) => setTimeout(r, 20));
+    const reconciled = await runSweep({ [paymentId]: { status: "mempool" } });
+    expect(reconciled).toBe(0);
+
+    const after = await SELF.fetch(`http://example.com/api/test/payment-stage/${paymentId}`);
+    const afterBody = await after.json<{ data: { updatedAt: string; stageStatus: string } }>();
+    expect(afterBody.data.stageStatus).toBe("staged");
+    expect(afterBody.data.updatedAt > originalUpdatedAt).toBe(true);
+  });
+
   it("skips rows still inside the grace window to avoid racing the POST reconcile", async () => {
     const paymentId = "pay_sweep_grace_001";
     const classifiedId = "cl-sweep-grace-001";

--- a/src/index.ts
+++ b/src/index.ts
@@ -219,6 +219,25 @@ app.post("/api/test/payment-stage/:paymentId/reconcile", async (c) => {
   return c.json(await res.json(), res.status as 200 | 400 | 404);
 });
 
+// Test-only — trigger the staged-payment alarm sweep without waiting 50s.
+// Accepts { results: { [paymentId]: { status, txid?, terminalReason? } } }
+// to stub checkPayment per row. If `results` is omitted, the live X402_RELAY
+// binding is used (useful for end-to-end probes).
+app.post("/api/test/sweep-staged-payments", async (c) => {
+  if (!isTestEnv(c)) return c.json({ error: "Not found" }, 404);
+  const body = (await parseJsonBody(c)) as {
+    graceMs?: number;
+    limit?: number;
+    results?: Record<string, { status: string; txid?: string; terminalReason?: string }>;
+  } | null;
+  const res = await getDoStub(c).fetch("https://do/test/sweep-staged-payments", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body ?? {}),
+  });
+  return c.json(await res.json(), res.status as 200 | 400 | 404);
+});
+
 // Health endpoint (available at both /health and /api/health)
 function healthHandler(c: AppContext) {
   return c.json({

--- a/src/index.ts
+++ b/src/index.ts
@@ -219,6 +219,16 @@ app.post("/api/test/payment-stage/:paymentId/reconcile", async (c) => {
   return c.json(await res.json(), res.status as 200 | 400 | 404);
 });
 
+// Test-only — mark a staged row 'expired' so tests can cover the late-settlement path.
+app.post("/api/test/payment-stage/:paymentId/force-expire", async (c) => {
+  if (!isTestEnv(c)) return c.json({ error: "Not found" }, 404);
+  const res = await getDoStub(c).fetch(
+    `https://do/test/payment-staging/${encodeURIComponent(c.req.param("paymentId"))}/force-expire`,
+    { method: "POST" }
+  );
+  return c.json(await res.json(), res.status as 200 | 404);
+});
+
 // Test-only — trigger the staged-payment alarm sweep without waiting 50s.
 // Accepts { results: { [paymentId]: { status, txid?, terminalReason? } } }
 // to stub checkPayment per row. If `results` is omitted, the live X402_RELAY

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -244,19 +244,39 @@ type CheckPaymentFn = (paymentId: string) => Promise<CheckPaymentResult>;
  * Return a bound checkPayment callable if the relay binding exposes one.
  * In the test miniflare config X402_RELAY is a plain Fetcher (no RPC methods),
  * so the sweep no-ops without throwing.
+ *
+ * Returns a closure that calls `relay.checkPayment(paymentId)` with the relay
+ * as receiver — extracting the method and calling it standalone would drop
+ * `this` for WorkerEntrypoint-based RPC bindings.
  */
 function resolveRelayCheckPayment(relay: unknown): CheckPaymentFn | null {
   if (!relay || typeof relay !== "object") return null;
-  const fn = (relay as Record<string, unknown>).checkPayment;
-  if (typeof fn !== "function") return null;
-  return (paymentId) => (fn as CheckPaymentFn)(paymentId);
+  const bound = relay as Record<string, unknown> & { checkPayment?: CheckPaymentFn };
+  if (typeof bound.checkPayment !== "function") return null;
+  return (paymentId) => bound.checkPayment!(paymentId);
 }
 
+const TERMINAL_PAYMENT_STATES = new Set(["confirmed", "failed", "replaced", "not_found"]);
+
 /**
- * Scan payment_staging for rows still in 'staged' that are older than graceMs,
- * call the provided checkPayment for each, and reconcile on terminal outcomes.
- * Caller-agnostic — the sweep closure receives a bound checkPayment (either the
- * live X402_RELAY RPC or a test stub) so this function has no env dependency.
+ * Scan payment_staging for rows eligible for backend reconciliation, call
+ * checkPayment for each, and apply terminal outcomes. Caller-agnostic — the
+ * sweep receives a bound checkPayment (live X402_RELAY RPC or a test stub)
+ * so this function has no env dependency.
+ *
+ * Eligibility: rows in 'staged' or 'expired' whose `created_at` is older than
+ * `graceMs`. 'expired' rows are included because the TTL is advisory —
+ * `purgeExpiredStagedRecords` keeps them around precisely so late settlements
+ * can still be delivered; the sweep is the primary consumer of that path.
+ *
+ * Ordering: `ORDER BY updated_at ASC` so the batch rotates through the pool.
+ * On each non-terminal response we bump `updated_at` to push the row to the
+ * back of the queue — without this, a backlog of pending rows at the front
+ * would starve newer staged rows forever.
+ *
+ * Concurrency: checkPayment calls are serial on purpose — the relay is shared
+ * infrastructure and a burst of alarm-driven concurrent calls under backlog
+ * recovery would be self-DoS-ing. `limit` (default 10) caps the per-tick cost.
  */
 async function sweepPaymentStagingRows(
   sql: DurableObjectState["storage"]["sql"],
@@ -269,8 +289,8 @@ async function sweepPaymentStagingRows(
   const rows = sql
     .exec(
       `SELECT payment_id FROM payment_staging
-        WHERE stage_status = 'staged' AND created_at < ?
-        ORDER BY created_at ASC
+        WHERE stage_status IN ('staged', 'expired') AND created_at < ?
+        ORDER BY updated_at ASC
         LIMIT ?`,
       cutoff,
       limit
@@ -283,12 +303,11 @@ async function sweepPaymentStagingRows(
     const paymentId = row.payment_id;
     try {
       const result = await checkPayment(paymentId);
-      if (
-        result.status === "confirmed" ||
-        result.status === "failed" ||
-        result.status === "replaced" ||
-        result.status === "not_found"
-      ) {
+      if (typeof result?.status !== "string") {
+        console.warn(`[alarm-sweep] invalid checkPayment response for paymentId=${paymentId}:`, result);
+        continue;
+      }
+      if (TERMINAL_PAYMENT_STATES.has(result.status)) {
         const reconciled = reconcileStageRow(
           sql,
           paymentId,
@@ -296,12 +315,20 @@ async function sweepPaymentStagingRows(
           result.txid,
           result.terminalReason as PaymentTerminalReason | undefined
         );
-        if (reconciled && reconciled.stageStatus !== "staged") {
+        if (reconciled && reconciled.stageStatus !== "staged" && reconciled.stageStatus !== "expired") {
           reconciledCount += 1;
           console.log(
             `[alarm-sweep] reconciled paymentId=${paymentId} status=${result.status} stage=${reconciled.stageStatus}`
           );
         }
+      } else {
+        // Non-terminal — bump updated_at so the row rotates to the back of the
+        // sweep queue next tick and newer staged rows get a turn.
+        sql.exec(
+          "UPDATE payment_staging SET updated_at = ? WHERE payment_id = ?",
+          new Date().toISOString(),
+          paymentId
+        );
       }
     } catch (err) {
       console.error(`[alarm-sweep] checkPayment failed for paymentId=${paymentId}:`, err);
@@ -1087,6 +1114,19 @@ export class NewsDO extends DurableObject<Env> {
         body.terminalReason
       );
       return c.json({ ok: true, data: reconciled } satisfies DOResult<PaymentStageMaterialized | null>);
+    });
+
+    // Test-only — mark a staged row as 'expired' directly so we can cover the
+    // late-settlement path without waiting out the 24h TTL.
+    this.router.post("/test/payment-staging/:paymentId/force-expire", (c) => {
+      const paymentId = c.req.param("paymentId");
+      this.ctx.storage.sql.exec(
+        "UPDATE payment_staging SET stage_status = 'expired', updated_at = ? WHERE payment_id = ? AND stage_status = 'staged'",
+        new Date().toISOString(),
+        paymentId
+      );
+      const row = getPaymentStageRow(this.ctx.storage.sql, paymentId);
+      return c.json({ ok: true, data: row } satisfies DOResult<PaymentStageMaterialized | null>);
     });
 
     // Test-only hook — trigger sweepStagedPayments without waiting for the

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -149,6 +149,168 @@ function getPaymentStageRow(
 }
 
 /**
+ * Apply a terminal reconciliation decision to a single staged payment row.
+ * Shared by the /payment-staging/:paymentId/reconcile route (poll-driven) and
+ * the alarm sweep (backend-driven). Returns the row after the write, or null
+ * if no staged record exists for paymentId.
+ *
+ * A no-op for rows already in 'finalized' or 'discarded' — idempotent under
+ * concurrent poll + sweep reconciliation.
+ */
+function reconcileStageRow(
+  sql: DurableObjectState["storage"]["sql"],
+  paymentId: string,
+  status: PaymentTrackedState,
+  txid?: string,
+  terminalReason?: PaymentTerminalReason
+): PaymentStageMaterialized | null {
+  const staged = getPaymentStageRow(sql, paymentId);
+  if (!staged) return null;
+  if (staged.stageStatus !== "staged" && staged.stageStatus !== "expired") {
+    return staged;
+  }
+
+  const now = new Date().toISOString();
+
+  if (status === "confirmed") {
+    if (staged.kind === "classified_submission") {
+      const payload = staged.payload as Extract<PaymentStagePayload, { kind: "classified_submission" }>;
+      sql.exec(
+        `INSERT OR IGNORE INTO classifieds
+           (id, btc_address, category, headline, body, payment_txid, status, created_at, expires_at)
+         VALUES (?, ?, ?, ?, ?, ?, 'pending_review', ?, ?)`,
+        payload.classified_id,
+        payload.btc_address,
+        payload.category,
+        payload.headline,
+        payload.body,
+        txid ?? payload.payment_txid,
+        now,
+        now
+      );
+    } else if (staged.kind === "brief_access") {
+      const payload = staged.payload as Extract<PaymentStagePayload, { kind: "brief_access" }>;
+      if (payload.payer) {
+        sql.exec(
+          `INSERT OR IGNORE INTO earnings
+             (id, btc_address, amount_sats, reason, reference_id, created_at)
+           VALUES (?, ?, ?, 'brief-revenue', ?, ?)`,
+          generateId(),
+          payload.payer,
+          payload.amount_sats,
+          paymentId,
+          now
+        );
+      }
+    }
+
+    sql.exec(
+      `UPDATE payment_staging
+          SET stage_status = 'finalized',
+              terminal_status = 'confirmed',
+              terminal_reason = NULL,
+              updated_at = ?,
+              finalized_at = ?,
+              discarded_at = NULL
+        WHERE payment_id = ?`,
+      now,
+      now,
+      paymentId
+    );
+  } else if (status === "failed" || status === "replaced" || status === "not_found") {
+    sql.exec(
+      `UPDATE payment_staging
+          SET stage_status = 'discarded',
+              terminal_status = ?,
+              terminal_reason = ?,
+              updated_at = ?,
+              discarded_at = ?
+        WHERE payment_id = ?`,
+      status,
+      terminalReason ?? null,
+      now,
+      now,
+      paymentId
+    );
+  }
+
+  return getPaymentStageRow(sql, paymentId);
+}
+
+type CheckPaymentResult = { status: string; txid?: string; terminalReason?: string };
+type CheckPaymentFn = (paymentId: string) => Promise<CheckPaymentResult>;
+
+/**
+ * Return a bound checkPayment callable if the relay binding exposes one.
+ * In the test miniflare config X402_RELAY is a plain Fetcher (no RPC methods),
+ * so the sweep no-ops without throwing.
+ */
+function resolveRelayCheckPayment(relay: unknown): CheckPaymentFn | null {
+  if (!relay || typeof relay !== "object") return null;
+  const fn = (relay as Record<string, unknown>).checkPayment;
+  if (typeof fn !== "function") return null;
+  return (paymentId) => (fn as CheckPaymentFn)(paymentId);
+}
+
+/**
+ * Scan payment_staging for rows still in 'staged' that are older than graceMs,
+ * call the provided checkPayment for each, and reconcile on terminal outcomes.
+ * Caller-agnostic — the sweep closure receives a bound checkPayment (either the
+ * live X402_RELAY RPC or a test stub) so this function has no env dependency.
+ */
+async function sweepPaymentStagingRows(
+  sql: DurableObjectState["storage"]["sql"],
+  checkPayment: CheckPaymentFn,
+  opts: { graceMs?: number; limit?: number } = {}
+): Promise<number> {
+  const graceMs = opts.graceMs ?? 30_000;
+  const limit = opts.limit ?? 10;
+  const cutoff = new Date(Date.now() - graceMs).toISOString();
+  const rows = sql
+    .exec(
+      `SELECT payment_id FROM payment_staging
+        WHERE stage_status = 'staged' AND created_at < ?
+        ORDER BY created_at ASC
+        LIMIT ?`,
+      cutoff,
+      limit
+    )
+    .toArray() as Array<{ payment_id: string }>;
+  if (rows.length === 0) return 0;
+
+  let reconciledCount = 0;
+  for (const row of rows) {
+    const paymentId = row.payment_id;
+    try {
+      const result = await checkPayment(paymentId);
+      if (
+        result.status === "confirmed" ||
+        result.status === "failed" ||
+        result.status === "replaced" ||
+        result.status === "not_found"
+      ) {
+        const reconciled = reconcileStageRow(
+          sql,
+          paymentId,
+          result.status as PaymentTrackedState,
+          result.txid,
+          result.terminalReason as PaymentTerminalReason | undefined
+        );
+        if (reconciled && reconciled.stageStatus !== "staged") {
+          reconciledCount += 1;
+          console.log(
+            `[alarm-sweep] reconciled paymentId=${paymentId} status=${result.status} stage=${reconciled.stageStatus}`
+          );
+        }
+      }
+    } catch (err) {
+      console.error(`[alarm-sweep] checkPayment failed for paymentId=${paymentId}:`, err);
+    }
+  }
+  return reconciledCount;
+}
+
+/**
  * Expire staged payment records that have been in the "staged" state longer
  * than PAYMENT_STAGE_TTL_MS. Marks them as 'expired' instead of deleting so
  * the payment history remains recoverable (e.g. if the on-chain tx confirmed
@@ -917,81 +1079,40 @@ export class NewsDO extends DurableObject<Env> {
         );
       }
 
-      const staged = getPaymentStageRow(this.ctx.storage.sql, paymentId);
-      if (!staged) {
-        return c.json({ ok: true, data: null } satisfies DOResult<PaymentStageMaterialized | null>);
-      }
+      const reconciled = reconcileStageRow(
+        this.ctx.storage.sql,
+        paymentId,
+        body.status,
+        body.txid,
+        body.terminalReason
+      );
+      return c.json({ ok: true, data: reconciled } satisfies DOResult<PaymentStageMaterialized | null>);
+    });
 
-      if (staged.stageStatus !== "staged" && staged.stageStatus !== "expired") {
-        return c.json({ ok: true, data: staged } satisfies DOResult<PaymentStageMaterialized>);
-      }
-
-      const now = new Date().toISOString();
-
-      if (body.status === "confirmed") {
-        if (staged.kind === "classified_submission") {
-          const payload = staged.payload as Extract<PaymentStagePayload, { kind: "classified_submission" }>;
-          this.ctx.storage.sql.exec(
-            `INSERT OR IGNORE INTO classifieds
-               (id, btc_address, category, headline, body, payment_txid, status, created_at, expires_at)
-             VALUES (?, ?, ?, ?, ?, ?, 'pending_review', ?, ?)`,
-            payload.classified_id,
-            payload.btc_address,
-            payload.category,
-            payload.headline,
-            payload.body,
-            body.txid ?? payload.payment_txid,
-            now,
-            now
-          );
-        } else if (staged.kind === "brief_access") {
-          const payload = staged.payload as Extract<PaymentStagePayload, { kind: "brief_access" }>;
-          if (payload.payer) {
-            this.ctx.storage.sql.exec(
-              `INSERT OR IGNORE INTO earnings
-                 (id, btc_address, amount_sats, reason, reference_id, created_at)
-               VALUES (?, ?, ?, 'brief-revenue', ?, ?)`,
-              generateId(),
-              payload.payer,
-              payload.amount_sats,
-              paymentId,
-              now
-            );
+    // Test-only hook — trigger sweepStagedPayments without waiting for the
+    // 50-second alarm cadence. Gated at the worker layer on ENVIRONMENT !== 'production'.
+    // If `results` is provided, stubs checkPayment per paymentId; otherwise falls
+    // back to the live X402_RELAY binding.
+    this.router.post("/test/sweep-staged-payments", async (c) => {
+      const body = (await parseRequiredJson<{
+        graceMs?: number;
+        limit?: number;
+        results?: Record<string, CheckPaymentResult>;
+      }>(c)) ?? {};
+      const stubs = body.results;
+      const checkPayment: CheckPaymentFn | undefined = stubs
+        ? async (paymentId) => {
+            const stub = stubs[paymentId];
+            if (!stub) throw new Error(`no test stub for paymentId=${paymentId}`);
+            return stub;
           }
-        }
-
-        this.ctx.storage.sql.exec(
-          `UPDATE payment_staging
-              SET stage_status = 'finalized',
-                  terminal_status = 'confirmed',
-                  terminal_reason = NULL,
-                  updated_at = ?,
-                  finalized_at = ?,
-                  discarded_at = NULL
-            WHERE payment_id = ?`,
-          now,
-          now,
-          paymentId
-        );
-      } else if (body.status === "failed" || body.status === "replaced" || body.status === "not_found") {
-        this.ctx.storage.sql.exec(
-          `UPDATE payment_staging
-              SET stage_status = 'discarded',
-                  terminal_status = ?,
-                  terminal_reason = ?,
-                  updated_at = ?,
-                  discarded_at = ?
-            WHERE payment_id = ?`,
-          body.status,
-          body.terminalReason ?? null,
-          now,
-          now,
-          paymentId
-        );
-      }
-
-      const reconciled = getPaymentStageRow(this.ctx.storage.sql, paymentId);
-      return c.json({ ok: true, data: reconciled ?? null } satisfies DOResult<PaymentStageMaterialized | null>);
+        : undefined;
+      const reconciled = await this.sweepStagedPayments({
+        graceMs: body.graceMs,
+        limit: body.limit,
+        checkPayment,
+      });
+      return c.json({ ok: true, data: { reconciled } } satisfies DOResult<{ reconciled: number }>);
     });
 
     // -------------------------------------------------------------------------
@@ -5161,8 +5282,42 @@ export class NewsDO extends DurableObject<Env> {
       .toArray();
   }
 
-  /** Keep-alive alarm — reschedules itself every 50 seconds to prevent DO eviction. */
+  /**
+   * Reconcile staged x402 payments whose client never polled /api/payment-status.
+   * Picks up to `limit` rows in 'staged' older than `graceMs`, queries the relay,
+   * and applies terminal outcomes via reconcileStageRow. Returns the number of
+   * rows finalized or discarded (pending-state rows are left for the next tick).
+   *
+   * Grace window prevents racing the synchronous POST-time reconcile path — a
+   * fresh stage row is almost always followed by the POST's own status check.
+   *
+   * Wrapper around sweepPaymentStagingRows — binds the SQL handle and the live
+   * X402_RELAY.checkPayment. A checkPayment override can be passed for tests.
+   */
+  async sweepStagedPayments(opts: {
+    graceMs?: number;
+    limit?: number;
+    checkPayment?: CheckPaymentFn;
+  } = {}): Promise<number> {
+    const check = opts.checkPayment ?? resolveRelayCheckPayment(this.env.X402_RELAY);
+    if (!check) return 0;
+    return sweepPaymentStagingRows(this.ctx.storage.sql, check, {
+      graceMs: opts.graceMs,
+      limit: opts.limit,
+    });
+  }
+
+  /**
+   * Keep-alive alarm — reschedules itself every 50 seconds to prevent DO eviction.
+   * Also sweeps staged x402 payments whose client never polled /api/payment-status,
+   * so backend-owned polling fills the gap from fire-and-forget clients (#572).
+   */
   async alarm(): Promise<void> {
+    try {
+      await this.sweepStagedPayments();
+    } catch (err) {
+      console.error("[alarm] sweepStagedPayments threw:", err);
+    }
     await this.ctx.storage.setAlarm(Date.now() + 50_000);
   }
 


### PR DESCRIPTION
## Summary

Closes #572.

Fire-and-forget MCP agents who paid through x402 but never polled `/api/payment-status` ended up with confirmed on-chain payments and no delivered classified/brief — the stage row sat until the 24h TTL while the sats settled silently. Reconciliation only ran synchronously at POST time (confirmed-only) or when the caller drove `GET /api/payment-status/:paymentId`.

This PR fills the gap by adding a bounded reconcile sweep inside the existing 50s DO keep-alive alarm. Each tick picks up to 10 staged rows older than a 30s grace window, calls `X402_RELAY.checkPayment`, and applies terminal outcomes through the same reconcile logic the poll route uses.

**Cadence:** 50s alarm + 30s grace → backend-owned settlement lands in ~80s worst case, well inside the 24h stage TTL. Existing `GET /api/payment-status/:paymentId` route is unchanged for operators and clients that do poll.

## Shape

- `reconcileStageRow(sql, paymentId, status, txid?, terminalReason?)` — extracted so the `/payment-staging/:paymentId/reconcile` DO route and the new sweep share identical write semantics (idempotent; no-op on `finalized` / `discarded` rows).
- `sweepPaymentStagingRows(sql, checkPayment, opts)` — env-agnostic. `SELECT ... ORDER BY created_at ASC LIMIT n`, per-row try/catch so one relay blip doesn't abort the batch.
- `NewsDO.sweepStagedPayments(opts)` — binds `this.env.X402_RELAY.checkPayment`; returns 0 and no-ops cleanly when the binding isn't an RPC (test miniflare).
- `NewsDO.alarm()` — calls the sweep before rescheduling, wrapped in try/catch so sweep failures never block the 50s reschedule.
- Test-only `POST /api/test/sweep-staged-payments` accepts a `results` stub map so tests drive `checkPayment` without a live relay.

## Test plan

- [x] `src/__tests__/payment-stage-alarm-sweep.test.ts` — 5 cases covering: confirmed → finalized, failed → discarded, pending (mempool) untouched, grace-window respected, no-relay no-op
- [x] `npm test -- --run` passes (only pre-existing cold-start timeouts in `scoring-math.test.ts` and similar files remain — unchanged by this PR)
- [x] `npx tsc --noEmit` clean
- [ ] Verify on staging: submit a classified via MCP without polling, watch it finalize within ~80s

## What this doesn't do (deliberately)

- No per-paymentId attempt counter — the 24h TTL + existing `purgeExpiredStagedRecords` already handles give-up, and fixed-cadence alarm doesn't need backoff.
- No Cloudflare Queues — the singleton DO already has an alarm firing every 50s; adding a queue would be new infra for the same outcome.