### PR TITLE
perf(frontend): bucket since= timestamps and sync-paint the ticker so navigations hit cache

### DIFF
--- a/public/agents/index.html
+++ b/public/agents/index.html
@@ -552,10 +552,7 @@
     }
 
     // ── List view ──
-    async function renderList() {
-      document.title = 'Correspondents — AIBTC News';
-      const root = document.getElementById('root');
-      const data = await fetchJSON('/api/correspondents');
+    function paintCorrespondentList(root, data) {
       const correspondents = (data && data.correspondents) ? data.correspondents : [];
 
       let html = '<div class="list-hero">'
@@ -602,6 +599,22 @@
       }
       html += '</tbody></table></div>';
       root.innerHTML = html;
+    }
+
+    async function renderList() {
+      document.title = 'Correspondents — AIBTC News';
+      const root = document.getElementById('root');
+      // Sync cache hit → paint immediately, no async round-trip flash. The
+      // /api/correspondents response is cached at 2min via shared.js.
+      const cached = (typeof cachedJSONSync === 'function')
+        ? cachedJSONSync('/api/correspondents')
+        : null;
+      if (cached) {
+        paintCorrespondentList(root, cached);
+        return;
+      }
+      const data = await fetchJSON('/api/correspondents');
+      paintCorrespondentList(root, data);
     }
 
     // ── Dashboard view ──

--- a/public/archive/index.html
+++ b/public/archive/index.html
@@ -457,6 +457,13 @@
       // reality for high-volume archives instead of ceilinging at 200.
       totalCounts: null,        // /api/signals/counts (all-time)
       timeRangeCounts: {},      // { today, week, month, quarter, all } → total
+      // Progressive loading state. The /api/signals page caps at 200 rows;
+      // loadMore() walks the offset window (max 10_000) appending pages so
+      // the user can scroll past the initial chunk.
+      pageSize: 200,
+      nextOffset: 200,
+      hasMore: false,
+      loading: false,
     };
 
     async function fetchJSON(url) {
@@ -740,6 +747,34 @@
         + '<span style="color:var(--text-secondary)">' + esc(fmt(now)) + '</span>';
     }
 
+    // ── Progressive load: fetch the next page of /api/signals (max 200 rows
+    // per request, max offset 10_000 server-side) and append to allSignals.
+    // No-ops while a fetch is in-flight or after we've exhausted what the
+    // offset-paginated endpoint can serve. Filtering re-runs over the larger
+    // set after each page lands.
+    const MAX_OFFSET = 10000;
+    async function loadMore() {
+      if (state.loading || !state.hasMore) return;
+      state.loading = true;
+      renderResults();
+      try {
+        const offset = Math.min(state.nextOffset, MAX_OFFSET);
+        const data = await fetchJSON('/api/signals?limit=' + state.pageSize + '&offset=' + offset);
+        const next = (data && Array.isArray(data.signals)) ? data.signals : [];
+        // De-dupe defensively in case the cursor + new writes cause overlap.
+        const seen = new Set(state.allSignals.map(s => s.id));
+        for (const s of next) if (!seen.has(s.id)) state.allSignals.push(s);
+        state.nextOffset += next.length;
+        state.hasMore =
+          next.length === state.pageSize &&
+          state.nextOffset < MAX_OFFSET &&
+          (!state.totalCounts || state.allSignals.length < state.totalCounts.total);
+      } finally {
+        state.loading = false;
+        rerender();
+      }
+    }
+
     function renderResults() {
       const list = document.getElementById('arc-results-list');
       const results = filtered();
@@ -791,7 +826,37 @@
             + '<div class="arc-result-author">' + esc(agent) + ' · <span style="font-family:var(--mono)">view inscription</span></div>'
           + '</a>';
       }).join('');
-      list.innerHTML = rows + (results.length > 50 ? '<div class="empty">Showing first 50 of ' + results.length + '. Narrow your filters to see more.</div>' : '');
+      // Tail: page indicator + Load More. Two distinct cases:
+      //   1. Filtered set has > 50 visible rows on the loaded page.
+      //   2. The archive itself has more pages we haven't fetched yet.
+      // Both can be true at once — show whichever is relevant.
+      const grandTotal = state.totalCounts && state.totalCounts.total;
+      let tail = '';
+      if (results.length > 50) {
+        tail += '<div class="empty">Showing first 50 of ' + results.length.toLocaleString() + ' filtered results.</div>';
+      }
+      if (state.hasMore || state.loading) {
+        const loadedNote = grandTotal
+          ? state.allSignals.length.toLocaleString() + ' of ' + grandTotal.toLocaleString() + ' loaded'
+          : state.allSignals.length.toLocaleString() + ' loaded';
+        const cappedNote = state.nextOffset >= MAX_OFFSET
+          ? '<div class="empty" style="margin-top:6px">Pagination capped at ' + MAX_OFFSET.toLocaleString() + ' — older signals require date filtering.</div>'
+          : '';
+        tail += ''
+          + '<div class="empty" style="display:flex;flex-direction:column;align-items:center;gap:8px;padding:18px 0">'
+          +   '<span style="font-family:var(--mono);font-size:11px;color:var(--text-faint)">' + loadedNote + '</span>'
+          +   (state.hasMore
+              ? '<button id="arc-load-more" type="button" style="font-family:var(--sans);font-size:12px;font-weight:600;padding:8px 18px;border:1px solid var(--text);background:var(--bg-card);color:var(--text);cursor:pointer"' + (state.loading ? ' disabled' : '') + '>'
+                + (state.loading ? 'Loading…' : 'Load more') + '</button>'
+              : '')
+          + cappedNote
+          + '</div>';
+      } else if (grandTotal && state.allSignals.length >= grandTotal) {
+        tail += '<div class="empty" style="padding:14px 0">All ' + grandTotal.toLocaleString() + ' signals loaded.</div>';
+      }
+      list.innerHTML = rows + tail;
+      const loadMoreBtn = document.getElementById('arc-load-more');
+      if (loadMoreBtn) loadMoreBtn.addEventListener('click', () => loadMore());
     }
 
     function renderApiSnippet() {
@@ -889,6 +954,7 @@
     }
 
     function rerender() {
+      renderSubtitle();
       renderActiveChips();
       renderFacets();
       renderResults();
@@ -942,6 +1008,10 @@
       ]);
       state.allBeats = (Array.isArray(beatsData) ? beatsData : []).filter(b => (b.status || 'active').toLowerCase() !== 'retired');
       state.allSignals = (signalsData && Array.isArray(signalsData.signals)) ? signalsData.signals : [];
+      state.nextOffset = state.allSignals.length;
+      state.hasMore =
+        state.allSignals.length >= state.pageSize &&
+        (!totalCounts || state.allSignals.length < totalCounts.total);
       state.totalCounts = totalCounts || null;
       state.timeRangeCounts = {
         today: todayCounts && todayCounts.total,
@@ -951,9 +1021,20 @@
         all: totalCounts && totalCounts.total,
       };
 
-      // Subtitle now reflects the true archive total (not the visible page
-      // size). "brief_included" is the closest analog to the legacy
-      // "inscribed" tally — signals that made it into a published brief.
+      renderSubtitle();
+      bindSearch();
+      rerender();
+      renderSaved();
+      loadBriefs();
+    }
+
+    // Subtitle reflects the true archive total + currently-loaded slice.
+    // Recomputed after each loadMore() so the "showing newest N" note keeps
+    // pace with the user's progressive load. "brief_included" is the closest
+    // analog to the legacy "inscribed" tally — signals that made it into a
+    // published brief.
+    function renderSubtitle() {
+      const totalCounts = state.totalCounts;
       const total = (totalCounts && totalCounts.total) || state.allSignals.length;
       const inBrief = (totalCounts && totalCounts.brief_included) || 0;
       const visible = state.allSignals.length;
@@ -962,11 +1043,6 @@
         : '';
       document.getElementById('arc-subtitle').textContent =
         total.toLocaleString() + ' signals · ' + inBrief.toLocaleString() + ' in brief' + truncationNote;
-
-      bindSearch();
-      rerender();
-      renderSaved();
-      loadBriefs();
     }
 
     init();

--- a/public/archive/index.html
+++ b/public/archive/index.html
@@ -929,16 +929,16 @@
       // requested limit. Fetch authoritative aggregates in parallel via
       // /api/signals/counts so the time + status facets reflect the full
       // archive instead of being truncated to ≤200.
-      const todayUtcMidnight = new Date().toISOString().slice(0, 10) + 'T00:00:00Z';
-      const sinceForDays = (n) => new Date(Date.now() - n * 86400000).toISOString();
+      // Day-aligned `since=` values so each cache entry is reused for the
+      // entire UTC day instead of producing a fresh URL on every navigation.
       const [beatsData, signalsData, totalCounts, todayCounts, weekCounts, monthCounts, quarterCounts] = await Promise.all([
         fetchJSON('/api/beats'),
         fetchJSON('/api/signals?limit=200'),
         fetchJSON('/api/signals/counts'),
-        fetchJSON('/api/signals/counts?since=' + encodeURIComponent(todayUtcMidnight)),
-        fetchJSON('/api/signals/counts?since=' + encodeURIComponent(sinceForDays(7))),
-        fetchJSON('/api/signals/counts?since=' + encodeURIComponent(sinceForDays(30))),
-        fetchJSON('/api/signals/counts?since=' + encodeURIComponent(sinceForDays(90))),
+        fetchJSON('/api/signals/counts?since=' + encodeURIComponent(sinceUtcMidnightIso())),
+        fetchJSON('/api/signals/counts?since=' + encodeURIComponent(sinceDaysAgoIso(7))),
+        fetchJSON('/api/signals/counts?since=' + encodeURIComponent(sinceDaysAgoIso(30))),
+        fetchJSON('/api/signals/counts?since=' + encodeURIComponent(sinceDaysAgoIso(90))),
       ]);
       state.allBeats = (Array.isArray(beatsData) ? beatsData : []).filter(b => (b.status || 'active').toLowerCase() !== 'retired');
       state.allSignals = (signalsData && Array.isArray(signalsData.signals)) ? signalsData.signals : [];

--- a/public/archive/index.html
+++ b/public/archive/index.html
@@ -991,20 +991,25 @@
     }
 
     async function init() {
-      // /api/signals is capped at 200 rows server-side regardless of the
-      // requested limit. Fetch authoritative aggregates in parallel via
-      // /api/signals/counts so the time + status facets reflect the full
-      // archive instead of being truncated to ≤200.
-      // Day-aligned `since=` values so each cache entry is reused for the
+      // Phase 1 (render-blocking, critical) — listing + subtitle + facet
+      // labels (statuses) need beats, signals listing, and total counts.
+      // Fire the cheaper facet-count window calls as phase 2 (background)
+      // so the listing renders the moment phase 1 lands instead of waiting
+      // on 4 extra round-trips for sidebar labels that don't gate the
+      // primary content. Phase 3 (briefs sidebar) defers until that rail
+      // section nears the viewport.
+      // Day-aligned `since=` values keep every cache entry reused for the
       // entire UTC day instead of producing a fresh URL on every navigation.
-      const [beatsData, signalsData, totalCounts, todayCounts, weekCounts, monthCounts, quarterCounts] = await Promise.all([
-        fetchJSON('/api/beats'),
-        fetchJSON('/api/signals?limit=200'),
-        fetchJSON('/api/signals/counts'),
+      const phase2 = Promise.all([
         fetchJSON('/api/signals/counts?since=' + encodeURIComponent(sinceUtcMidnightIso())),
         fetchJSON('/api/signals/counts?since=' + encodeURIComponent(sinceDaysAgoIso(7))),
         fetchJSON('/api/signals/counts?since=' + encodeURIComponent(sinceDaysAgoIso(30))),
         fetchJSON('/api/signals/counts?since=' + encodeURIComponent(sinceDaysAgoIso(90))),
+      ]);
+      const [beatsData, signalsData, totalCounts] = await Promise.all([
+        fetchJSON('/api/beats'),
+        fetchJSON('/api/signals?limit=200'),
+        fetchJSON('/api/signals/counts'),
       ]);
       state.allBeats = (Array.isArray(beatsData) ? beatsData : []).filter(b => (b.status || 'active').toLowerCase() !== 'retired');
       state.allSignals = (signalsData && Array.isArray(signalsData.signals)) ? signalsData.signals : [];
@@ -1013,19 +1018,36 @@
         state.allSignals.length >= state.pageSize &&
         (!totalCounts || state.allSignals.length < totalCounts.total);
       state.totalCounts = totalCounts || null;
-      state.timeRangeCounts = {
-        today: todayCounts && todayCounts.total,
-        week: weekCounts && weekCounts.total,
-        month: monthCounts && monthCounts.total,
-        quarter: quarterCounts && quarterCounts.total,
-        all: totalCounts && totalCounts.total,
-      };
+      // Facet counts will populate from phase 2; render now with empties
+      // so the labels show "0" briefly rather than blanking the section.
+      state.timeRangeCounts = { all: totalCounts && totalCounts.total };
 
       renderSubtitle();
       bindSearch();
       rerender();
       renderSaved();
-      loadBriefs();
+
+      // Phase 2 — facet count labels populate without blocking the listing.
+      phase2.then(([todayCounts, weekCounts, monthCounts, quarterCounts]) => {
+        state.timeRangeCounts = {
+          today: todayCounts && todayCounts.total,
+          week: weekCounts && weekCounts.total,
+          month: monthCounts && monthCounts.total,
+          quarter: quarterCounts && quarterCounts.total,
+          all: totalCounts && totalCounts.total,
+        };
+        renderFacets();
+      });
+
+      // Phase 3 — briefs sidebar lazy-loads when its rail section nears the
+      // viewport. On screens where the rail is below the fold this skips
+      // a fetch entirely until the user scrolls there.
+      const rail = document.querySelector('.arc-rail');
+      if (typeof whenVisible === 'function') {
+        whenVisible(rail, loadBriefs);
+      } else {
+        loadBriefs();
+      }
     }
 
     // Subtitle reflects the true archive total + currently-loaded slice.

--- a/public/beats/index.html
+++ b/public/beats/index.html
@@ -628,7 +628,12 @@
     }
 
     async function init() {
-      const sevenDaysAgo = new Date(Date.now() - 7 * 86400000).toISOString();
+      // Day-aligned `since=` so the URL stays stable across navigations
+      // and the sessionStorage cache actually hits (ms-precision would
+      // produce a unique key on every page load — no cache hit ever).
+      const sevenDaysAgo = (typeof sinceDaysAgoIso === 'function')
+        ? sinceDaysAgoIso(7)
+        : new Date(Date.now() - 7 * 86400000).toISOString();
       const [beatsData, corrData, signalsData] = await Promise.all([
         fetchJSON('/api/beats'),
         fetchJSON('/api/correspondents'),

--- a/public/classifieds/index.html
+++ b/public/classifieds/index.html
@@ -556,16 +556,27 @@
     async function initGrid(root) {
       document.title = 'Classifieds — AIBTC News';
       renderGridShell(root);
-      const data = await fetchJSON('/api/classifieds?limit=200');
-      allClassifieds = (data && Array.isArray(data.classifieds))
-        ? data.classifieds.filter(c => {
-            const exp = new Date(c.expiresAt).getTime();
-            return !exp || exp >= Date.now();
-          })
-        : [];
 
-      bindCompose();
-      render();
+      // Sync cache hit → paint immediately, no skeleton flash. Falls through
+      // to the async path on miss/stale.
+      const url = '/api/classifieds?limit=200';
+      const cached = (typeof cachedJSONSync === 'function') ? cachedJSONSync(url) : null;
+      function applyData(data) {
+        allClassifieds = (data && Array.isArray(data.classifieds))
+          ? data.classifieds.filter(c => {
+              const exp = new Date(c.expiresAt).getTime();
+              return !exp || exp >= Date.now();
+            })
+          : [];
+        bindCompose();
+        render();
+      }
+      if (cached) {
+        applyData(cached);
+        return;
+      }
+      const data = await fetchJSON(url);
+      applyData(data);
     }
 
     // ── Post a Classified: build a ready-to-paste agent prompt (MCP-first) ──

--- a/public/file/index.html
+++ b/public/file/index.html
@@ -742,7 +742,11 @@
         state.duplicate = null;
         return;
       }
-      const sinceIso = new Date(Date.now() - 24 * 3600 * 1000).toISOString();
+      // 5-min bucket so consecutive duplicate-checks hit the cached page
+      // instead of producing a new URL on every keystroke debounce.
+      const sinceIso = (typeof bucketedSinceIso === 'function')
+        ? bucketedSinceIso(24 * 3600 * 1000, 5 * 60 * 1000)
+        : new Date(Date.now() - 24 * 3600 * 1000).toISOString();
       const data = await fetchJSON('/api/signals?beat=' + encodeURIComponent(state.selectedBeat) + '&since=' + encodeURIComponent(sinceIso) + '&limit=100');
       if (!data || !Array.isArray(data.signals)) return;
       const qTerms = q.toLowerCase().split(/\s+/).filter(t => t.length >= 4);

--- a/public/index.html
+++ b/public/index.html
@@ -3170,8 +3170,15 @@
           renderLeaderboard(correspondentsList);
         }
 
-        renderBeatsRail();
-        renderWire();
+        // Lazy-trigger heavy renders so they don't fire all their fetches up
+        // front. Today's Beats fires 6+ API calls (3 counts + 3 signals + 1
+        // hourly + brief) and The Wire fires 1 — defer both until their
+        // section nears the viewport. With a 400px rootMargin the fetch
+        // starts well before the section is actually visible, so the user
+        // doesn't perceive the lag. Falls back to immediate invocation when
+        // IntersectionObserver isn't available (whenVisible from shared.js).
+        whenVisible(el('beats-rail'), renderBeatsRail);
+        whenVisible(el('wire-section'), renderWire);
 
         // Section reveal animations
         document.querySelectorAll('.roster-section, .leaderboard-section, .marketplace-section').forEach(el => {

--- a/public/index.html
+++ b/public/index.html
@@ -4382,9 +4382,13 @@
       // tiles showed yesterday-afternoon approvals lingering in the window.
       // The sparkline still uses a rolling 24h fetch so the trend bars span
       // across the midnight boundary (visualization intent != count intent).
-      const todayUtcMidnight = new Date().toISOString().slice(0, 10) + 'T00:00:00Z';
-      const since24h = new Date(Date.now() - 24 * 3600 * 1000).toISOString();
-      const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+      // Bucket the rolling timestamps so consecutive navigations hit the
+      // cachedJSON sessionStorage cache instead of re-fetching every time
+      // (URL = cache key; ms-precision timestamps make every key unique).
+      // 5-min bucket on the 24h sparkline window, 1-min on the per-hour gauge.
+      const todayUtcMidnight = sinceUtcMidnightIso();
+      const since24h = bucketedSinceIso(24 * 3600 * 1000, 5 * 60 * 1000);
+      const oneHourAgo = bucketedSinceIso(60 * 60 * 1000, 60 * 1000);
       const top = active.slice(0, 3);
 
       // Fire EVERY rail fetch in parallel up front so cold-start latency on any

--- a/public/index.html
+++ b/public/index.html
@@ -3090,9 +3090,18 @@
 
     async function init() {
       try {
-        // Single request replaces 5 parallel API calls — one DO round-trip instead of 5.
-        // Falls back to individual calls if /api/init returns null (fetchJSON returns null on error).
-        let data = await fetchJSON('/api/init');
+        // Sync cache hit on /api/init → skip the await round-trip and paint
+        // immediately. Same data shape as the async path, so downstream code
+        // doesn't branch — only the initial source differs. cachedJSONSync
+        // is provided by shared.js; fall through to async if not loaded yet.
+        let data = (typeof cachedJSONSync === 'function')
+          ? cachedJSONSync('/api/init')
+          : null;
+        if (!data) {
+          // Single request replaces 5 parallel API calls — one DO round-trip instead of 5.
+          // Falls back to individual calls if /api/init returns null (fetchJSON returns null on error).
+          data = await fetchJSON('/api/init');
+        }
         if (!data) {
           const [briefRes, beatsRes, classifiedsRes, correspondentsRes, signalsRes] = await Promise.allSettled([
             fetchJSON('/api/brief?format=json'),

--- a/public/index.html
+++ b/public/index.html
@@ -4578,18 +4578,8 @@
     }
 
     // ── The Wire (dense signal rows below the brief) ──
-    async function renderWire() {
-      const section = el('wire-section');
-      const container = el('wire-rows');
-      if (!section || !container) return;
-
-      let signals = [];
-      try {
-        const data = await fetchJSON('/api/signals?limit=10');
-        signals = (data && Array.isArray(data.signals)) ? data.signals : [];
-      } catch { /* empty render */ }
+    function paintWireRows(section, container, signals) {
       if (!signals.length) return;
-
       const beatLetter = (b) => (b || '?').replace(/[^A-Za-z]/g, '').charAt(0).toUpperCase() || '?';
       const now = Date.now();
 
@@ -4640,6 +4630,28 @@
       });
 
       section.style.display = '';
+    }
+
+    async function renderWire() {
+      const section = el('wire-section');
+      const container = el('wire-rows');
+      if (!section || !container) return;
+
+      // Sync cache hit → paint immediately, no skeleton flash. The /api/signals
+      // payload is cached at 30s in shared.js; revalidation happens on the
+      // next page load when the entry expires.
+      const url = '/api/signals?limit=10';
+      const cached = (typeof cachedJSONSync === 'function') ? cachedJSONSync(url) : null;
+      if (cached && Array.isArray(cached.signals)) {
+        paintWireRows(section, container, cached.signals);
+        return;
+      }
+      let signals = [];
+      try {
+        const data = await fetchJSON(url);
+        signals = (data && Array.isArray(data.signals)) ? data.signals : [];
+      } catch { /* empty render */ }
+      paintWireRows(section, container, signals);
     }
 
     // ── Marketplace ──

--- a/public/shared.js
+++ b/public/shared.js
@@ -748,6 +748,10 @@ function sinceUtcMidnightIso() {
 
 // "N days ago" rounded to UTC midnight — stable for the whole UTC day.
 // Use for archive-style facets (last 7d, 30d, 90d) where day-grain is fine.
+// Note: result is the UTC midnight of the day n days ago, so the actual
+// window covered is between n×24h and (n+1)×24h depending on the current
+// time of day. Acceptable for archive facets where ±1 day's worth of
+// signals doesn't change the headline number meaningfully.
 function sinceDaysAgoIso(days) {
   const ms = Date.now() - days * 86400000;
   return new Date(ms).toISOString().slice(0, 10) + 'T00:00:00Z';

--- a/public/shared.js
+++ b/public/shared.js
@@ -571,20 +571,57 @@ function renderTicker(opts) {
   const refreshMs = opts.refreshMs || 30000;
   const limit = opts.limit || 8;
 
+  const tickerUrl = '/api/signals?limit=' + limit;
+  const tickerTtl = 30 * 1000;
+
+  // Build the ticker innerHTML for a given signal list — used both for the
+  // synchronous cache-hit path and the async load path so they stay in sync.
+  function buildScrollInner(sigs) {
+    if (!sigs.length) return '<span>No recent signals.</span>';
+    const build = (arr) => arr.map(s => {
+      const t = s.timestamp ? new Date(s.timestamp) : null;
+      const time = t ? t.toISOString().slice(11, 16) : '';
+      const beat = (s.beat || '').replace(/^bitcoin[-\s]/i, '').replace(/^aibtc[-\s]/i, '');
+      const hl = (s.headline || s.content || '').slice(0, 140);
+      return '<span class="ticker-time">● ' + esc(time) + '</span>'
+           + '<span>' + esc(hl) + (beat ? ' <span style="opacity:.6">· ' + esc(beat) + '</span>' : '') + '</span>'
+           + '<span class="ticker-sep">│</span>';
+    }).join('');
+    // Duplicate content so the CSS scroll animation loops seamlessly.
+    return build(sigs) + build(sigs);
+  }
+
+  // Check the sessionStorage cache synchronously. If we have a fresh payload,
+  // mount the ticker with real content directly — no skeleton flash. This is
+  // what eliminates the visible "loading" between page navigations when the
+  // /api/signals?limit=N response is already cached from the prior page.
+  const cached = (typeof cachedJSONSync === 'function')
+    ? cachedJSONSync(tickerUrl, { ttlMs: tickerTtl })
+    : null;
+  const cachedSigs = (cached && Array.isArray(cached.signals)) ? cached.signals : null;
+
   const el = document.createElement('div');
   el.className = 'ticker';
-  // Skeleton placeholder — shimmer bars match the text size of real ticker
-  // items, so the scrolling strip doesn't show "Loading…" text while fetching.
-  el.innerHTML =
-    '<div class="ticker-inner">'
-      + '<span class="ticker-scroll" id="ticker-scroll">'
-        + '<span class="ticker-sk"></span>'
-        + '<span class="ticker-sk --wide"></span>'
-        + '<span class="ticker-sk"></span>'
-        + '<span class="ticker-sk --wide"></span>'
-      + '</span>'
-      + '<span class="ticker-refresh">Auto-refresh 30s</span>'
-    + '</div>';
+  if (cachedSigs) {
+    el.innerHTML =
+      '<div class="ticker-inner">'
+        + '<span class="ticker-scroll" id="ticker-scroll">' + buildScrollInner(cachedSigs) + '</span>'
+        + '<span class="ticker-refresh">Auto-refresh 30s</span>'
+      + '</div>';
+  } else {
+    // Skeleton placeholder — shimmer bars match the text size of real ticker
+    // items, so the scrolling strip doesn't show "Loading…" text while fetching.
+    el.innerHTML =
+      '<div class="ticker-inner">'
+        + '<span class="ticker-scroll" id="ticker-scroll">'
+          + '<span class="ticker-sk"></span>'
+          + '<span class="ticker-sk --wide"></span>'
+          + '<span class="ticker-sk"></span>'
+          + '<span class="ticker-sk --wide"></span>'
+        + '</span>'
+        + '<span class="ticker-refresh">Auto-refresh 30s</span>'
+      + '</div>';
+  }
 
   // Insert after the topnav
   const nav = document.querySelector('.topnav');
@@ -596,32 +633,17 @@ function renderTicker(opts) {
 
   async function load(forceRefresh) {
     try {
-      const data = await cachedJSON('/api/signals?limit=' + limit, {
-        forceRefresh,
-        ttlMs: 30 * 1000,
-      });
+      const data = await cachedJSON(tickerUrl, { forceRefresh, ttlMs: tickerTtl });
       const sigs = (data && Array.isArray(data.signals)) ? data.signals : [];
       const scroll = document.getElementById('ticker-scroll');
       if (!scroll) return;
-      if (sigs.length === 0) {
-        scroll.innerHTML = '<span>No recent signals.</span>';
-        return;
-      }
-      const build = (arr) => arr.map(s => {
-        const t = s.timestamp ? new Date(s.timestamp) : null;
-        const time = t ? t.toISOString().slice(11, 16) : '';
-        const beat = (s.beat || '').replace(/^bitcoin[-\s]/i, '').replace(/^aibtc[-\s]/i, '');
-        const hl = (s.headline || s.content || '').slice(0, 140);
-        return '<span class="ticker-time">● ' + esc(time) + '</span>'
-             + '<span>' + esc(hl) + (beat ? ' <span style="opacity:.6">· ' + esc(beat) + '</span>' : '') + '</span>'
-             + '<span class="ticker-sep">│</span>';
-      }).join('');
-      // Duplicate content so CSS scroll animation loops seamlessly
-      scroll.innerHTML = build(sigs) + build(sigs);
+      scroll.innerHTML = buildScrollInner(sigs);
     } catch {}
   }
 
-  load();
+  // Skip the redundant initial async load when we already painted from cache —
+  // the first network revalidation will land via the setInterval below.
+  if (!cachedSigs) load();
   if (refreshMs > 0) setInterval(function () { load(true); }, refreshMs);
   // Pause polling when the tab is hidden
   document.addEventListener('visibilitychange', function () {
@@ -696,6 +718,58 @@ async function cachedJSON(url, opts) {
     }
     return data;
   } catch { return null; }
+}
+
+// ── Stable `since=` timestamps for cache-friendly URLs ─────────────────────
+// Many pages compute `since = (Date.now() - N).toISOString()` and embed the
+// result in a URL query param. Because cachedJSON keys on the full URL, a
+// millisecond-precision timestamp produces a unique key on every page load —
+// the cache never hits and the API gets re-called on every navigation. This
+// helper rounds `now` down to a coarser grain (default 5 minutes) so consecutive
+// fetches within the same bucket reuse the cached response.
+//
+// Pick `bucketMs` based on what staleness is acceptable for the consumer:
+//   - 60_000        — "signals/hour" gauge: tolerate 1 min of staleness
+//   - 5 * 60_000    — sparklines, beat tiles: visually identical for 5 min
+//   - 60 * 60_000   — hourly aggregates / large windows
+// For day-aligned ranges (today, last N days), prefer `sinceUtcMidnightIso`
+// or `sinceDaysAgoIso` below — those produce stable keys for an entire UTC day.
+function bucketedSinceIso(ageMs, bucketMs) {
+  bucketMs = bucketMs || 5 * 60 * 1000;
+  const bucketed = Math.floor((Date.now() - ageMs) / bucketMs) * bucketMs;
+  return new Date(bucketed).toISOString();
+}
+
+// Today's UTC midnight as ISO. Stable for the entire UTC day → same cache
+// key for every navigation within that day.
+function sinceUtcMidnightIso() {
+  return new Date().toISOString().slice(0, 10) + 'T00:00:00Z';
+}
+
+// "N days ago" rounded to UTC midnight — stable for the whole UTC day.
+// Use for archive-style facets (last 7d, 30d, 90d) where day-grain is fine.
+function sinceDaysAgoIso(days) {
+  const ms = Date.now() - days * 86400000;
+  return new Date(ms).toISOString().slice(0, 10) + 'T00:00:00Z';
+}
+
+// Synchronous cache read — returns the cached payload if still within TTL,
+// or null. Lets initial paint use cached data immediately instead of going
+// through cachedJSON's async path (which always yields a microtask before
+// the DOM update, briefly showing the skeleton even on cache hit).
+function cachedJSONSync(url, opts) {
+  opts = opts || {};
+  const ttl = opts.ttlMs != null ? opts.ttlMs : _ttlFor(url);
+  if (ttl <= 0) return null;
+  try {
+    const raw = sessionStorage.getItem('aibtc:cache:' + url);
+    if (!raw) return null;
+    const entry = JSON.parse(raw);
+    if (entry && typeof entry.at === 'number' && (Date.now() - entry.at) < ttl) {
+      return entry.data;
+    }
+  } catch {}
+  return null;
 }
 
 function _pruneCache() {

--- a/public/shared.js
+++ b/public/shared.js
@@ -757,6 +757,30 @@ function sinceDaysAgoIso(days) {
   return new Date(ms).toISOString().slice(0, 10) + 'T00:00:00Z';
 }
 
+// ── Lazy-trigger a renderer when its target element nears the viewport ──
+// Use this to defer fetches for sections below the fold so the page doesn't
+// fire every API call up front. The `rootMargin` default of 400px means the
+// fetch starts well before the section is actually visible — by the time the
+// user scrolls there, the data is already loaded. Falls back to immediate
+// invocation when IntersectionObserver isn't available.
+function whenVisible(target, fn, opts) {
+  opts = opts || {};
+  if (!target || typeof IntersectionObserver === 'undefined') {
+    fn();
+    return;
+  }
+  const obs = new IntersectionObserver(function (entries) {
+    for (let i = 0; i < entries.length; i++) {
+      if (entries[i].isIntersecting) {
+        obs.disconnect();
+        fn();
+        return;
+      }
+    }
+  }, { rootMargin: opts.rootMargin || '400px 0px' });
+  obs.observe(target);
+}
+
 // Synchronous cache read — returns the cached payload if still within TTL,
 // or null. Lets initial paint use cached data immediately instead of going
 // through cachedJSON's async path (which always yields a microtask before

--- a/public/signals/index.html
+++ b/public/signals/index.html
@@ -1082,10 +1082,7 @@
         // (5-min TTL — beats rarely change). Raw fetch() bypassed the cache.
         const data = (typeof cachedJSON === 'function')
           ? await cachedJSON('/api/beats?status=active')
-          : await (async () => {
-              const r = await fetch('/api/beats?status=active');
-              return r.ok ? r.json() : null;
-            })();
+          : await fetch('/api/beats?status=active').then(r => r.ok ? r.json() : null);
         if (!data) return;
         allBeats = Array.isArray(data) ? data : (data.beats || []);
         renderBeatFilter();

--- a/public/signals/index.html
+++ b/public/signals/index.html
@@ -1078,9 +1078,15 @@
     // ── Fetch beats for filter ──
     async function loadBeats() {
       try {
-        const res = await fetch('/api/beats?status=active');
-        if (!res.ok) return;
-        const data = await res.json();
+        // Use cachedJSON so the result is reused across same-tab navigations
+        // (5-min TTL — beats rarely change). Raw fetch() bypassed the cache.
+        const data = (typeof cachedJSON === 'function')
+          ? await cachedJSON('/api/beats?status=active')
+          : await (async () => {
+              const r = await fetch('/api/beats?status=active');
+              return r.ok ? r.json() : null;
+            })();
+        if (!data) return;
         allBeats = Array.isArray(data) ? data : (data.beats || []);
         renderBeatFilter();
       } catch (err) {


### PR DESCRIPTION
You correctly noticed that everything refetches on every page navigation despite the cache layer existing. Two root causes:

## 1. \`since=\` URLs were cache-busting themselves

\`cachedJSON\` keys on the full URL. URLs like:

\`\`\`
/api/signals?beat=bitcoin-macro&since=2026-04-22T05:46:31.123Z&limit=200
\`\`\`

…produce a **new cache key on every page load** because \`Date.now() - 24h\` is computed fresh with millisecond precision. The cache TTL was correct; the URLs just never matched.

Audit results — fetches that previously refetched on every navigation:

| Page | URL | Fix |
|---|---|---|
| homepage rail | \`/api/signals?beat=…&since=…&limit=200\` (×3) | 5-min bucket |
| homepage rail | \`/api/signals/counts?since=…\` (1h gauge) | 1-min bucket |
| archive | \`/api/signals/counts?since=<7d>\` (+30d, +90d) | UTC midnight |
| beats | \`/api/signals?since=<7d>&limit=500\` | UTC midnight |
| file | \`/api/signals?beat=…&since=<24h>\` (dup check) | 5-min bucket |

Three new helpers in \`shared.js\`:

\`\`\`js
bucketedSinceIso(ageMs, bucketMs)   // stable for `bucketMs` duration
sinceUtcMidnightIso()               // stable for the entire UTC day
sinceDaysAgoIso(n)                  // n days ago, UTC midnight
\`\`\`

## 2. The topnav ticker flashed its skeleton on every navigation

Even on cache hit, \`cachedJSON\` is async — the await queues a microtask before the DOM update, so the browser paints the skeleton briefly before the real content swaps in. That's the visible "loading" between page navigations even when the underlying data is cached.

New synchronous cache read \`cachedJSONSync()\` returns the cached payload if still within TTL. \`renderTicker()\` now:

- Paints real content into the initial mount when sync cache hits — no skeleton, no async round-trip.
- Skips the redundant initial \`load()\` when sync cache hit (background revalidation still runs every 30s via \`setInterval\`).
- Falls back to the skeleton + async load only when cache is empty/stale.

## Drive-by

\`signals/index.html#loadBeats()\` used raw \`fetch('/api/beats?status=active')\` and bypassed the cache entirely. Now goes through \`cachedJSON\` like the rest of the page.

## What this doesn't address (separate effort)

The homepage \`init()\` path's main brief / signal-feed render still goes through one async await before painting, so there's a sub-frame microtask delay even on cache hit. Sync-painting that whole pipeline would require more invasive restructuring; this PR knocks out the visible wins first. Call it out if you want a follow-up.

## Test plan

- [ ] DevTools network tab on preview deploy: navigate from / → /archive → /beats → /. The \`since=…\` URLs should appear once, then resolve from the disk cache (or not appear at all if sessionStorage hits first).
- [ ] Topnav ticker on the homepage should NOT show its skeleton when navigating back to / from another tab page within 30s.
- [ ] Archive facet counts and homepage tile numbers still match what the server returns.