### PR TITLE
perf(api): edge-cache /api/init via Workers Cache API (~3s TTFB → <100ms on hit)

### DIFF
--- a/public/beats/index.html
+++ b/public/beats/index.html
@@ -439,7 +439,7 @@
       return svg;
     }
 
-    function renderBeatCards(beats, signalsByBeat, correspondents) {
+    function renderBeatCards(beats, countsBySlug, correspondents) {
       const container = document.getElementById('beat-cards');
       if (!beats.length) {
         container.innerHTML = '<div class="empty">No beats found.</div>';
@@ -448,16 +448,23 @@
       container.innerHTML = beats.map(b => {
         const color = b.color || BEAT_FALLBACK_COLORS[b.slug] || '#1a1a1a';
         const memberCount = b.memberCount || 0;
-        const sigs = signalsByBeat[b.slug] || [];
-        // Editorial state: `brief_included`/`approved` are the "made it" states
-        // in this data model (no raw `inscribed` per-signal).
-        const todayStart = new Date();
-        todayStart.setUTCHours(0, 0, 0, 0);
-        const approvedOrInBriefToday = sigs.filter(s => {
-          if (!s.timestamp || new Date(s.timestamp) < todayStart) return false;
-          const st = (s.status || '').toLowerCase();
-          return st === 'approved' || st === 'brief_included' || st === 'inscribed';
-        }).length;
+
+        // Counts come from /api/signals/counts (purpose-built, not row-capped).
+        // Previously we computed both numbers by client-filtering /api/signals
+        // (server-capped at 200 rows total across all beats), which silently
+        // undercounted "Signals · 7d" by 30-40× whenever a high-volume beat
+        // like bitcoin-macro filled the window. weekTotal is the full 7-day
+        // pipeline (any status); approvedToday is the editorially-accepted
+        // count for the current UTC day.
+        //
+        // Show '—' (em dash) when counts haven't landed yet — hard-coding 0
+        // would imply "no signals" when really we just don't know yet. The
+        // dash gets swapped for the real number by fillBeatCardCounts() once
+        // the per-beat /api/signals/counts response lands.
+        const counts = countsBySlug[b.slug];
+        const weekTotal = counts ? counts.week : '—';
+        const approvedToday = counts ? counts.approvedToday : '—';
+
         const active = (b.status || 'active') === 'active';
         const retired = (b.status || '').toLowerCase() === 'retired';
         // Real editor from the beats API (beat.editor.address), falling back gracefully
@@ -467,7 +474,7 @@
           || (editorAddr ? truncAddr(editorAddr) : 'Vacant');
 
         return ''
-          + '<a class="beat-card" href="/signals/?beat=' + encodeURIComponent(b.slug) + '">'
+          + '<a class="beat-card" data-beat-slug="' + esc(b.slug) + '" href="/signals/?beat=' + encodeURIComponent(b.slug) + '">'
             + '<div class="beat-card-head">'
               + '<span class="pip --lg" style="background:' + color + '"></span>'
               + '<span class="name">' + esc(b.name) + '</span>'
@@ -480,8 +487,8 @@
             + '<div class="beat-card-desc">' + esc(b.description || '—') + '</div>'
             + '<div class="beat-card-stats">'
               + '<div><div class="beat-card-stat-num">' + memberCount + '</div><div class="beat-card-stat-label">Agents</div></div>'
-              + '<div><div class="beat-card-stat-num">' + sigs.length + '</div><div class="beat-card-stat-label">Signals · 7d</div></div>'
-              + '<div><div class="beat-card-stat-num --good">' + approvedOrInBriefToday + '</div><div class="beat-card-stat-label">In Brief · Today</div></div>'
+              + '<div><div class="beat-card-stat-num" data-stat="week">' + weekTotal + '</div><div class="beat-card-stat-label">Signals · 7d</div></div>'
+              + '<div><div class="beat-card-stat-num --good" data-stat="approvedToday">' + approvedToday + '</div><div class="beat-card-stat-label">Approved · Today</div></div>'
             + '</div>'
             + '<div class="beat-card-editor">'
               + '<span class="label">Editor</span>'
@@ -489,6 +496,18 @@
             + '</div>'
           + '</a>';
       }).join('');
+    }
+
+    // Update an already-rendered beat card's counts in place once /api/signals/counts
+    // returns for that beat. Avoids a full container re-render and lets each beat's
+    // numbers fill in as its responses land instead of waiting on the slowest one.
+    function fillBeatCardCounts(slug, counts) {
+      const card = document.querySelector('.beat-card[data-beat-slug="' + CSS.escape(slug) + '"]');
+      if (!card) return;
+      const weekEl = card.querySelector('[data-stat="week"]');
+      const todayEl = card.querySelector('[data-stat="approvedToday"]');
+      if (weekEl) weekEl.textContent = counts.week;
+      if (todayEl) todayEl.textContent = counts.approvedToday;
     }
 
     function renderRosterChips(beats, correspondents) {
@@ -634,29 +653,48 @@
       const sevenDaysAgo = (typeof sinceDaysAgoIso === 'function')
         ? sinceDaysAgoIso(7)
         : new Date(Date.now() - 7 * 86400000).toISOString();
-      const [beatsData, corrData, signalsData] = await Promise.all([
+      const todayUtcMidnight = (typeof sinceUtcMidnightIso === 'function')
+        ? sinceUtcMidnightIso()
+        : new Date().toISOString().slice(0, 10) + 'T00:00:00Z';
+
+      const [beatsData, corrData] = await Promise.all([
         fetchJSON('/api/beats'),
         fetchJSON('/api/correspondents'),
-        fetchJSON('/api/signals?since=' + encodeURIComponent(sevenDaysAgo) + '&limit=500'),
       ]);
 
       const allBeats = Array.isArray(beatsData) ? beatsData : [];
       const activeBeats = allBeats.filter(b => (b.status || 'active').toLowerCase() !== 'retired');
       const correspondents = (corrData && corrData.correspondents) ? corrData.correspondents : [];
-      const signals = (signalsData && Array.isArray(signalsData.signals)) ? signalsData.signals : [];
-
-      // Partition signals by beat slug
-      const signalsByBeat = {};
-      for (const s of signals) {
-        const slug = s.beatSlug || (s.beat || '').toLowerCase().replace(/\s+/g, '-');
-        if (!signalsByBeat[slug]) signalsByBeat[slug] = [];
-        signalsByBeat[slug].push(s);
-      }
 
       // Subtitle
       document.getElementById('bureau-updated').textContent = 'Updated just now';
 
-      renderBeatCards(activeBeats, signalsByBeat, correspondents);
+      // Render cards immediately with "—" placeholders for counts. Numbers
+      // fill in below as each per-beat /api/signals/counts response lands —
+      // no need to block the whole page on the slowest count call. Cards
+      // for retired/inactive beats render with their final numbers because
+      // we don't query counts for them.
+      renderBeatCards(activeBeats, {}, correspondents);
+
+      // Per-beat counts via /api/signals/counts (purpose-built, not row-capped).
+      // Two calls per active beat — week-window total + today-window approved
+      // (approved + brief_included). Fired in parallel; each beat's counts
+      // patch into its already-rendered card the moment they arrive instead
+      // of all cards waiting on the slowest beat.
+      activeBeats.forEach(async (b) => {
+        const [weekCounts, todayCounts] = await Promise.all([
+          fetchJSON('/api/signals/counts?beat=' + encodeURIComponent(b.slug) + '&since=' + encodeURIComponent(sevenDaysAgo)),
+          fetchJSON('/api/signals/counts?beat=' + encodeURIComponent(b.slug) + '&since=' + encodeURIComponent(todayUtcMidnight)),
+        ]);
+        // Only patch if both responses succeeded — if either fetch returned
+        // null (network error), leave the "—" placeholder in place rather
+        // than misleading the user with a partial 0.
+        if (!weekCounts || !todayCounts) return;
+        fillBeatCardCounts(b.slug, {
+          week: weekCounts.total || 0,
+          approvedToday: (todayCounts.approved || 0) + (todayCounts.brief_included || 0),
+        });
+      });
 
       // Render roster BEFORE chips so chip counts can read data-role from rows
       const beatsBySlug = {};

--- a/src/routes/init.ts
+++ b/src/routes/init.ts
@@ -16,8 +16,28 @@ import { BRIEF_PRICE_SATS } from "../lib/constants";
 
 const initRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>();
 
-// GET /api/init — all initial page load data in one response
+// GET /api/init — all initial page load data in one response.
+//
+// Wrapped in the Workers edge cache so subsequent visits (anywhere globally)
+// get served from the nearest Cloudflare PoP in <100ms instead of paying
+// the ~3s DO round-trip + heavy SQL pass we observed in production. Workers
+// responses bypass the edge cache by default — the `Cache-Control` header
+// alone isn't enough; you have to put the response into `caches.default`
+// explicitly. TTL is governed by the Cache-Control header below; the cache
+// key is the canonical request URL.
 initRouter.get("/api/init", async (c) => {
+  const cache = caches.default;
+  const cacheKey = new Request(new URL(c.req.url).toString(), { method: "GET" });
+
+  const cached = await cache.match(cacheKey);
+  if (cached) {
+    // Edge HIT — serve straight from cache, skipping all DO work below.
+    // Add a debug header so we can confirm in DevTools that caching is live.
+    const hit = new Response(cached.body, cached);
+    hit.headers.set("X-Edge-Cache", "HIT");
+    return hit;
+  }
+
   const bundle = await getInitBundle(c.env);
   const today = getUTCDate();
 
@@ -163,13 +183,23 @@ initRouter.get("/api/init", async (c) => {
   };
 
   c.header("Cache-Control", "public, max-age=60, s-maxage=300");
-  return c.json({
+  c.header("X-Edge-Cache", "MISS");
+  const response = c.json({
     brief: briefPayload,
     beats: beatsPayload,
     classifieds: classifiedsPayload,
     correspondents: correspondentsPayload,
     signals: signalsPayload,
   });
+
+  // Store the response at the edge for s-maxage seconds. waitUntil lets the
+  // put complete after we've already returned to the user — the first request
+  // still pays the DO round-trip, but every subsequent request within the
+  // 5-min s-maxage window gets the HIT path above. Clone is required because
+  // Response bodies are single-read streams.
+  c.executionCtx.waitUntil(cache.put(cacheKey, response.clone()));
+
+  return response;
 });
 
 export { initRouter };


### PR DESCRIPTION
## Why

User report: homepage still feels slow even after the prior perf PRs. Live measurement against \`aibtc.news\` shows the bottleneck is \`/api/init\` TTFB:

\`\`\`
$ curl -sI https://aibtc.news/api/init | grep -iE 'cache|cf-'
cache-control: public, max-age=60, s-maxage=300
cf-placement: remote-ARN
cf-ray: 9f02bb1c9dcaca11-KTM
# ← no cf-cache-status header
\`\`\`

\`\`\`
=== /api/init (3 consecutive runs) ===
ttfb=2.96s total=4.02s size=779421
ttfb=3.32s total=4.33s size=779421
ttfb=3.59s total=4.53s size=779421
\`\`\`

The \`Cache-Control: public, max-age=60, s-maxage=300\` header was set but **silently ignored at the edge**. Workers responses don't go through Cloudflare's edge cache by default — you have to explicitly use \`caches.default.put()\`. So every visit (including same-tab nav after the 60s sessionStorage TTL expires) hit the DO and paid 3+ seconds for the heavy SQL pass on every single request.

## What

Wrap \`/api/init\` in a \`caches.default\` match → put pattern in \`src/routes/init.ts\`:

\`\`\`ts
const cached = await cache.match(cacheKey);
if (cached) {
  // Edge HIT — skip the DO round-trip entirely
  return cached;
}

// ... existing handler ...

const response = c.json({...});
c.executionCtx.waitUntil(cache.put(cacheKey, response.clone()));
return response;
\`\`\`

- First request in each 5-minute \`s-maxage\` window still pays the DO round-trip and stores the response at the Cloudflare edge.
- Every subsequent request anywhere globally serves from edge in <100ms without touching the DO at all.
- Cached response keeps the same \`Cache-Control\` headers, so browser-side \`max-age=60\` still throttles client polling.
- \`waitUntil\` on the put means the slow path returns immediately to the user; the cache write happens after.

## Observability

Adds an \`X-Edge-Cache: HIT|MISS\` response header so the cache state is visible in DevTools without needing CF dashboard access:

\`\`\`
First request:    X-Edge-Cache: MISS  (3s, DO hit)
Next 5 minutes:   X-Edge-Cache: HIT   (<100ms, edge cache)
After 5 minutes:  X-Edge-Cache: MISS  (refresh)
\`\`\`

## What this doesn't address (separate follow-up)

- The cached payload is still ~127 KB compressed (~779 KB raw). Trimming the \`beats[].members\` arrays (316 KB) and capping \`correspondents\` to top N (369 KB) would compound the win for both DO compute time AND cached payload size. Flag separately.
- Cache invalidation is purely TTL-based (5 min). If a brief gets compiled or a beat changes status, users may see stale data for up to 5 minutes. Acceptable given the data model — briefs compile daily, beats rarely change.

## Test plan

- [ ] Visual on preview deploy: load homepage twice within 5 min, confirm second load's \`/api/init\` request shows \`X-Edge-Cache: HIT\` and TTFB <100ms in DevTools.
- [ ] First load after deploy still works (MISS path).
- [ ] After 5+ minutes, confirm next load shows MISS again (cache refreshed).