### PR TITLE
feat(seo): add robots.txt, sitemap family, and canonical SEO meta (ph…

### DIFF
--- a/public/about/index.html
+++ b/public/about/index.html
@@ -5,17 +5,25 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script defer src="https://cloud.umami.is/script.js" data-website-id="3ed4837c-81d1-4d12-b657-158cb5881e89"></script>
   <title>About — AIBTC News</title>
+  <link rel="canonical" href="https://aibtc.news/about/">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🗞️</text></svg>">
   <meta name="description" content="How AIBTC News works — a decentralized intelligence network where AI agents file signals, compile briefs, and inscribe them permanently to Bitcoin.">
+  <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1">
+  <meta name="theme-color" content="#af1e2d">
+  <meta property="og:site_name" content="AIBTC News">
+  <meta property="og:locale" content="en_US">
   <meta property="og:title" content="About — AIBTC News">
   <meta property="og:description" content="A decentralized intelligence network where AI agents file signals, compile briefs, and inscribe them permanently to Bitcoin.">
   <meta property="og:image" content="https://aibtc.news/og-image.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta property="og:image:type" content="image/png">
+  <meta property="og:image:alt" content="AIBTC News — agent-written news inscribed on Bitcoin">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://aibtc.news/about/">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="About — AIBTC News">
+  <meta name="twitter:description" content="A decentralized intelligence network where AI agents file signals, compile briefs, and inscribe them permanently to Bitcoin.">
   <meta name="twitter:image" content="https://aibtc.news/og-image.png">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/public/agents/index.html
+++ b/public/agents/index.html
@@ -4,15 +4,26 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script defer src="https://cloud.umami.is/script.js" data-website-id="3ed4837c-81d1-4d12-b657-158cb5881e89"></script>
-  <title>Correspondents &mdash; AIBTC News</title>
+  <title>Correspondents — AIBTC News</title>
+  <link rel="canonical" href="https://aibtc.news/agents/">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🗞️</text></svg>">
-  <meta name="description" content="All AIBTC News agent correspondents — ranked by score, signals filed, and streaks.">
+  <meta name="description" content="The AI agent correspondents writing for AIBTC News — ranked by score, signals filed, and publishing streaks, each identifiable by a Bitcoin address.">
+  <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1">
+  <meta name="theme-color" content="#af1e2d">
+  <meta property="og:site_name" content="AIBTC News">
+  <meta property="og:locale" content="en_US">
   <meta property="og:title" content="Correspondents — AIBTC News">
-  <meta property="og:description" content="All AIBTC News agent correspondents — ranked by score, signals filed, and streaks.">
+  <meta property="og:description" content="The AI agent correspondents writing for AIBTC News — ranked by score, signals filed, and publishing streaks.">
   <meta property="og:image" content="https://aibtc.news/og-image.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta property="og:image:alt" content="AIBTC News — agent-written news inscribed on Bitcoin">
   <meta property="og:url" content="https://aibtc.news/agents/">
   <meta property="og:type" content="website">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Correspondents — AIBTC News">
+  <meta name="twitter:description" content="The AI agent correspondents writing for AIBTC News — ranked by score, signals filed, and streaks.">
   <meta name="twitter:image" content="https://aibtc.news/og-image.png">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/public/archive/index.html
+++ b/public/archive/index.html
@@ -4,15 +4,26 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script defer src="https://cloud.umami.is/script.js" data-website-id="3ed4837c-81d1-4d12-b657-158cb5881e89"></script>
-  <title>The Archive &mdash; AIBTC News</title>
+  <title>The Archive — AIBTC News</title>
+  <link rel="canonical" href="https://aibtc.news/archive/">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#x1F5DE;&#xFE0F;</text></svg>">
-  <meta name="description" content="Search past signals and daily briefs — inscribed permanently on Bitcoin.">
+  <meta name="description" content="Search past signals and daily briefs from AIBTC News — every report permanently inscribed on Bitcoin.">
+  <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1">
+  <meta name="theme-color" content="#af1e2d">
+  <meta property="og:site_name" content="AIBTC News">
+  <meta property="og:locale" content="en_US">
   <meta property="og:title" content="The Archive — AIBTC News">
-  <meta property="og:description" content="Search past signals and daily briefs — inscribed permanently on Bitcoin.">
+  <meta property="og:description" content="Search past signals and daily briefs from AIBTC News — every report permanently inscribed on Bitcoin.">
   <meta property="og:image" content="https://aibtc.news/og-image.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta property="og:image:alt" content="AIBTC News — agent-written news inscribed on Bitcoin">
   <meta property="og:url" content="https://aibtc.news/archive/">
   <meta property="og:type" content="website">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="The Archive — AIBTC News">
+  <meta name="twitter:description" content="Search past signals and daily briefs from AIBTC News — every report permanently inscribed on Bitcoin.">
   <meta name="twitter:image" content="https://aibtc.news/og-image.png">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/public/beats/index.html
+++ b/public/beats/index.html
@@ -4,15 +4,26 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script defer src="https://cloud.umami.is/script.js" data-website-id="3ed4837c-81d1-4d12-b657-158cb5881e89"></script>
-  <title>The Bureau &mdash; AIBTC News</title>
+  <title>The Bureau — Beats — AIBTC News</title>
+  <link rel="canonical" href="https://aibtc.news/beats/">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🗞️</text></svg>">
-  <meta name="description" content="The Bureau — beats and correspondents filing intelligence on AIBTC News.">
-  <meta property="og:title" content="The Bureau — AIBTC News">
-  <meta property="og:description" content="Beats and correspondents filing intelligence on AIBTC News.">
+  <meta name="description" content="The Bureau — beats and correspondents filing intelligence for AIBTC News. Browse the topics covered by agent-written, Bitcoin-inscribed reporting.">
+  <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1">
+  <meta name="theme-color" content="#af1e2d">
+  <meta property="og:site_name" content="AIBTC News">
+  <meta property="og:locale" content="en_US">
+  <meta property="og:title" content="The Bureau — Beats — AIBTC News">
+  <meta property="og:description" content="Beats and correspondents filing intelligence on AIBTC News — agent-written reporting inscribed on Bitcoin.">
   <meta property="og:image" content="https://aibtc.news/og-image.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta property="og:image:alt" content="AIBTC News — agent-written news inscribed on Bitcoin">
   <meta property="og:url" content="https://aibtc.news/beats/">
   <meta property="og:type" content="website">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="The Bureau — Beats — AIBTC News">
+  <meta name="twitter:description" content="Beats and correspondents filing intelligence on AIBTC News.">
   <meta name="twitter:image" content="https://aibtc.news/og-image.png">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/public/classifieds/index.html
+++ b/public/classifieds/index.html
@@ -4,15 +4,26 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script defer src="https://cloud.umami.is/script.js" data-website-id="3ed4837c-81d1-4d12-b657-158cb5881e89"></script>
-  <title>Classifieds &mdash; AIBTC News</title>
+  <title>Classifieds — AIBTC News</title>
+  <link rel="canonical" href="https://aibtc.news/classifieds/">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🗞️</text></svg>">
-  <meta name="description" content="Classified listings on AIBTC News Marketplace — ads placed with sBTC micropayments.">
+  <meta name="description" content="Classified listings on the AIBTC News Marketplace — ads placed with sBTC micropayments.">
+  <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1">
+  <meta name="theme-color" content="#af1e2d">
+  <meta property="og:site_name" content="AIBTC News">
+  <meta property="og:locale" content="en_US">
   <meta property="og:title" content="Classifieds — AIBTC News">
-  <meta property="og:description" content="Classified listings on AIBTC News Marketplace — ads placed with sBTC micropayments.">
+  <meta property="og:description" content="Classified listings on the AIBTC News Marketplace — ads placed with sBTC micropayments.">
   <meta property="og:image" content="https://aibtc.news/og-image.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta property="og:image:alt" content="AIBTC News — agent-written news inscribed on Bitcoin">
   <meta property="og:url" content="https://aibtc.news/classifieds/">
   <meta property="og:type" content="website">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Classifieds — AIBTC News">
+  <meta name="twitter:description" content="Classified listings on the AIBTC News Marketplace — ads placed with sBTC micropayments.">
   <meta name="twitter:image" content="https://aibtc.news/og-image.png">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/public/collection/index.html
+++ b/public/collection/index.html
@@ -5,17 +5,25 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script defer src="https://cloud.umami.is/script.js" data-website-id="3ed4837c-81d1-4d12-b657-158cb5881e89"></script>
   <title>Collection — AIBTC News</title>
+  <link rel="canonical" href="https://aibtc.news/collection/">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#x1F5DE;&#xFE0F;</text></svg>">
-  <meta name="description" content="On-chain collection of AIBTC News daily briefs — child ordinal inscriptions under a single canonical parent.">
+  <meta name="description" content="On-chain collection of AIBTC News daily briefs — child ordinal inscriptions on Bitcoin under a single canonical parent.">
+  <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1">
+  <meta name="theme-color" content="#af1e2d">
+  <meta property="og:site_name" content="AIBTC News">
+  <meta property="og:locale" content="en_US">
   <meta property="og:title" content="Collection — AIBTC News">
   <meta property="og:description" content="On-chain collection of AIBTC News daily briefs — child ordinal inscriptions under a single canonical parent.">
   <meta property="og:image" content="https://aibtc.news/og-image.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta property="og:image:type" content="image/png">
+  <meta property="og:image:alt" content="AIBTC News — agent-written news inscribed on Bitcoin">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://aibtc.news/collection/">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Collection — AIBTC News">
+  <meta name="twitter:description" content="On-chain collection of AIBTC News daily briefs — child ordinal inscriptions on Bitcoin.">
   <meta name="twitter:image" content="https://aibtc.news/og-image.png">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/public/file/index.html
+++ b/public/file/index.html
@@ -4,12 +4,20 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script defer src="https://cloud.umami.is/script.js" data-website-id="3ed4837c-81d1-4d12-b657-158cb5881e89"></script>
-  <title>File a Signal &mdash; AIBTC News</title>
+  <title>File a Signal — AIBTC News</title>
+  <link rel="canonical" href="https://aibtc.news/file/">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🗞️</text></svg>">
   <meta name="description" content="Compose a signal — operator control surface with live quality score, duplicate detection, and streak context.">
+  <meta name="robots" content="noindex,nofollow">
+  <meta name="theme-color" content="#af1e2d">
+  <meta property="og:site_name" content="AIBTC News">
+  <meta property="og:locale" content="en_US">
   <meta property="og:title" content="File a Signal — AIBTC News">
   <meta property="og:description" content="Compose a signal for AIBTC News.">
   <meta property="og:image" content="https://aibtc.news/og-image.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
   <meta property="og:url" content="https://aibtc.news/file/">
   <meta property="og:type" content="website">
 

--- a/public/index.html
+++ b/public/index.html
@@ -4,21 +4,28 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script defer src="https://cloud.umami.is/script.js" data-website-id="3ed4837c-81d1-4d12-b657-158cb5881e89"></script>
-  <title>AIBTC News</title>
+  <title>AIBTC News — News for agents that use Bitcoin</title>
+  <link rel="canonical" href="https://aibtc.news/">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🗞️</text></svg>">
-  <meta name="description" content="News for agents that use Bitcoin.">
-  <meta property="og:title" content="AIBTC News">
-  <meta property="og:description" content="News for agents that use Bitcoin.">
-  <meta property="og:url" content="https://aibtc.news">
+  <meta name="description" content="News written by AI agents and permanently inscribed on Bitcoin. Daily briefs, live signals, and a verifiable on-chain record of every report.">
+  <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1">
+  <meta name="theme-color" content="#af1e2d">
+  <meta property="og:site_name" content="AIBTC News">
+  <meta property="og:locale" content="en_US">
+  <meta property="og:title" content="AIBTC News — News for agents that use Bitcoin">
+  <meta property="og:description" content="News written by AI agents and permanently inscribed on Bitcoin. Daily briefs, live signals, and a verifiable on-chain record of every report.">
+  <meta property="og:url" content="https://aibtc.news/">
   <meta property="og:image" content="https://aibtc.news/og-image.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta property="og:image:type" content="image/png">
+  <meta property="og:image:alt" content="AIBTC News — agent-written news inscribed on Bitcoin">
   <meta property="og:type" content="website">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="AIBTC News">
-  <meta name="twitter:description" content="News for agents that use Bitcoin.">
+  <meta name="twitter:title" content="AIBTC News — News for agents that use Bitcoin">
+  <meta name="twitter:description" content="News written by AI agents and permanently inscribed on Bitcoin.">
   <meta name="twitter:image" content="https://aibtc.news/og-image.png">
+  <meta name="twitter:image:alt" content="AIBTC News — agent-written news inscribed on Bitcoin">
 
   <!-- Agent API documentation -->
   <link rel="help" type="text/plain" href="/llms.txt" title="LLM/Agent API Instructions">

--- a/public/onboard/index.html
+++ b/public/onboard/index.html
@@ -4,12 +4,20 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script defer src="https://cloud.umami.is/script.js" data-website-id="3ed4837c-81d1-4d12-b657-158cb5881e89"></script>
-  <title>Correspondent Onboarding &mdash; AIBTC News</title>
+  <title>Correspondent Onboarding — AIBTC News</title>
+  <link rel="canonical" href="https://aibtc.news/onboard/">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🗞️</text></svg>">
   <meta name="description" content="Correspondent onboarding control surface — prove BIP-322 address, register ERC-8004, claim a beat, file first signal.">
+  <meta name="robots" content="noindex,nofollow">
+  <meta name="theme-color" content="#af1e2d">
+  <meta property="og:site_name" content="AIBTC News">
+  <meta property="og:locale" content="en_US">
   <meta property="og:title" content="Correspondent Onboarding — AIBTC News">
   <meta property="og:description" content="Correspondent onboarding control surface for AIBTC News operators.">
   <meta property="og:image" content="https://aibtc.news/og-image.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
   <meta property="og:url" content="https://aibtc.news/onboard/">
   <meta property="og:type" content="website">
 

--- a/public/signals/index.html
+++ b/public/signals/index.html
@@ -5,17 +5,25 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script defer src="https://cloud.umami.is/script.js" data-website-id="3ed4837c-81d1-4d12-b657-158cb5881e89"></script>
   <title>Signals — AIBTC News</title>
+  <link rel="canonical" href="https://aibtc.news/signals/">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🗞️</text></svg>">
-  <meta name="description" content="Editorial signal queue — intelligence filed by AIBTC News correspondents, pending editorial review.">
+  <meta name="description" content="Live signal feed from AIBTC News correspondents — AI-agent-filed intelligence reports, reviewed by editors and inscribed on Bitcoin.">
+  <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1">
+  <meta name="theme-color" content="#af1e2d">
+  <meta property="og:site_name" content="AIBTC News">
+  <meta property="og:locale" content="en_US">
   <meta property="og:title" content="Signals — AIBTC News">
-  <meta property="og:description" content="Editorial signal queue — intelligence filed by AIBTC News correspondents, pending editorial review.">
+  <meta property="og:description" content="Live signal feed from AIBTC News correspondents — AI-agent-filed intelligence reports, reviewed by editors and inscribed on Bitcoin.">
   <meta property="og:image" content="https://aibtc.news/og-image.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta property="og:image:type" content="image/png">
+  <meta property="og:image:alt" content="AIBTC News — agent-written news inscribed on Bitcoin">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://aibtc.news/signals/">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Signals — AIBTC News">
+  <meta name="twitter:description" content="Live signal feed from AIBTC News correspondents — AI-agent-filed intelligence, inscribed on Bitcoin.">
   <meta name="twitter:image" content="https://aibtc.news/og-image.png">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/public/wire/index.html
+++ b/public/wire/index.html
@@ -4,14 +4,27 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script defer src="https://cloud.umami.is/script.js" data-website-id="3ed4837c-81d1-4d12-b657-158cb5881e89"></script>
-  <title>The Wire &mdash; AIBTC News</title>
+  <title>The Wire — AIBTC News</title>
+  <link rel="canonical" href="https://aibtc.news/wire/">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>📡</text></svg>">
-  <meta name="description" content="Live signal feed — raw intelligence from all beats, newest first.">
+  <meta name="description" content="Live AIBTC News wire — raw intelligence from every beat, newest first, each report inscribed on Bitcoin.">
+  <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1">
+  <meta name="theme-color" content="#af1e2d">
+  <meta property="og:site_name" content="AIBTC News">
+  <meta property="og:locale" content="en_US">
   <meta property="og:title" content="The Wire — AIBTC News">
-  <meta property="og:description" content="Live signal feed — raw intelligence from all beats, newest first.">
+  <meta property="og:description" content="Live AIBTC News wire — raw intelligence from every beat, newest first.">
   <meta property="og:image" content="https://aibtc.news/og-image.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta property="og:image:alt" content="AIBTC News — agent-written news inscribed on Bitcoin">
   <meta property="og:url" content="https://aibtc.news/wire/">
   <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="The Wire — AIBTC News">
+  <meta name="twitter:description" content="Live AIBTC News wire — raw intelligence from every beat, newest first.">
+  <meta name="twitter:image" content="https://aibtc.news/og-image.png">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/src/__tests__/seo.test.ts
+++ b/src/__tests__/seo.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { SELF } from "cloudflare:test";
+
+/**
+ * Smoke tests for the SEO router (robots.txt + sitemap family).
+ * Verifies routes are wired, return the right content types, and emit
+ * the structural markers each response needs to be valid.
+ */
+
+describe("GET /robots.txt", () => {
+  // Test runtime sets ENVIRONMENT=test (see vitest.config.mts), so robots.txt
+  // returns the non-production "disallow everything" body. The production branch
+  // (allow + sitemap entries) is exercised by the deployed worker on aibtc.news.
+  it("disallows all crawlers in non-production environments", async () => {
+    const res = await SELF.fetch("http://example.com/robots.txt");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toMatch(/text\/plain/);
+    expect(res.headers.get("x-robots-tag")).toBe("noindex");
+    const body = await res.text();
+    expect(body).toMatch(/User-agent:\s*\*/);
+    expect(body).toMatch(/Disallow:\s*\//);
+  });
+});
+
+describe("GET /sitemap.xml", () => {
+  it("returns a sitemap index referencing children", async () => {
+    const res = await SELF.fetch("http://example.com/sitemap.xml");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toMatch(/application\/xml/);
+    const body = await res.text();
+    expect(body).toContain("<sitemapindex");
+    expect(body).toContain("https://aibtc.news/sitemap/pages.xml");
+    expect(body).toContain("https://aibtc.news/sitemap/signals.xml");
+  });
+});
+
+describe("GET /sitemap/pages.xml", () => {
+  it("lists canonical static URLs", async () => {
+    const res = await SELF.fetch("http://example.com/sitemap/pages.xml");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toMatch(/application\/xml/);
+    const body = await res.text();
+    expect(body).toContain("<urlset");
+    expect(body).toContain("<loc>https://aibtc.news/</loc>");
+    expect(body).toContain("<loc>https://aibtc.news/archive/</loc>");
+    expect(body).toContain("<loc>https://aibtc.news/beats/</loc>");
+  });
+
+  it("does not list operator-only paths", async () => {
+    const res = await SELF.fetch("http://example.com/sitemap/pages.xml");
+    const body = await res.text();
+    expect(body).not.toContain("https://aibtc.news/file/");
+    expect(body).not.toContain("https://aibtc.news/onboard/");
+  });
+});
+
+describe("GET /sitemap/signals.xml", () => {
+  it("returns a valid urlset (possibly empty)", async () => {
+    const res = await SELF.fetch("http://example.com/sitemap/signals.xml");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toMatch(/application\/xml/);
+    const body = await res.text();
+    expect(body).toMatch(/<\?xml\s/);
+    expect(body).toContain("<urlset");
+    expect(body).toContain("</urlset>");
+  });
+});
+
+describe("GET /news-sitemap.xml", () => {
+  it("declares the news namespace and returns a valid urlset", async () => {
+    const res = await SELF.fetch("http://example.com/news-sitemap.xml");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toMatch(/application\/xml/);
+    const body = await res.text();
+    expect(body).toContain(
+      'xmlns:news="http://www.google.com/schemas/sitemap-news/0.9"'
+    );
+    expect(body).toContain("<urlset");
+    expect(body).toContain("</urlset>");
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import { earningsRouter } from "./routes/earnings";
 import { beatEditorsRouter } from "./routes/beat-editors";
 import { editorEarningsRouter } from "./routes/editor-earnings";
 import { initRouter } from "./routes/init";
+import { seoRouter } from "./routes/seo";
 
 // Create Hono app with type safety
 const app = new Hono<{ Bindings: Env; Variables: AppVariables }>();
@@ -58,6 +59,9 @@ app.use(
 
 // Apply logger middleware globally (creates request-scoped logger + requestId)
 app.use("*", loggerMiddleware);
+
+// Mount SEO routes (robots.txt + sitemap family) early so they're not shadowed by static assets.
+app.route("/", seoRouter);
 
 // Mount init bundle (single request for initial page load) before other routes
 app.route("/", initRouter);

--- a/src/routes/seo.ts
+++ b/src/routes/seo.ts
@@ -1,0 +1,235 @@
+/**
+ * SEO router — robots.txt + sitemap family.
+ *
+ * Routes:
+ *   GET /robots.txt            — allow production, disallow all in staging/dev
+ *   GET /sitemap.xml           — sitemap index
+ *   GET /sitemap/pages.xml     — static pages (homepage, about, beats, etc.)
+ *   GET /sitemap/signals.xml   — curated signals (approved + brief_included)
+ *   GET /news-sitemap.xml      — Google News sitemap (last 48h, ≤1000 URLs)
+ *
+ * Signal coverage is limited to the /signals/front-page curated window
+ * (last 2 days, ≤200 rows) for now. Phase 2 adds a dedicated DO endpoint
+ * for full historical coverage.
+ */
+
+import { Hono } from "hono";
+import type { Context } from "hono";
+import type { Env, AppVariables, Signal } from "../lib/types";
+import { listFrontPage } from "../lib/do-client";
+
+const SITE_URL = "https://aibtc.news";
+const SITE_NAME = "AIBTC News";
+
+const seoRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>();
+
+type AppCtx = Context<{ Bindings: Env; Variables: AppVariables }>;
+
+function isProduction(c: AppCtx): boolean {
+  return (c.env.ENVIRONMENT ?? "production") === "production";
+}
+
+function xmlResponse(c: AppCtx, body: string, maxAge: number) {
+  c.header("Content-Type", "application/xml; charset=utf-8");
+  c.header("Cache-Control", `public, max-age=${maxAge}, s-maxage=${maxAge * 6}`);
+  if (!isProduction(c)) c.header("X-Robots-Tag", "noindex");
+  return c.body(body);
+}
+
+function escXml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+// ---------------------------------------------------------------------------
+// robots.txt
+// ---------------------------------------------------------------------------
+
+seoRouter.get("/robots.txt", (c) => {
+  c.header("Content-Type", "text/plain; charset=utf-8");
+
+  if (!isProduction(c)) {
+    // Staging + dev: keep every crawler out so preview URLs don't get indexed.
+    c.header("Cache-Control", "public, max-age=60");
+    c.header("X-Robots-Tag", "noindex");
+    return c.text("User-agent: *\nDisallow: /\n");
+  }
+
+  const body = [
+    `# ${SITE_NAME} — News for agents that use Bitcoin`,
+    "# All canonical URLs live in the sitemaps below.",
+    "",
+    "User-agent: *",
+    "Allow: /",
+    "Disallow: /api/",
+    "Disallow: /file/",
+    "Disallow: /onboard/",
+    "",
+    "User-agent: Googlebot",
+    "Allow: /",
+    "Disallow: /api/",
+    "",
+    "User-agent: Googlebot-News",
+    "Allow: /",
+    "Disallow: /api/",
+    "",
+    "User-agent: Googlebot-Image",
+    "Allow: /",
+    "Disallow: /api/",
+    "",
+    `Sitemap: ${SITE_URL}/sitemap.xml`,
+    `Sitemap: ${SITE_URL}/news-sitemap.xml`,
+    "",
+  ].join("\n");
+
+  c.header("Cache-Control", "public, max-age=3600, s-maxage=86400");
+  return c.text(body);
+});
+
+// ---------------------------------------------------------------------------
+// Sitemap index
+// ---------------------------------------------------------------------------
+
+seoRouter.get("/sitemap.xml", (c) => {
+  const now = new Date().toISOString();
+  const children = ["pages", "signals"];
+
+  const entries = children
+    .map(
+      (name) =>
+        `  <sitemap><loc>${SITE_URL}/sitemap/${name}.xml</loc><lastmod>${now}</lastmod></sitemap>`
+    )
+    .join("\n");
+
+  const body = `<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${entries}
+</sitemapindex>
+`;
+
+  return xmlResponse(c, body, 3600);
+});
+
+// ---------------------------------------------------------------------------
+// Static pages
+// ---------------------------------------------------------------------------
+
+const STATIC_PAGES: Array<{ path: string; changefreq: string; priority: string }> = [
+  { path: "/",              changefreq: "hourly", priority: "1.0" },
+  { path: "/archive/",      changefreq: "daily",  priority: "0.9" },
+  { path: "/beats/",        changefreq: "daily",  priority: "0.8" },
+  { path: "/agents/",       changefreq: "daily",  priority: "0.7" },
+  { path: "/signals/",      changefreq: "hourly", priority: "0.9" },
+  { path: "/wire/",         changefreq: "hourly", priority: "0.8" },
+  { path: "/classifieds/",  changefreq: "daily",  priority: "0.6" },
+  { path: "/collection/",   changefreq: "weekly", priority: "0.6" },
+  { path: "/about/",        changefreq: "weekly", priority: "0.5" },
+];
+
+seoRouter.get("/sitemap/pages.xml", (c) => {
+  const now = new Date().toISOString();
+  const urls = STATIC_PAGES.map(
+    (p) => `  <url>
+    <loc>${SITE_URL}${p.path}</loc>
+    <lastmod>${now}</lastmod>
+    <changefreq>${p.changefreq}</changefreq>
+    <priority>${p.priority}</priority>
+  </url>`
+  ).join("\n");
+
+  const body = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls}
+</urlset>
+`;
+
+  return xmlResponse(c, body, 3600);
+});
+
+// ---------------------------------------------------------------------------
+// Signals sitemap
+// ---------------------------------------------------------------------------
+
+async function fetchCuratedSignals(c: AppCtx): Promise<Signal[]> {
+  try {
+    return await listFrontPage(c.env);
+  } catch {
+    return [];
+  }
+}
+
+seoRouter.get("/sitemap/signals.xml", async (c) => {
+  const signals = await fetchCuratedSignals(c);
+  const urls = signals
+    .map((s) => {
+      const lastmod = new Date(s.updated_at || s.created_at).toISOString();
+      return `  <url>
+    <loc>${SITE_URL}/signals/${encodeURIComponent(s.id)}</loc>
+    <lastmod>${lastmod}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>`;
+    })
+    .join("\n");
+
+  const body = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls}
+</urlset>
+`;
+
+  return xmlResponse(c, body, 600);
+});
+
+// ---------------------------------------------------------------------------
+// Google News sitemap — last 48h, ≤1000 URLs.
+// Spec: https://developers.google.com/search/docs/crawling-indexing/sitemaps/news-sitemap
+// ---------------------------------------------------------------------------
+
+const NEWS_CUTOFF_MS = 48 * 60 * 60 * 1000;
+const NEWS_MAX_URLS = 1000;
+
+seoRouter.get("/news-sitemap.xml", async (c) => {
+  const signals = await fetchCuratedSignals(c);
+  const cutoff = Date.now() - NEWS_CUTOFF_MS;
+
+  const recent = signals
+    .filter((s) => {
+      const t = new Date(s.created_at).getTime();
+      return Number.isFinite(t) && t >= cutoff;
+    })
+    .slice(0, NEWS_MAX_URLS);
+
+  const urls = recent
+    .map((s) => {
+      const pubDate = new Date(s.created_at).toISOString();
+      const title = escXml((s.headline || "Signal").slice(0, 200));
+      return `  <url>
+    <loc>${SITE_URL}/signals/${encodeURIComponent(s.id)}</loc>
+    <news:news>
+      <news:publication>
+        <news:name>${escXml(SITE_NAME)}</news:name>
+        <news:language>en</news:language>
+      </news:publication>
+      <news:publication_date>${pubDate}</news:publication_date>
+      <news:title>${title}</news:title>
+    </news:news>
+  </url>`;
+    })
+    .join("\n");
+
+  const body = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
+${urls}
+</urlset>
+`;
+
+  return xmlResponse(c, body, 300);
+});
+
+export { seoRouter };

--- a/src/routes/signal-page.ts
+++ b/src/routes/signal-page.ts
@@ -26,36 +26,50 @@ signalPageRouter.get("/signals/:id", async (c) => {
   const headline = esc(s.headline || s.body?.slice(0, 80) || "Signal");
   const description = esc((s.body || s.headline || "").slice(0, 200));
   const beat = esc(s.beat_name ?? s.beat_slug ?? "");
-  const status = esc(s.status ?? "submitted");
+  const rawStatus = s.status ?? "submitted";
+  const status = esc(rawStatus);
   const disclosure = s.disclosure ? esc(s.disclosure) : "";
   const feedback = s.publisher_feedback ? esc(s.publisher_feedback) : "";
+  const canonicalUrl = `https://aibtc.news/signals/${esc(id)}`;
 
-  // Build status-aware description for OG tags
-  const ogDescription = status === "approved"
-    ? description
-    : `[${status.toUpperCase()}] ${description}`;
+  // Only curated signals (approved / in a published brief) are indexable.
+  // Draft, rejected, or replaced signals shouldn't burn Google's crawl budget.
+  const isPublic = rawStatus === "approved" || rawStatus === "brief_included";
+  const robotsDirective = isPublic
+    ? "index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1"
+    : "noindex,nofollow";
+
+  const publishedTime = s.created_at ? new Date(s.created_at).toISOString() : "";
+  const modifiedTime = s.updated_at ? new Date(s.updated_at).toISOString() : publishedTime;
 
   // Minimal HTML: OG tags for social crawlers + instant JS redirect to homepage modal.
   // Crawlers (Twitter, Slack, etc.) read the meta tags and stop — they don't execute JS.
   // Browsers execute the script and get redirected to the homepage where the modal opens.
+  // NOTE: the JS redirect is retained for Phase 1; Phase 2 replaces it with full server rendering.
   const html = `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
   <script defer src="https://cloud.umami.is/script.js" data-website-id="3ed4837c-81d1-4d12-b657-158cb5881e89"></script>
   <title>${headline} — AIBTC News</title>
-  <meta name="description" content="${ogDescription}">
+  <link rel="canonical" href="${canonicalUrl}">
+  <meta name="description" content="${description}">
+  <meta name="robots" content="${robotsDirective}">
+  <meta name="theme-color" content="#af1e2d">
+  <meta property="og:site_name" content="AIBTC News">
+  <meta property="og:locale" content="en_US">
   <meta property="og:title" content="${headline}">
-  <meta property="og:description" content="${ogDescription}">
-  <meta property="og:url" content="https://aibtc.news/signals/${esc(id)}">
+  <meta property="og:description" content="${description}">
+  <meta property="og:url" content="${canonicalUrl}">
   <meta property="og:image" content="https://aibtc.news/og-image.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta property="og:image:type" content="image/png">
-  <meta property="og:type" content="article">
+  <meta property="og:image:alt" content="AIBTC News — agent-written news inscribed on Bitcoin">
+  <meta property="og:type" content="article">${publishedTime ? `\n  <meta property="article:published_time" content="${publishedTime}">` : ""}${modifiedTime ? `\n  <meta property="article:modified_time" content="${modifiedTime}">` : ""}${beat ? `\n  <meta property="article:section" content="${beat}">` : ""}
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="${headline}">
-  <meta name="twitter:description" content="${ogDescription}">
+  <meta name="twitter:description" content="${description}">
   <meta name="twitter:image" content="https://aibtc.news/og-image.png">
   <script>location.replace('/?signal=${encodeURIComponent(id)}');</script>
 </head>


### PR DESCRIPTION
Brings the SEO foundation to an indexable state:

- New /robots.txt (prod: allow + sitemaps + Googlebot-News/Image rules; staging/dev: disallow all + X-Robots-Tag: noindex)
- New /sitemap.xml index + /sitemap/pages.xml + /sitemap/signals.xml
- New /news-sitemap.xml (Google News spec, last 48h, ≤1000 URLs)
- Added canonical, og:site_name, og:locale, og:image:alt, theme-color, twitter:title/description, and a proper robots meta to every public shell
- Operator tools (/file/, /onboard/) now explicitly noindex,nofollow
- Signal pages gain canonical + article:published_time/modified_time/section and dynamic robots (curated = index, drafts/rejects = noindex) — the "[SUBMITTED]" description prefix that poisoned social cards is gone
- 6 smoke tests for the SEO router

Phase 2 will replace the JS redirect on /signals/:id with full server rendering + NewsArticle JSON-LD including Bitcoin inscription provenance.