### PR TITLE
perf(homepage): trim initial /api/init signals payload to last 48h

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4835,6 +4835,25 @@
       }
 
       scrollState.loading = false;
+
+      // Sparse-window cascade: IntersectionObserver only fires on transition,
+      // so when the initial 48h window returns very few signals (or any single
+      // page doesn't push the sentinel out of viewport), the observer stays
+      // silent and the user has no scroll trigger to load more. Re-check the
+      // sentinel after each successful load and call again if it's still
+      // within the same 200px rootMargin we observe with. Bounded by
+      // hasMore + nextBefore advancing each iteration, so this terminates
+      // when the feed runs out or the new content finally pushes the
+      // sentinel below the viewport.
+      if (!scrollState.done && scrollState.sentinel) {
+        const rect = scrollState.sentinel.getBoundingClientRect();
+        const stillVisible = rect.top < (window.innerHeight + 200);
+        if (stillVisible) {
+          // Defer to a microtask so the just-inserted DOM gets a layout pass
+          // before the next iteration measures-and-decides.
+          Promise.resolve().then(loadNextDay);
+        }
+      }
     }
 
     function renderDaySection(dateStr, signals) {

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -2086,9 +2086,12 @@ export class NewsDO extends DurableObject<Env> {
       return c.json({ ok: true, data: signals } satisfies DOResult<Signal[]>);
     });
 
-    // GET /signals/front-page — all approved + brief_included signals in a single query
-    // Eliminates the need for two separate /signals calls from the Worker route.
-    // LIMIT 500 preserves the old behavior (200 approved + 200 brief_included = up to 400).
+    // GET /signals/front-page — curated signals (approved + brief_included)
+    // from the last 48 hours. Older signals are loaded on-demand via the
+    // date-paginated /signals/front-page-page endpoint as the user scrolls.
+    // The previous LIMIT 500 returned ~12 days of data in one ~830 KB
+    // response; this trims the initial payload to a few dozen signals
+    // typical for the 48h window. Hard cap at 200 as a safety bound.
     this.router.get("/signals/front-page", (c) => {
       const rows = this.ctx.storage.sql
         .exec(
@@ -2097,9 +2100,10 @@ export class NewsDO extends DurableObject<Env> {
            LEFT JOIN beats b ON s.beat_slug = b.slug
            LEFT JOIN signal_tags st ON s.id = st.signal_id
            WHERE s.status IN ('approved', 'brief_included')
+             AND s.created_at >= datetime('now', '-2 days')
            GROUP BY s.id
            ORDER BY s.created_at DESC
-           LIMIT 500`
+           LIMIT 200`
         )
         .toArray();
 
@@ -4719,7 +4723,11 @@ export class NewsDO extends DurableObject<Env> {
         console.error("Leaderboard query failed in init bundle:", e);
       }
 
-      // Front-page signals (approved + brief_included)
+      // Front-page signals (approved + brief_included) for the initial render.
+      // Limited to last 48h so the bundled /api/init payload is small enough
+      // to render fast. The frontend's existing infinite-scroll path
+      // (/api/front-page?before=…&limit=50) loads older signals on demand
+      // as the user scrolls, so the deeper archive isn't lost — just deferred.
       const signalRows = this.ctx.storage.sql
         .exec(
           `SELECT s.*, b.name as beat_name, GROUP_CONCAT(st.tag) as tags_csv
@@ -4727,9 +4735,10 @@ export class NewsDO extends DurableObject<Env> {
            LEFT JOIN beats b ON s.beat_slug = b.slug
            LEFT JOIN signal_tags st ON s.id = st.signal_id
            WHERE s.status IN ('approved', 'brief_included')
+             AND s.created_at >= datetime('now', '-2 days')
            GROUP BY s.id
            ORDER BY s.created_at DESC
-           LIMIT 500`
+           LIMIT 200`
         )
         .toArray();
       const signals = signalRows.map((r) => rowToSignal(r as Record<string, unknown>));

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -87,6 +87,34 @@ function rowToSignal(row: Record<string, unknown>): Signal {
   };
 }
 
+// ── Front-page (curated) signals window ──
+// The homepage's initial render shows curated (approved + brief_included)
+// signals from this rolling window only; older days are loaded on demand
+// via /signals/front-page-page as the user scrolls. Both /init bundle and
+// /signals/front-page use the same window — keep the SQL fragment in one
+// place so future tweaks (window or row cap) are a one-line change.
+const FRONT_PAGE_WINDOW_SQL = "-2 days";
+const FRONT_PAGE_MAX_ROWS = 200;
+
+const FRONT_PAGE_SIGNALS_QUERY = `
+  SELECT s.*, b.name as beat_name, GROUP_CONCAT(st.tag) as tags_csv
+  FROM signals s
+  LEFT JOIN beats b ON s.beat_slug = b.slug
+  LEFT JOIN signal_tags st ON s.id = st.signal_id
+  WHERE s.status IN ('approved', 'brief_included')
+    AND s.created_at >= datetime('now', '${FRONT_PAGE_WINDOW_SQL}')
+  GROUP BY s.id
+  ORDER BY s.created_at DESC
+  LIMIT ${FRONT_PAGE_MAX_ROWS}
+`;
+
+function queryFrontPageSignals(
+  sql: DurableObjectState["storage"]["sql"]
+): Signal[] {
+  return sql.exec(FRONT_PAGE_SIGNALS_QUERY).toArray()
+    .map((r) => rowToSignal(r as Record<string, unknown>));
+}
+
 function rowToCompiledSignal(row: Record<string, unknown>): RawCompiledSignalRow {
   const raw = row as unknown as RawCompiledSignalRow;
   return {
@@ -2087,27 +2115,11 @@ export class NewsDO extends DurableObject<Env> {
     });
 
     // GET /signals/front-page — curated signals (approved + brief_included)
-    // from the last 48 hours. Older signals are loaded on-demand via the
-    // date-paginated /signals/front-page-page endpoint as the user scrolls.
-    // The previous LIMIT 500 returned ~12 days of data in one ~830 KB
-    // response; this trims the initial payload to a few dozen signals
-    // typical for the 48h window. Hard cap at 200 as a safety bound.
+    // for the initial render. Window + row cap defined by FRONT_PAGE_WINDOW_SQL
+    // and FRONT_PAGE_MAX_ROWS at the top of this file; older signals load on
+    // demand via /signals/front-page-page as the user scrolls.
     this.router.get("/signals/front-page", (c) => {
-      const rows = this.ctx.storage.sql
-        .exec(
-          `SELECT s.*, b.name as beat_name, GROUP_CONCAT(st.tag) as tags_csv
-           FROM signals s
-           LEFT JOIN beats b ON s.beat_slug = b.slug
-           LEFT JOIN signal_tags st ON s.id = st.signal_id
-           WHERE s.status IN ('approved', 'brief_included')
-             AND s.created_at >= datetime('now', '-2 days')
-           GROUP BY s.id
-           ORDER BY s.created_at DESC
-           LIMIT 200`
-        )
-        .toArray();
-
-      const signals = rows.map((r) => rowToSignal(r as Record<string, unknown>));
+      const signals = queryFrontPageSignals(this.ctx.storage.sql);
       return c.json({ ok: true, data: signals } satisfies DOResult<Signal[]>);
     });
 
@@ -4724,24 +4736,10 @@ export class NewsDO extends DurableObject<Env> {
       }
 
       // Front-page signals (approved + brief_included) for the initial render.
-      // Limited to last 48h so the bundled /api/init payload is small enough
-      // to render fast. The frontend's existing infinite-scroll path
-      // (/api/front-page?before=…&limit=50) loads older signals on demand
-      // as the user scrolls, so the deeper archive isn't lost — just deferred.
-      const signalRows = this.ctx.storage.sql
-        .exec(
-          `SELECT s.*, b.name as beat_name, GROUP_CONCAT(st.tag) as tags_csv
-           FROM signals s
-           LEFT JOIN beats b ON s.beat_slug = b.slug
-           LEFT JOIN signal_tags st ON s.id = st.signal_id
-           WHERE s.status IN ('approved', 'brief_included')
-             AND s.created_at >= datetime('now', '-2 days')
-           GROUP BY s.id
-           ORDER BY s.created_at DESC
-           LIMIT 200`
-        )
-        .toArray();
-      const signals = signalRows.map((r) => rowToSignal(r as Record<string, unknown>));
+      // Window + row cap defined by FRONT_PAGE_WINDOW_SQL / FRONT_PAGE_MAX_ROWS;
+      // older signals load on demand via /api/front-page?before=… as the user
+      // scrolls.
+      const signals = queryFrontPageSignals(this.ctx.storage.sql);
 
       return c.json({
         ok: true,


### PR DESCRIPTION
## Why

The /init DO query was returning the 500 newest curated (\`approved\` + \`brief_included\`) signals on every homepage load. Live measurement against \`aibtc.news\`:

\`\`\`
/api/front-page → 500 signals, payload ≈ 831 KB
                  newest 2026-04-22T05:41:59Z, oldest 2026-04-09T05:05:10Z (12 days)
\`\`\`

Most of that ~830 KB was never seen above the fold — the homepage already has a working infinite-scroll path that fires \`/api/front-page?before=<date>&limit=50\` to load older days as the user scrolls (\`initInfiniteScroll()\` in \`public/index.html\`). The 500-row up-front load existed for a no-brief fallback that no longer needs it.

## What

One backend change in \`src/objects/news-do.ts\` — both DO routes that feed the curated front-page signal list (\`/init\` bundle and \`/signals/front-page\` standalone) now filter to the last 48h with a hard cap of 200 rows:

\`\`\`sql
WHERE s.status IN ('approved', 'brief_included')
  AND s.created_at >= datetime('now', '-2 days')
ORDER BY s.created_at DESC
LIMIT 200
\`\`\`

No frontend change needed. The existing \`initInfiniteScroll(scrollCursor)\` path picks up where the initial render leaves off — \`scrollCursor\` is already the oldest rendered day, so older signals page in cleanly when the user scrolls past the initial chunk.

## Net effect on a typical homepage load

- Initial \`/api/init\` payload drops from ~830 KB → a few dozen KB (typical 48h window).
- Brief + roster + leaderboard render faster (less JSON to parse).
- Deeper archive (>48h) loads on demand instead of being paid for up front.
- A user who bounces from the brief never pays for the older days at all.

## Test plan

- [x] \`signal-review.test.ts\` + \`do-client.test.ts\` pass (15 tests). They assert response shape, not row counts, so the 48h trim is invisible to them.
- [x] \`tsc --noEmit\` clean.
- [ ] Visual on preview deploy: homepage initial render shows last ~48h of signals; scrolling triggers \`/api/front-page?before=…\` and appends older days as before.