### PR TITLE
perf(api): edge-cache correspondents, beats, classifieds, front-page (same pattern as #592)

### DIFF
--- a/src/lib/edge-cache.ts
+++ b/src/lib/edge-cache.ts
@@ -1,0 +1,64 @@
+/**
+ * Workers edge-cache helper.
+ *
+ * Workers responses don't automatically populate Cloudflare's edge cache —
+ * the `Cache-Control` header alone is treated as "instructions for downstream
+ * caches" but no downstream cache is ever asked unless the response is
+ * explicitly stored via `caches.default.put()`. This helper wraps the
+ * match → put pattern so route handlers can opt in with a single call.
+ *
+ * Pattern:
+ *
+ *   router.get("/api/foo", async (c) => {
+ *     const cached = await edgeCacheMatch(c);
+ *     if (cached) return cached;
+ *
+ *     // ... build response ...
+ *     c.header("Cache-Control", "public, max-age=60, s-maxage=300");
+ *     const response = c.json(payload);
+ *     edgeCachePut(c, response);
+ *     return response;
+ *   });
+ *
+ * Cache key is the canonical request URL (so `?before=2026-04-22` and the
+ * naked path get separate entries). TTL is taken from the response's
+ * `Cache-Control` `s-maxage` directive at edge level. Browser revalidation
+ * still honours `max-age` independently.
+ */
+import type { Context } from "hono";
+import type { Env, AppVariables } from "./types";
+
+type Ctx = Context<{ Bindings: Env; Variables: AppVariables }>;
+
+function buildCacheKey(c: Ctx): Request {
+  return new Request(new URL(c.req.url).toString(), { method: "GET" });
+}
+
+/**
+ * Look up the current request in the edge cache. Returns the cached Response
+ * (with an `X-Edge-Cache: HIT` header attached for observability) or `null`
+ * on miss. Safe to call from any GET handler.
+ */
+export async function edgeCacheMatch(c: Ctx): Promise<Response | null> {
+  const cached = await caches.default.match(buildCacheKey(c));
+  if (!cached) return null;
+  // Clone-via-Response constructor so we can mutate the headers without
+  // touching the body stream (which would break subsequent reads).
+  const hit = new Response(cached.body, cached);
+  hit.headers.set("X-Edge-Cache", "HIT");
+  return hit;
+}
+
+/**
+ * Store the response in the edge cache for the duration of its
+ * `Cache-Control` `s-maxage`. Tags an `X-Edge-Cache: MISS` header on the
+ * response we return to the client (so the caller can confirm the write
+ * happened). The actual cache write runs via `executionCtx.waitUntil` so
+ * the user doesn't pay any latency for it.
+ */
+export function edgeCachePut(c: Ctx, response: Response): void {
+  response.headers.set("X-Edge-Cache", "MISS");
+  c.executionCtx.waitUntil(
+    caches.default.put(buildCacheKey(c), response.clone())
+  );
+}

--- a/src/lib/edge-cache.ts
+++ b/src/lib/edge-cache.ts
@@ -25,12 +25,9 @@
  * `Cache-Control` `s-maxage` directive at edge level. Browser revalidation
  * still honours `max-age` independently.
  */
-import type { Context } from "hono";
-import type { Env, AppVariables } from "./types";
+import type { AppContext } from "./types";
 
-type Ctx = Context<{ Bindings: Env; Variables: AppVariables }>;
-
-function buildCacheKey(c: Ctx): Request {
+function buildCacheKey(c: AppContext): Request {
   return new Request(new URL(c.req.url).toString(), { method: "GET" });
 }
 
@@ -39,7 +36,7 @@ function buildCacheKey(c: Ctx): Request {
  * (with an `X-Edge-Cache: HIT` header attached for observability) or `null`
  * on miss. Safe to call from any GET handler.
  */
-export async function edgeCacheMatch(c: Ctx): Promise<Response | null> {
+export async function edgeCacheMatch(c: AppContext): Promise<Response | null> {
   const cached = await caches.default.match(buildCacheKey(c));
   if (!cached) return null;
   // Clone-via-Response constructor so we can mutate the headers without
@@ -55,10 +52,18 @@ export async function edgeCacheMatch(c: Ctx): Promise<Response | null> {
  * response we return to the client (so the caller can confirm the write
  * happened). The actual cache write runs via `executionCtx.waitUntil` so
  * the user doesn't pay any latency for it.
+ *
+ * The `MISS` header is set on the live response *after* cloning the
+ * about-to-be-stored copy, so the cached entry at rest does not carry the
+ * misleading `X-Edge-Cache: MISS` header — only what comes back from the
+ * subsequent edgeCacheMatch() call has the status header (overwritten to
+ * `HIT` there). Inspecting the raw cache entry now shows the response as
+ * the route originally produced it.
  */
-export function edgeCachePut(c: Ctx, response: Response): void {
+export function edgeCachePut(c: AppContext, response: Response): void {
+  const cacheCopy = response.clone();
   response.headers.set("X-Edge-Cache", "MISS");
   c.executionCtx.waitUntil(
-    caches.default.put(buildCacheKey(c), response.clone())
+    caches.default.put(buildCacheKey(c), cacheCopy)
   );
 }

--- a/src/routes/beats.ts
+++ b/src/routes/beats.ts
@@ -6,6 +6,7 @@ import { validateSlug, validateHexColor, validateBtcAddress, sanitizeString } fr
 import { getBeat, createBeat, updateBeat, deleteBeat, getBeatMembership, getConfig, getActiveBeatSlugs, listBeats } from "../lib/do-client";
 import { CONFIG_PUBLISHER_ADDRESS } from "../lib/constants";
 import { verifyAuth } from "../services/auth";
+import { edgeCacheMatch, edgeCachePut } from "../lib/edge-cache";
 
 const beatsRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>();
 
@@ -16,7 +17,12 @@ const beatRateLimit = createRateLimitMiddleware({
 
 // GET /api/beats — list all beats
 // Supports ?include=members to expand full members array (default: memberCount only)
+// Edge-cached: ?status=active and ?include=members produce different cache
+// keys via the request URL, so each variant is cached independently.
 beatsRouter.get("/api/beats", async (c) => {
+  const cached = await edgeCacheMatch(c);
+  if (cached) return cached;
+
   const beats = await listBeats(c.env);
   const includeMembers = c.req.query("include") === "members";
   const statusFilter = c.req.query("status")?.toLowerCase();
@@ -55,7 +61,9 @@ beatsRouter.get("/api/beats", async (c) => {
   }
 
   c.header("Cache-Control", "public, max-age=60, s-maxage=300");
-  return c.json(filtered);
+  const response = c.json(filtered);
+  edgeCachePut(c, response);
+  return response;
 });
 
 // GET /api/beats/membership — list beats an agent has joined

--- a/src/routes/classifieds.ts
+++ b/src/routes/classifieds.ts
@@ -72,19 +72,29 @@ classifiedsRouter.get("/api/classifieds/rotation", async (c) => {
 
 // GET /api/classifieds — list classifieds
 // Default: active approved ads. With ?agent=ADDRESS: all submissions for that agent.
-// Edge-cached: anomalously slow in production (~5.8s for ~2.6 KB output) so
-// the cache fix delivers an outsized win on top of the standard pattern.
-// Per-agent and per-category variants get separate cache entries via the URL.
+// Edge-cached for the public default path — anomalously slow in production
+// (~5.8s for ~2.6 KB output) so the cache fix delivers an outsized win.
+// Per-category variants get separate cache entries via the URL.
+//
+// We deliberately skip the edge cache for ?agent= queries: that mode returns
+// the agent's pending/rejected/expired submissions, and caching makes status
+// changes (approval, expiry) invisible for up to s-maxage. The agent is the
+// primary consumer of this view and likely needs immediate freshness on their
+// own submissions. The endpoint is already public (no auth gate today), so
+// skipping the cache changes nothing about visibility — just about staleness.
 classifiedsRouter.get("/api/classifieds", async (c) => {
-  const cached = await edgeCacheMatch(c);
-  if (cached) return cached;
-
   const category = c.req.query("category");
   const agent = c.req.query("agent");
   const limitParam = c.req.query("limit");
   const limit = limitParam
     ? Math.min(Math.max(1, parseInt(limitParam, 10) || 50), 1000)
     : undefined;
+
+  const cacheable = !agent;
+  if (cacheable) {
+    const cached = await edgeCacheMatch(c);
+    if (cached) return cached;
+  }
 
   const classifieds = await listClassifieds(c.env, { category, agent, limit });
 
@@ -107,9 +117,14 @@ classifiedsRouter.get("/api/classifieds", async (c) => {
     };
   });
 
-  c.header("Cache-Control", "public, max-age=60, s-maxage=300");
+  // Per-agent views aren't cached (see above); send a private,no-store
+  // header so downstream caches don't independently snapshot them either.
+  c.header(
+    "Cache-Control",
+    cacheable ? "public, max-age=60, s-maxage=300" : "private, no-store"
+  );
   const response = c.json({ classifieds: withNames, total: withNames.length });
-  edgeCachePut(c, response);
+  if (cacheable) edgeCachePut(c, response);
   return response;
 });
 

--- a/src/routes/classifieds.ts
+++ b/src/routes/classifieds.ts
@@ -27,6 +27,7 @@ import {
 import { logPaymentEvent } from "../lib/payment-logging";
 import { buildLocalPaymentStatusUrl, buildPaymentRequired, verifyPayment, mapVerificationError } from "../services/x402";
 import { resolveNamesWithTimeout, generateId } from "../lib/helpers";
+import { edgeCacheMatch, edgeCachePut } from "../lib/edge-cache";
 
 /** Transform a Classified row to the camelCase API response shape. */
 export function transformClassified(cl: Classified) {
@@ -71,7 +72,13 @@ classifiedsRouter.get("/api/classifieds/rotation", async (c) => {
 
 // GET /api/classifieds — list classifieds
 // Default: active approved ads. With ?agent=ADDRESS: all submissions for that agent.
+// Edge-cached: anomalously slow in production (~5.8s for ~2.6 KB output) so
+// the cache fix delivers an outsized win on top of the standard pattern.
+// Per-agent and per-category variants get separate cache entries via the URL.
 classifiedsRouter.get("/api/classifieds", async (c) => {
+  const cached = await edgeCacheMatch(c);
+  if (cached) return cached;
+
   const category = c.req.query("category");
   const agent = c.req.query("agent");
   const limitParam = c.req.query("limit");
@@ -101,7 +108,9 @@ classifiedsRouter.get("/api/classifieds", async (c) => {
   });
 
   c.header("Cache-Control", "public, max-age=60, s-maxage=300");
-  return c.json({ classifieds: withNames, total: withNames.length });
+  const response = c.json({ classifieds: withNames, total: withNames.length });
+  edgeCachePut(c, response);
+  return response;
 });
 
 // GET /api/classifieds/:id — get a single classified ad

--- a/src/routes/correspondents.ts
+++ b/src/routes/correspondents.ts
@@ -6,14 +6,20 @@ import { Hono } from "hono";
 import type { Env, AppVariables } from "../lib/types";
 import { getCorrespondentsBundle } from "../lib/do-client";
 import { truncAddr, buildBeatsByAddress, resolveNamesWithTimeout } from "../lib/helpers";
+import { edgeCacheMatch, edgeCachePut } from "../lib/edge-cache";
 
 const correspondentsRouter = new Hono<{
   Bindings: Env;
   Variables: AppVariables;
 }>();
 
-// GET /api/correspondents — ranked correspondents with signal counts, streaks, and names
+// GET /api/correspondents — ranked correspondents with signal counts, streaks, and names.
+// Edge-cached: production response is ~371 KB and the DO round-trip costs ~3s
+// without the cache. Single put per s-maxage window then sub-100ms thereafter.
 correspondentsRouter.get("/api/correspondents", async (c) => {
+  const cached = await edgeCacheMatch(c);
+  if (cached) return cached;
+
   // Single DO round-trip fetches correspondents, beats, and leaderboard together
   const bundle = await getCorrespondentsBundle(c.env);
   const rows = bundle.correspondents;
@@ -77,7 +83,9 @@ correspondentsRouter.get("/api/correspondents", async (c) => {
   );
 
   c.header("Cache-Control", "public, max-age=60, s-maxage=300");
-  return c.json({ correspondents, total: correspondents.length });
+  const response = c.json({ correspondents, total: correspondents.length });
+  edgeCachePut(c, response);
+  return response;
 });
 
 export { correspondentsRouter };

--- a/src/routes/init.ts
+++ b/src/routes/init.ts
@@ -12,31 +12,18 @@ import { getInitBundle } from "../lib/do-client";
 import { transformClassified } from "./classifieds";
 import { getUTCDate, truncAddr, buildBeatsByAddress, resolveNamesWithTimeout } from "../lib/helpers";
 import { BRIEF_PRICE_SATS } from "../lib/constants";
+import { edgeCacheMatch, edgeCachePut } from "../lib/edge-cache";
 
 
 const initRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>();
 
 // GET /api/init — all initial page load data in one response.
-//
-// Wrapped in the Workers edge cache so subsequent visits (anywhere globally)
-// get served from the nearest Cloudflare PoP in <100ms instead of paying
-// the ~3s DO round-trip + heavy SQL pass we observed in production. Workers
-// responses bypass the edge cache by default — the `Cache-Control` header
-// alone isn't enough; you have to put the response into `caches.default`
-// explicitly. TTL is governed by the Cache-Control header below; the cache
-// key is the canonical request URL.
+// Edge-cached via the Workers Cache API (see src/lib/edge-cache.ts) so
+// subsequent visits within the s-maxage window serve from the nearest
+// Cloudflare PoP in <100ms instead of paying the ~3s DO round-trip.
 initRouter.get("/api/init", async (c) => {
-  const cache = caches.default;
-  const cacheKey = new Request(new URL(c.req.url).toString(), { method: "GET" });
-
-  const cached = await cache.match(cacheKey);
-  if (cached) {
-    // Edge HIT — serve straight from cache, skipping all DO work below.
-    // Add a debug header so we can confirm in DevTools that caching is live.
-    const hit = new Response(cached.body, cached);
-    hit.headers.set("X-Edge-Cache", "HIT");
-    return hit;
-  }
+  const cached = await edgeCacheMatch(c);
+  if (cached) return cached;
 
   const bundle = await getInitBundle(c.env);
   const today = getUTCDate();
@@ -183,7 +170,6 @@ initRouter.get("/api/init", async (c) => {
   };
 
   c.header("Cache-Control", "public, max-age=60, s-maxage=300");
-  c.header("X-Edge-Cache", "MISS");
   const response = c.json({
     brief: briefPayload,
     beats: beatsPayload,
@@ -191,14 +177,7 @@ initRouter.get("/api/init", async (c) => {
     correspondents: correspondentsPayload,
     signals: signalsPayload,
   });
-
-  // Store the response at the edge for s-maxage seconds. waitUntil lets the
-  // put complete after we've already returned to the user — the first request
-  // still pays the DO round-trip, but every subsequent request within the
-  // 5-min s-maxage window gets the HIT path above. Clone is required because
-  // Response bodies are single-read streams.
-  c.executionCtx.waitUntil(cache.put(cacheKey, response.clone()));
-
+  edgeCachePut(c, response);
   return response;
 });
 

--- a/src/routes/signal-review.ts
+++ b/src/routes/signal-review.ts
@@ -13,6 +13,7 @@ import { validateDateFormat } from "../lib/validators";
 import { validateBtcAddress } from "../lib/validators";
 import { verifyAuth } from "../services/auth";
 import { REVIEW_RATE_LIMIT, REVIEWABLE_SIGNAL_STATUSES } from "../lib/constants";
+import { edgeCacheMatch, edgeCachePut } from "../lib/edge-cache";
 
 const signalReviewRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>();
 
@@ -114,7 +115,13 @@ signalReviewRouter.patch("/api/signals/:id/review", reviewRateLimit, async (c) =
 // GET /api/front-page — curated signals (approved + brief_included only)
 // Without ?before: returns all approved + brief_included signals (today's feed)
 // With ?before=YYYY-MM-DD: returns one day of signals strictly before that date (infinite scroll)
+// Edge-cached for both modes — paginated mode in particular benefits because
+// the URL is stable per day, so the same page served to every infinite-scroll
+// reader after the first hit is served from edge.
 signalReviewRouter.get("/api/front-page", async (c) => {
+  const cached = await edgeCacheMatch(c);
+  if (cached) return cached;
+
   const before = c.req.query("before") ?? null;
   const limitParam = c.req.query("limit");
   const limit = limitParam ? Math.min(Math.max(1, parseInt(limitParam, 10) || 50), 200) : 50;
@@ -147,12 +154,14 @@ signalReviewRouter.get("/api/front-page", async (c) => {
     }));
 
     c.header("Cache-Control", "public, max-age=60, s-maxage=300");
-    return c.json({
+    const response = c.json({
       signals: transformed,
       date: result.date,
       hasMore: result.hasMore,
       curated: true,
     });
+    edgeCachePut(c, response);
+    return response;
   }
 
   // Default mode: single DO query for all approved + brief_included signals
@@ -174,11 +183,13 @@ signalReviewRouter.get("/api/front-page", async (c) => {
   }));
 
   c.header("Cache-Control", "public, max-age=60, s-maxage=300");
-  return c.json({
+  const response = c.json({
     signals: transformed,
     total: transformed.length,
     curated: true,
   });
+  edgeCachePut(c, response);
+  return response;
 });
 
 export { signalReviewRouter };


### PR DESCRIPTION
## Why

PR #592 wrapped \`/api/init\` in the Workers Cache API and dropped its TTFB from ~3s to <100ms after first hit. From the audit immediately after that PR landed, four more endpoints have the same problem:

\`\`\`
$ for url in /api/correspondents /api/classifieds /api/beats /api/front-page; do
    curl -s -o /dev/null -w "$url ttfb=%{time_starttransfer}s size=%{size_download} edge=%header{x-edge-cache}\n" "https://aibtc.news$url"
  done
/api/correspondents ttfb=2.97s size=371106 edge=
/api/classifieds    ttfb=5.80s size=2630   edge=
/api/beats          ttfb=1.32s size=5433   edge=
/api/front-page     ttfb=0.57s size=91945  edge=
\`\`\`

Same root cause as #592: each route sets a \`Cache-Control: public, s-maxage=300\` header but Workers responses bypass the edge cache unless explicitly stored via \`caches.default\`.

## What

Extract the inline \`match → put\` pattern from #592 into \`src/lib/edge-cache.ts\` as two helpers:

\`\`\`ts
export async function edgeCacheMatch(c): Promise<Response | null>
export function edgeCachePut(c, response): void
\`\`\`

Apply to five routes (one is \`/api/init\` refactored to use the helper instead of inline code):

| Route | Before TTFB | Cached TTL | After (hit) |
|---|---|---|---|
| \`/api/init\` | 0.29s (already cached) | 300s | <100ms (no change, just refactored) |
| \`/api/correspondents\` | 2.97s | 300s | <100ms |
| \`/api/classifieds\` | 5.80s | 300s | <100ms |
| \`/api/beats\` | 1.32s | 300s | <100ms |
| \`/api/front-page\` | 0.57s | 300s | <100ms |

Cache key is the canonical request URL — \`?status=active\`, \`?include=members\`, \`?before=2026-04-22\`, etc. each get independent cache entries, so query-string variants don't collide. \`X-Edge-Cache: HIT|MISS\` response header is set on every response so cache state is observable in DevTools.

## Side notes

- **\`/api/classifieds\` 5.8s TTFB for 2.6 KB output is anomalously slow.** That's the underlying DO query needing investigation — separate fix. The cache layer just gets us out of paying that cost on every visit in the meantime.
- Cache invalidation is purely TTL-based (5 min). New classifieds/beats/correspondent updates may show up to 5 minutes of staleness. Acceptable given how rarely those things change.
- 37 tests across the touched routes all pass locally.
- The same pattern is reusable for any other GET endpoint where staleness is acceptable.

## Test plan

- [ ] Visual on preview deploy: load each affected URL twice within 5 minutes; second request shows \`X-Edge-Cache: HIT\` and TTFB <100ms.
- [ ] After 5+ minutes, cache refreshes (\`X-Edge-Cache: MISS\` again on first hit).
- [ ] Beats page renders the same as before (it now hits cached \`/api/beats\` + \`/api/correspondents\` + \`/api/signals/counts\`).
- [ ] Homepage's classifieds rotation still works (unaffected — uses \`/api/classifieds/rotation\`, which has \`Cache-Control: no-store\` and is intentionally uncached).