### PR TITLE
fix(archive,homepage): accurate archive facet counts; align Today's Beats to UTC

### DIFF
--- a/public/archive/index.html
+++ b/public/archive/index.html
@@ -420,12 +420,16 @@
     };
 
     const STATUSES = [
-      { key: 'inscribed', label: 'Inscribed', color: 'var(--good)' },
-      { key: 'approved',  label: 'Approved' },
-      { key: 'submitted', label: 'Pending',   color: 'var(--warn)' },
-      { key: 'pending',   label: 'Pending',   color: 'var(--warn)' },
-      { key: 'retracted', label: 'Retracted', color: 'var(--accent)' },
-      { key: 'rejected',  label: 'Rejected',  color: 'var(--accent)' },
+      { key: 'brief_included', label: 'In Brief',   color: 'var(--good)' },
+      { key: 'approved',       label: 'Approved' },
+      { key: 'submitted',      label: 'Pending',    color: 'var(--warn)' },
+      { key: 'replaced',       label: 'Replaced',   color: 'var(--accent)' },
+      { key: 'rejected',       label: 'Rejected',   color: 'var(--accent)' },
+      // Legacy keys retained for backwards-compat with bookmarked filter URLs;
+      // never returned by the API, so their counts will always be 0.
+      { key: 'inscribed',      label: 'Inscribed',  color: 'var(--good)' },
+      { key: 'pending',        label: 'Pending',    color: 'var(--warn)' },
+      { key: 'retracted',      label: 'Retracted',  color: 'var(--accent)' },
     ];
 
     const TIME_RANGES = [
@@ -448,6 +452,11 @@
       allSignals: [],
       allBeats: [],
       allBriefs: [],
+      // Authoritative server counts (not capped by the 200-row signals page).
+      // Populated in init(); used by facet labels so the displayed counts match
+      // reality for high-volume archives instead of ceilinging at 200.
+      totalCounts: null,        // /api/signals/counts (all-time)
+      timeRangeCounts: {},      // { today, week, month, quarter, all } → total
     };
 
     async function fetchJSON(url) {
@@ -484,6 +493,12 @@
     function sinceForRange(rangeKey) {
       const r = TIME_RANGES.find(x => x.key === rangeKey);
       if (!r || r.key === 'all') return null;
+      // "Today" anchors at UTC midnight so the local listing filter matches
+      // the facet count (which the server computes against today UTC). Other
+      // ranges stay rolling — week/month/quarter is naturally a rolling window.
+      if (r.key === 'today') {
+        return new Date(new Date().toISOString().slice(0, 10) + 'T00:00:00Z');
+      }
       return new Date(Date.now() - r.days * 86400000);
     }
 
@@ -509,16 +524,30 @@
       const host = document.getElementById('arc-facets');
       const results = filtered();
 
-      // Beat counts
+      // Beat + agent counts are derived from the visible signal page (the
+      // 200-row /api/signals fetch), which is honest for the listing context
+      // — the user can only filter to what's loaded. Status counts override
+      // with server totals (state.totalCounts) when available so they reflect
+      // the full archive instead of ceilinging at 200.
       const beatCounts = {};
       const agentCounts = {};
-      const statusCounts = {};
+      const statusCounts = state.totalCounts
+        ? {
+            approved: state.totalCounts.approved || 0,
+            submitted: state.totalCounts.submitted || 0,
+            rejected: state.totalCounts.rejected || 0,
+            replaced: state.totalCounts.replaced || 0,
+            brief_included: state.totalCounts.brief_included || 0,
+          }
+        : {};
       for (const s of state.allSignals) {
         const slug = s.beatSlug || (s.beat || '').toLowerCase().replace(/\s+/g, '-');
         if (slug) beatCounts[slug] = (beatCounts[slug] || 0) + 1;
         if (s.btcAddress) agentCounts[s.btcAddress] = (agentCounts[s.btcAddress] || 0) + 1;
-        const st = (s.status || '').toLowerCase();
-        if (st) statusCounts[st] = (statusCounts[st] || 0) + 1;
+        if (!state.totalCounts) {
+          const st = (s.status || '').toLowerCase();
+          if (st) statusCounts[st] = (statusCounts[st] || 0) + 1;
+        }
       }
 
       const topAgents = Object.entries(agentCounts)
@@ -539,7 +568,11 @@
           }).join('')
         : '';
 
-      const statusKeys = ['inscribed', 'approved', 'submitted', 'pending', 'retracted', 'rejected']
+      // Real schema statuses (src/lib/constants.ts): submitted, approved,
+      // replaced, rejected, brief_included. Legacy 'inscribed'/'pending'/
+      // 'retracted' kept for backwards-compat with bookmarked filter URLs but
+      // hidden when their server count is 0.
+      const statusKeys = ['brief_included', 'approved', 'submitted', 'replaced', 'rejected', 'inscribed', 'pending', 'retracted']
         .filter(k => statusCounts[k]);
       const statusGroup = statusKeys.map(k => {
         const info = STATUSES.find(s => s.key === k) || { label: k };
@@ -589,6 +622,13 @@
     }
 
     function signalCountInRange(r) {
+      // Prefer the authoritative server-side count when available — local
+      // computation off state.allSignals would ceiling at the 200-row page
+      // limit on /api/signals and report misleadingly low totals for the
+      // 7d/30d/90d ranges.
+      if (state.timeRangeCounts && typeof state.timeRangeCounts[r.key] === 'number') {
+        return state.timeRangeCounts[r.key];
+      }
       if (!state.allSignals.length) return 0;
       if (r.key === 'all') return state.allSignals.length;
       const since = new Date(Date.now() - r.days * 86400000);
@@ -885,18 +925,43 @@
     }
 
     async function init() {
-      const [beatsData, signalsData] = await Promise.all([
+      // /api/signals is capped at 200 rows server-side regardless of the
+      // requested limit. Fetch authoritative aggregates in parallel via
+      // /api/signals/counts so the time + status facets reflect the full
+      // archive instead of being truncated to ≤200.
+      const todayUtcMidnight = new Date().toISOString().slice(0, 10) + 'T00:00:00Z';
+      const sinceForDays = (n) => new Date(Date.now() - n * 86400000).toISOString();
+      const [beatsData, signalsData, totalCounts, todayCounts, weekCounts, monthCounts, quarterCounts] = await Promise.all([
         fetchJSON('/api/beats'),
-        fetchJSON('/api/signals?limit=500'),
+        fetchJSON('/api/signals?limit=200'),
+        fetchJSON('/api/signals/counts'),
+        fetchJSON('/api/signals/counts?since=' + encodeURIComponent(todayUtcMidnight)),
+        fetchJSON('/api/signals/counts?since=' + encodeURIComponent(sinceForDays(7))),
+        fetchJSON('/api/signals/counts?since=' + encodeURIComponent(sinceForDays(30))),
+        fetchJSON('/api/signals/counts?since=' + encodeURIComponent(sinceForDays(90))),
       ]);
       state.allBeats = (Array.isArray(beatsData) ? beatsData : []).filter(b => (b.status || 'active').toLowerCase() !== 'retired');
       state.allSignals = (signalsData && Array.isArray(signalsData.signals)) ? signalsData.signals : [];
+      state.totalCounts = totalCounts || null;
+      state.timeRangeCounts = {
+        today: todayCounts && todayCounts.total,
+        week: weekCounts && weekCounts.total,
+        month: monthCounts && monthCounts.total,
+        quarter: quarterCounts && quarterCounts.total,
+        all: totalCounts && totalCounts.total,
+      };
 
-      const total = state.allSignals.length;
-      const briefs = 0;
-      const inscribed = state.allSignals.filter(s => (s.status || '').toLowerCase() === 'inscribed').length;
+      // Subtitle now reflects the true archive total (not the visible page
+      // size). "brief_included" is the closest analog to the legacy
+      // "inscribed" tally — signals that made it into a published brief.
+      const total = (totalCounts && totalCounts.total) || state.allSignals.length;
+      const inBrief = (totalCounts && totalCounts.brief_included) || 0;
+      const visible = state.allSignals.length;
+      const truncationNote = total > visible
+        ? ' · showing newest ' + visible.toLocaleString()
+        : '';
       document.getElementById('arc-subtitle').textContent =
-        total.toLocaleString() + ' signals · ' + inscribed.toLocaleString() + ' inscribed';
+        total.toLocaleString() + ' signals · ' + inBrief.toLocaleString() + ' in brief' + truncationNote;
 
       bindSearch();
       rerender();

--- a/public/index.html
+++ b/public/index.html
@@ -4368,20 +4368,21 @@
       const active = (beats || []).filter(b => (b.status || 'active').toLowerCase() === 'active');
       if (!active.length) return;
 
-      // 24h window. Tile numbers come from /api/signals/counts (purpose-built,
-      // not capped by row limits) so high-volume beats — bitcoin-macro currently
-      // files 600+ signals/24h, mostly rejected — don't crowd approved rows out
-      // of a 200-row /api/signals window and silently undercount the dashboard.
-      // /api/signals is still fetched, but only for the sparkline; for very
-      // active beats the sparkline reflects the most recent ~200 events.
-      const since = new Date(Date.now() - 24 * 3600 * 1000).toISOString();
+      // Tile numbers anchor on UTC midnight so they match the homepage
+      // dateline ("N approved today"). Rolling-24h numbers caused a confusing
+      // apparent mismatch — the dateline could read 0 approved while the
+      // tiles showed yesterday-afternoon approvals lingering in the window.
+      // The sparkline still uses a rolling 24h fetch so the trend bars span
+      // across the midnight boundary (visualization intent != count intent).
+      const todayUtcMidnight = new Date().toISOString().slice(0, 10) + 'T00:00:00Z';
+      const since24h = new Date(Date.now() - 24 * 3600 * 1000).toISOString();
       const top = active.slice(0, 3);
       const [perBeatCounts, perBeatSignals] = await Promise.all([
         Promise.all(top.map(b =>
-          fetchJSON('/api/signals/counts?beat=' + encodeURIComponent(b.slug) + '&since=' + encodeURIComponent(since))
+          fetchJSON('/api/signals/counts?beat=' + encodeURIComponent(b.slug) + '&since=' + encodeURIComponent(todayUtcMidnight))
         )),
         Promise.all(top.map(b =>
-          fetchJSON('/api/signals?beat=' + encodeURIComponent(b.slug) + '&since=' + encodeURIComponent(since) + '&limit=200')
+          fetchJSON('/api/signals?beat=' + encodeURIComponent(b.slug) + '&since=' + encodeURIComponent(since24h) + '&limit=200')
         )),
       ]);
 
@@ -4449,7 +4450,7 @@
         + '</a>';
       }).join('');
 
-      inner.innerHTML = '<div style="grid-column:1/-1"><div class="beat-tile-kicker">Today\'s Beats <span style="opacity:0.7;letter-spacing:0.08em">(24 hr)</span></div></div>' + tileHTML;
+      inner.innerHTML = '<div style="grid-column:1/-1"><div class="beat-tile-kicker">Today\'s Beats <span style="opacity:0.7;letter-spacing:0.08em">(UTC)</span></div></div>' + tileHTML;
 
       // WIRE STATUS block — signals/hour and brief recency come from dedicated
       // endpoints so they're accurate regardless of how many signals each beat


### PR DESCRIPTION
Follow-up to #584. Two more data-mismatch bugs verified live against `aibtc.news`:

## 1. Archive facet counts capped at 200

`public/archive/index.html` did `/api/signals?limit=500` (the API caps at 200 server-side regardless of the requested limit) and then computed time + status facet counts client-side. Every facet ceilinged at 200.

| Time facet | Page showed | Real count (from `/api/signals/counts`) |
|---|---|---|
| Today | 200 | **212** |
| This week | 200 | **5,314** |
| Last 30d | 200 | **20,031** |
| Last 90d / All | 200 | **20,205** |

Status facets had the same problem and also referenced legacy `'inscribed'/'pending'/'retracted'` keys that the schema doesn't return (real statuses: `submitted`, `approved`, `replaced`, `rejected`, `brief_included`).

## 2. Homepage "Today's Beats" semantic mismatch

After #584 the tile counts came from `/api/signals/counts` so they were no longer truncated, but they still used a **rolling-24h** window while the dateline ("N approved today") used **UTC today**. Result: yesterday-afternoon approvals showed as "approved" in the tile while the dateline correctly read "0 approved today" — looked like a bug across the same page.

## The fix

### `public/archive/index.html`

- 5 parallel `/api/signals/counts?since=…` calls hydrate `state.timeRangeCounts`; `signalCountInRange()` prefers server totals when available.
- Status facet counts come from the all-time `/api/signals/counts` envelope instead of the truncated 200-row page.
- `STATUSES` list updated to the real schema: `brief_included`, `approved`, `submitted`, `replaced`, `rejected`. Legacy `inscribed`/`pending`/`retracted` keys retained as no-op stubs for bookmarked filter URLs but hidden when their server count is 0.
- Subtitle now shows true total + truncation note: e.g. `"20,205 signals · 1,301 in brief · showing newest 200"`.
- "Today" filter anchored on UTC midnight to match its facet count semantic (was rolling 24h, which would have left the listing inconsistent with the new server-side count).

### `public/index.html` (`renderBeatsRail`)

- Tile counts switched from rolling 24h → UTC midnight via `/api/signals/counts?since=<utcMidnight>`. Numbers now match the dateline elsewhere on the page.
- Sparkline data still uses a rolling-24h window — the trend visualization spanning midnight is intentional (sparkline shows shape over time, tiles show today's tally).
- Tile subtitle `(24 hr)` → `(UTC)` to reflect the new semantic.

## Out of scope (separate follow-up)

- **Archive listing pagination.** The visible signal list is still capped at the most recent 200. A real fix needs the archive UI to drive the existing `offset` parameter on `/api/signals`. The new "showing newest N" subtitle note makes the cap honest in the meantime.

## Test plan

- [ ] Visual check on preview deploy:
  - Archive time facets show real counts (Today=~212, This week=~5K, 30d=~20K) instead of `200/200/200`.
  - Archive status facets show real schema labels (`In Brief`, `Approved`, `Pending`, `Replaced`, `Rejected`).
  - Archive subtitle shows true total + truncation note.
  - Homepage tile numbers match the dateline ("0 approved today" everywhere until the first review of the day, then both go up together).
  - Header reads `Today's Beats (UTC)`.
- [ ] No console errors; sparklines still render.