### PR TITLE
fix(signal-page): honest provenance copy for brief_included + pending

### DIFF
--- a/src/__tests__/signal-page.test.ts
+++ b/src/__tests__/signal-page.test.ts
@@ -11,11 +11,13 @@ import { SELF } from "cloudflare:test";
 const APPROVED_ID = "sigpage-approved-001";
 const DRAFT_ID = "sigpage-submitted-002";
 const HOSTILE_SOURCE_ID = "sigpage-hostile-003";
+const BRIEF_PENDING_ID = "sigpage-brief-pending-004";
 const MISSING_ID = "00000000-0000-0000-0000-000000000000";
 
 const APPROVED_ADDR = "bc1qsigpageapproved0000000000000000000000000";
 const DRAFT_ADDR = "bc1qsigpagedraft00000000000000000000000000000";
 const HOSTILE_ADDR = "bc1qsigpagehostile00000000000000000000000000";
+const PENDING_ADDR = "bc1qsigpagebriefpending00000000000000000000";
 
 beforeAll(async () => {
   await SELF.fetch("http://example.com/api/test-seed", {
@@ -60,6 +62,27 @@ beforeAll(async () => {
           created_at: "2026-04-20T12:00:00Z",
           status: "approved",
           disclosure: "",
+        },
+        {
+          id: BRIEF_PENDING_ID,
+          beat_slug: "bitcoin-macro",
+          btc_address: PENDING_ADDR,
+          headline: "Signal in a compiled-but-not-yet-inscribed brief",
+          body: "brief-pending provenance copy coverage.",
+          sources: "[]",
+          created_at: "2026-04-19T08:00:00Z",
+          status: "brief_included",
+          disclosure: "",
+        },
+      ],
+      briefs: [
+        {
+          date: "2026-04-19",
+          text: "test brief body",
+          json_data: null,
+          compiled_at: "2026-04-19T23:50:00Z",
+          inscribed_txid: null,
+          inscription_id: null,
         },
       ],
     }),
@@ -172,6 +195,39 @@ describe("GET /signals/:id — hostile source URL", () => {
     expect(body).not.toMatch(/href="javascript:/i);
     // The title is still rendered so the source row remains visible.
     expect(body).toContain("Evil link");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// brief_included without inscription — "brief-pending" copy
+// ---------------------------------------------------------------------------
+
+describe("GET /signals/:id — brief_included, brief not inscribed", () => {
+  it("says 'Awaiting Bitcoin inscription', NOT 'editorial review'", async () => {
+    const res = await SELF.fetch(
+      `http://example.com/signals/${BRIEF_PENDING_ID}`
+    );
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    // Should mention the brief date and the inscription-pending state.
+    expect(body).toMatch(/Included in the 2026-04-19 daily brief/);
+    expect(body).toMatch(/Awaiting Bitcoin inscription/);
+    // MUST NOT fall through to the stage-fallback copy — brief_included is
+    // past editorial review.
+    expect(body).not.toMatch(/currently in editorial review/);
+    // No inscription markers should leak into JSON-LD or visible DOM.
+    expect(body).not.toContain("BitcoinInscriptionId");
+    expect(body).not.toContain('"archivedAt"');
+  });
+
+  it("emits BriefDate but not BitcoinInscriptionId in JSON-LD identifier", async () => {
+    const res = await SELF.fetch(
+      `http://example.com/signals/${BRIEF_PENDING_ID}`
+    );
+    const body = await res.text();
+    expect(body).toContain('"propertyID":"BriefDate"');
+    expect(body).toContain('"value":"2026-04-19"');
+    expect(body).not.toContain('"propertyID":"BitcoinInscriptionId"');
   });
 });
 

--- a/src/lib/signal-provenance.ts
+++ b/src/lib/signal-provenance.ts
@@ -1,34 +1,38 @@
 /**
- * Signal provenance — look up the daily brief a signal was included in
- * so we can surface Bitcoin inscription proof on the signal's article page.
+ * Signal provenance — resolve a signal's place in the daily-brief inscription
+ * chain so the article page can render honest, stage-accurate copy and
+ * structured data.
  *
- * A signal is considered "inscribed" when:
- *   1. Its status is `brief_included`
- *   2. The brief for its UTC day exists
- *   3. That brief has a non-null `inscription_id`
- *
- * Any of those missing → returns null. Callers should treat null as
- * "no on-chain provenance to display yet".
+ * Three terminal states for a brief_included signal:
+ *   - "inscribed"      — the brief exists and has an inscription_id + txid.
+ *                        Full on-chain provenance block renders.
+ *   - "brief-pending"  — the brief exists but isn't inscribed yet.
+ *                        Render "awaiting Bitcoin inscription" copy.
+ *   - null             — signal isn't brief_included at all, or (edge case)
+ *                        the brief couldn't be fetched. Callers render the
+ *                        stage-based fallback using signal.status.
  */
 
 import type { Env, Signal } from "./types";
 import { getUTCDate } from "./helpers";
 import { getBriefByDate } from "./do-client";
 
-export interface SignalProvenance {
-  /** UTC calendar date (YYYY-MM-DD) of the brief this signal was included in. */
+interface InscribedProvenance {
+  state: "inscribed";
   briefDate: string;
-  /** Ordinal inscription ID — the immutable on-chain record of the brief. */
   inscriptionId: string;
-  /** Reveal transaction ID on Bitcoin (null if we only have the inscription_id). */
   inscribedTxid: string | null;
-  /** Ordinals viewer URL for the inscription — the human-facing "archivedAt" target. */
   inscriptionUrl: string;
-  /** mempool.space tx URL (null if we don't have a txid). */
   txUrl: string | null;
 }
 
-/** Returns null when the signal has no on-chain brief yet. */
+interface BriefPendingProvenance {
+  state: "brief-pending";
+  briefDate: string;
+}
+
+export type SignalProvenance = InscribedProvenance | BriefPendingProvenance;
+
 export async function getSignalProvenance(
   env: Env,
   signal: Signal
@@ -37,9 +41,14 @@ export async function getSignalProvenance(
 
   const briefDate = getUTCDate(new Date(signal.created_at));
   const brief = await getBriefByDate(env, briefDate).catch(() => null);
-  if (!brief?.inscription_id) return null;
+  if (!brief) return null;
+
+  if (!brief.inscription_id) {
+    return { state: "brief-pending", briefDate: brief.date };
+  }
 
   return {
+    state: "inscribed",
     briefDate: brief.date,
     inscriptionId: brief.inscription_id,
     inscribedTxid: brief.inscribed_txid,

--- a/src/routes/signal-page.ts
+++ b/src/routes/signal-page.ts
@@ -128,20 +128,22 @@ function buildNewsArticle(
       value: signal.id,
     },
   ];
+  // BriefDate applies whether or not the brief has been inscribed yet —
+  // it's the day of curation either way.
   if (provenance) {
-    identifier.push(
-      {
-        "@type": "PropertyValue",
-        propertyID: "BitcoinInscriptionId",
-        value: provenance.inscriptionId,
-        url: provenance.inscriptionUrl,
-      },
-      {
-        "@type": "PropertyValue",
-        propertyID: "BriefDate",
-        value: provenance.briefDate,
-      }
-    );
+    identifier.push({
+      "@type": "PropertyValue",
+      propertyID: "BriefDate",
+      value: provenance.briefDate,
+    });
+  }
+  if (provenance?.state === "inscribed") {
+    identifier.push({
+      "@type": "PropertyValue",
+      propertyID: "BitcoinInscriptionId",
+      value: provenance.inscriptionId,
+      url: provenance.inscriptionUrl,
+    });
     if (provenance.inscribedTxid && provenance.txUrl) {
       identifier.push({
         "@type": "PropertyValue",
@@ -190,12 +192,13 @@ function buildNewsArticle(
     creator: { "@id": agentId },
     digitalSourceType: IPTC_AI_SOURCE,
     creditText: `Reported by ${addrShort} (AI agent) for ${SITE_NAME}${
-      provenance ? ", inscribed on Bitcoin" : ""
+      provenance?.state === "inscribed" ? ", inscribed on Bitcoin" : ""
     }`,
     identifier,
   };
 
-  if (provenance) {
+  // Only advertise on-chain equivalence when the brief is actually inscribed.
+  if (provenance?.state === "inscribed") {
     article.sameAs = provenance.inscriptionUrl;
     article.archivedAt = provenance.inscriptionUrl;
   }
@@ -324,30 +327,19 @@ function renderProvenance(
       )}</p>`
     : `<p class="sig-disclosure"><strong>AI disclosure.</strong> This report was filed by an autonomous AI agent correspondent under the ${SITE_NAME} editorial framework. See the <a href="/about/">about page</a> for the full editorial policy.</p>`;
 
-  if (!provenance) {
-    const pending =
-      signal.status === "approved"
-        ? `<p class="sig-provenance-note">This signal is editorially approved. It will be sealed on Bitcoin with its next daily brief inscription.</p>`
-        : `<p class="sig-provenance-note">This signal is currently in editorial review and has not yet been inscribed on Bitcoin.</p>`;
-    return `
-      <section class="sig-provenance" aria-labelledby="sig-provenance-h">
-        <h2 id="sig-provenance-h">Provenance</h2>
-        ${disclosure}
-        ${pending}
-      </section>`;
-  }
-
-  const inscrShort = `${provenance.inscriptionId.slice(0, 10)}…${provenance.inscriptionId.slice(-8)}`;
-  const txRow = provenance.inscribedTxid && provenance.txUrl
-    ? `          <div class="sig-prov-row">
+  // Case 1: in an inscribed brief → full on-chain provenance block.
+  if (provenance?.state === "inscribed") {
+    const inscrShort = `${provenance.inscriptionId.slice(0, 10)}…${provenance.inscriptionId.slice(-8)}`;
+    const txRow =
+      provenance.inscribedTxid && provenance.txUrl
+        ? `          <div class="sig-prov-row">
             <dt>Reveal tx</dt>
             <dd><a href="${esc(provenance.txUrl)}" rel="noopener" target="_blank"><code>${esc(
               provenance.inscribedTxid.slice(0, 10)
             )}…${esc(provenance.inscribedTxid.slice(-8))}</code></a></dd>
           </div>`
-    : "";
-
-  return `
+        : "";
+    return `
       <section class="sig-provenance" aria-labelledby="sig-provenance-h">
         <h2 id="sig-provenance-h">Provenance</h2>
         ${disclosure}
@@ -367,6 +359,31 @@ function renderProvenance(
           </div>
 ${txRow}
         </dl>
+      </section>`;
+  }
+
+  // Case 2: included in a brief but the brief isn't inscribed yet.
+  if (provenance?.state === "brief-pending") {
+    return `
+      <section class="sig-provenance" aria-labelledby="sig-provenance-h">
+        <h2 id="sig-provenance-h">Provenance</h2>
+        ${disclosure}
+        <p class="sig-provenance-note">Included in the ${esc(
+          provenance.briefDate
+        )} daily brief. Awaiting Bitcoin inscription.</p>
+      </section>`;
+  }
+
+  // Case 3: not in any brief yet — use the signal's editorial status.
+  const pending =
+    signal.status === "approved"
+      ? `<p class="sig-provenance-note">This signal is editorially approved. It will be sealed on Bitcoin with its next daily brief inscription.</p>`
+      : `<p class="sig-provenance-note">This signal is currently in editorial review and has not yet been inscribed on Bitcoin.</p>`;
+  return `
+      <section class="sig-provenance" aria-labelledby="sig-provenance-h">
+        <h2 id="sig-provenance-h">Provenance</h2>
+        ${disclosure}
+        ${pending}
       </section>`;
 }
 


### PR DESCRIPTION
## Summary

Found during Phase 2A prod verification.

Signals with status \`brief_included\` whose brief **hasn't been inscribed on Bitcoin yet** (e.g. \`63d3eaf9-8243-4fc6-b7a9-050ef374f084\`, \`99061dcf-1741-4f12-9d8d-7b2986dfce0e\`) currently render:

> "This signal is currently in editorial review and has not yet been inscribed on Bitcoin."

That's wrong on both counts — \`brief_included\` is **past** editorial review, and we do know the brief date even before the inscription lands.

## Fix

Splits \`SignalProvenance\` into a discriminated union so the renderer and the JSON-LD builder can both make stage-accurate claims:

- \`"inscribed"\` — brief has \`inscription_id\` (+ optional txid). Full provenance block + \`sameAs\` + \`archivedAt\` + \`BitcoinInscriptionId\` / \`BitcoinTxId\` / \`BriefDate\` in \`identifier[]\`.
- \`"brief-pending"\` — brief exists, not inscribed yet. Renders *"Included in the YYYY-MM-DD daily brief. Awaiting Bitcoin inscription."* \`BriefDate\` emitted in JSON-LD; no inscription identifiers, no \`sameAs\`, no \`archivedAt\`.
- \`null\` — signal isn't \`brief_included\`. Falls back to status-based copy (\`approved\` → "awaiting next brief"; other → "in editorial review").

Important side effect: \`creditText\` now only claims *"inscribed on Bitcoin"* when the record is actually on-chain. We no longer overstate provenance in structured data.

## Production evidence

Verified these currently render the wrong "editorial review" copy on \`https://aibtc.news\`:
- \`/signals/63d3eaf9-8243-4fc6-b7a9-050ef374f084\` (aibtc-network beat)
- \`/signals/99061dcf-1741-4f12-9d8d-7b2986dfce0e\` (bitcoin-macro beat)
- \`/signals/e0598ecd-58c9-46ed-acd9-38ea0d59fb40\` (bitcoin-macro beat)

Inscribed-brief signals (e.g. \`7d995511-...\` from the 2026-03-29 inscription) already render correctly — that path isn't changed.

## Test plan

- [x] Typecheck clean (discriminated union forces all callers to narrow).
- [x] 2 new tests in \`signal-page.test.ts\` cover the brief-pending path:
  - Visible copy contains "Included in the 2026-04-19 daily brief" and "Awaiting Bitcoin inscription"; does NOT contain "currently in editorial review".
  - JSON-LD \`identifier[]\` contains \`BriefDate\` but NOT \`BitcoinInscriptionId\`.
  - No \`archivedAt\` / \`sameAs\` leaks for pending briefs.
- [x] Full suite: 309 pass / 4 fail (same pre-existing failures: \`identity-gate\`, \`scoring-math\`). Zero new failures.
- [ ] After merge: confirm \`63d3eaf9-...\` and \`99061dcf-...\` render the corrected copy in production.