### PR TITLE
fix(archive): render every loaded result so Load More actually adds visible rows

### DIFF
--- a/public/archive/index.html
+++ b/public/archive/index.html
@@ -792,7 +792,13 @@
       // Sort newest first
       results.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
 
-      const rows = results.slice(0, 50).map(s => {
+      // Render every loaded result. Slicing to a fixed count here meant Load
+      // More appended pages to state.allSignals (subtitle counter ticked up)
+      // but the visible list stayed pinned at the same 50 newest rows — the
+      // user saw counts climb with no new rows to show for it. The DOM cost
+      // of rendering ~hundreds-to-low-thousands of simple <a> rows is fine;
+      // Load More remains the user-controlled gate on how much grows here.
+      const rows = results.map(s => {
         const slug = s.beatSlug || (s.beat || '').toLowerCase().replace(/\s+/g, '-');
         const color = BEAT_COLORS[slug] || '#1a1a1a';
         const st = (s.status || '').toLowerCase();
@@ -826,15 +832,11 @@
             + '<div class="arc-result-author">' + esc(agent) + ' · <span style="font-family:var(--mono)">view inscription</span></div>'
           + '</a>';
       }).join('');
-      // Tail: page indicator + Load More. Two distinct cases:
-      //   1. Filtered set has > 50 visible rows on the loaded page.
-      //   2. The archive itself has more pages we haven't fetched yet.
-      // Both can be true at once — show whichever is relevant.
+      // Tail: progress note + Load More button when more pages exist on the
+      // server. The visible list is now everything filtered from what's
+      // loaded, so no "showing first N" caveat is needed inside the listing.
       const grandTotal = state.totalCounts && state.totalCounts.total;
       let tail = '';
-      if (results.length > 50) {
-        tail += '<div class="empty">Showing first 50 of ' + results.length.toLocaleString() + ' filtered results.</div>';
-      }
       if (state.hasMore || state.loading) {
         const loadedNote = grandTotal
           ? state.allSignals.length.toLocaleString() + ' of ' + grandTotal.toLocaleString() + ' loaded'


### PR DESCRIPTION
## Bug

User report: on the archive page, Load More fires successfully (subtitle "X of Y loaded" climbs, facet histogram updates) but the visible signal list never changes — feels like data loads but nothing appears in the UI.

## Root cause

\`renderResults()\` in \`public/archive/index.html\` hard-capped the visible list:

\`\`\`js
const rows = results.slice(0, 50).map(s => { ... })
\`\`\`

Load More appended the next 200-row page to \`state.allSignals\` — the in-memory pool grew, the subtitle "loaded N of M" climbed, the histogram across all loaded results updated — but the rendered listing stayed pinned at the same 50 *newest* rows because they were always the same after sorting newest-first. From the user's POV, every Load More click did nothing.

The 50-row cap predates the Load More feature; back then the message read "Showing first 50 of N. Narrow your filters to see more" because there was no other way to see more.

## Fix

Drop the \`.slice(0, 50)\` and render every loaded result. DOM cost of hundreds-to-low-thousands of simple \`<a>\` rows is fine, and Load More remains the user-controlled gate on how much grows here. Removes the now-misleading "Showing first 50 of N" note inside the listing — the subtitle ("X of Y loaded") + the Load More button already communicate the same idea cleaner.

## Test plan

- [ ] Visual on preview deploy: hit /archive, scroll the existing list, click Load More — new rows should appear at the bottom of the listing.
- [ ] Subtitle counter still tracks the loaded slice ("400 of 20,207 loaded" → "600 of 20,207 loaded" → …).
- [ ] Filter facets still update against all loaded results.