### PR TITLE
feat(seo): server-render homepage with HTMLRewriter + JSON-LD (phase 2b)

### DIFF
--- a/src/__tests__/health.test.ts
+++ b/src/__tests__/health.test.ts
@@ -6,12 +6,14 @@ import { SELF } from "cloudflare:test";
  * These use SELF to fetch through the real Workers runtime.
  */
 describe("GET /", () => {
-  it("returns 200 with service info", async () => {
+  // GET / now serves the server-rendered homepage (public/index.html
+  // transformed via HTMLRewriter). Detailed SSR assertions live in
+  // home-page.test.ts; here we just confirm the root still resolves
+  // successfully and returns HTML, not the old JSON service-info blob.
+  it("returns 200 HTML (homepage SSR, not service-info JSON)", async () => {
     const res = await SELF.fetch("http://example.com/");
     expect(res.status).toBe(200);
-    const body = await res.json<{ service: string; version: string }>();
-    expect(body.service).toBe("agent-news");
-    expect(typeof body.version).toBe("string");
+    expect(res.headers.get("content-type")).toMatch(/text\/html/);
   });
 });
 

--- a/src/__tests__/home-page.test.ts
+++ b/src/__tests__/home-page.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { SELF } from "cloudflare:test";
+
+/**
+ * Integration tests for the homepage SSR handler (GET /).
+ *
+ * With run_worker_first: ["/"] the worker intercepts the root, fetches the
+ * static shell via env.ASSETS, and streams it through HTMLRewriter to
+ * inject dynamic meta + JSON-LD. These tests verify:
+ *   - The shell loads via ASSETS and comes back as HTML.
+ *   - Head tags (title, description, og:*, twitter:*) get dynamic content
+ *     derived from the seeded brief + front-page signals.
+ *   - JSON-LD (NewsMediaOrganization, WebSite, ItemList) is injected.
+ *   - Original client bootstrap scripts (script tags, topnav placeholder,
+ *     /api/init fetch) are preserved — the client UX is untouched.
+ *   - Cache-Control is set (Worker responses aren't auto-cached at edge).
+ *   - The ?signal= deep-link bootstrap is still present.
+ *   - Other root-adjacent paths (e.g. /robots.txt) are NOT intercepted.
+ */
+
+const LEAD_HEADLINE =
+  "Homepage SSR lead — today's biggest story on AIBTC News";
+const SECOND_HEADLINE = "Second story that should appear in ItemList";
+const LEAD_ID = "home-ssr-lead-001";
+const SECOND_ID = "home-ssr-second-002";
+
+beforeAll(async () => {
+  // Seed two approved signals with fresh timestamps so listFrontPage
+  // picks them up (its window is -2 days).
+  const now = new Date();
+  const recent = new Date(now.getTime() - 60 * 60 * 1000).toISOString();
+  const earlier = new Date(now.getTime() - 90 * 60 * 1000).toISOString();
+
+  await SELF.fetch("http://example.com/api/test-seed", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      signals: [
+        {
+          id: LEAD_ID,
+          beat_slug: "bitcoin-macro",
+          btc_address: "bc1qhomessrlead0000000000000000000000000000",
+          headline: LEAD_HEADLINE,
+          body: "Body content for the lead signal used in homepage SSR tests.",
+          sources: "[]",
+          created_at: recent,
+          status: "approved",
+          disclosure: "",
+        },
+        {
+          id: SECOND_ID,
+          beat_slug: "bitcoin-macro",
+          btc_address: "bc1qhomessrsecond000000000000000000000000000",
+          headline: SECOND_HEADLINE,
+          body: "Body content for the second signal.",
+          sources: "[]",
+          created_at: earlier,
+          status: "approved",
+          disclosure: "",
+        },
+      ],
+    }),
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Baseline: still serves HTML with the correct cache story
+// ---------------------------------------------------------------------------
+
+describe("GET / — baseline", () => {
+  it("returns 200 HTML with explicit Cache-Control", async () => {
+    const res = await SELF.fetch("http://example.com/");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toMatch(/text\/html/);
+    // Worker responses aren't auto-cached at the edge — we set this header
+    // explicitly so Cloudflare's CDN will hold the rendered homepage.
+    expect(res.headers.get("cache-control")).toMatch(/s-maxage=/);
+  });
+
+  it("keeps the original client bootstrap scripts intact", async () => {
+    const res = await SELF.fetch("http://example.com/");
+    const body = await res.text();
+    // Client JS must still be present — we only augment the head.
+    expect(body).toContain("/shared.js");
+    expect(body).toContain("/api/init");
+    // Topnav placeholder div (reserved by the client shell) must remain.
+    expect(body).toContain('id="topnav-placeholder"');
+    // ?signal=:id deep-link bootstrap must still be there so copies of
+    // the old URL pattern keep opening the modal.
+    expect(body).toContain("params.get('signal')");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dynamic head rewrite
+// ---------------------------------------------------------------------------
+
+describe("GET / — dynamic head", () => {
+  it("rewrites <title> to include the lead headline", async () => {
+    const res = await SELF.fetch("http://example.com/");
+    const body = await res.text();
+    // Title format: "<truncated headline> — AIBTC News".
+    // The seeded lead headline is short enough to appear verbatim.
+    expect(body).toMatch(
+      /<title>Homepage SSR lead — today's biggest story on AIBTC News — AIBTC News<\/title>/
+    );
+  });
+
+  it("rewrites og:title and twitter:title to match", async () => {
+    const res = await SELF.fetch("http://example.com/");
+    const body = await res.text();
+    expect(body).toMatch(
+      /<meta property="og:title" content="Homepage SSR lead — today's biggest story on AIBTC News — AIBTC News">/
+    );
+    expect(body).toMatch(
+      /<meta name="twitter:title" content="Homepage SSR lead — today's biggest story on AIBTC News — AIBTC News">/
+    );
+  });
+
+  it("rewrites description with today's top headlines when no brief", async () => {
+    const res = await SELF.fetch("http://example.com/");
+    const body = await res.text();
+    // No brief seeded → description falls back to "Today on AIBTC News: ..."
+    expect(body).toMatch(
+      /<meta name="description" content="Today on AIBTC News: Homepage SSR lead/
+    );
+    expect(body).toMatch(
+      /<meta property="og:description" content="Today on AIBTC News: /
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// JSON-LD injection
+// ---------------------------------------------------------------------------
+
+describe("GET / — JSON-LD", () => {
+  it("injects NewsMediaOrganization + WebSite", async () => {
+    const res = await SELF.fetch("http://example.com/");
+    const body = await res.text();
+    expect(body).toContain('"@type":"NewsMediaOrganization"');
+    expect(body).toContain('"@type":"WebSite"');
+    expect(body).toContain('"@id":"https://aibtc.news/#org"');
+    expect(body).toContain('"@id":"https://aibtc.news/#website"');
+  });
+
+  it("injects ItemList with today's top signals", async () => {
+    const res = await SELF.fetch("http://example.com/");
+    const body = await res.text();
+    expect(body).toContain('"@type":"ItemList"');
+    expect(body).toContain('"@type":"ListItem"');
+    expect(body).toContain(
+      `"url":"https://aibtc.news/signals/${LEAD_ID}"`
+    );
+    // Second signal should also appear.
+    expect(body).toContain(
+      `"url":"https://aibtc.news/signals/${SECOND_ID}"`
+    );
+    expect(body).toContain(`"name":"${LEAD_HEADLINE}"`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scope check — run_worker_first must only match "/"
+// ---------------------------------------------------------------------------
+
+describe("GET /robots.txt — NOT intercepted by homepage handler", () => {
+  it("still serves robots.txt from the SEO router (not the homepage)", async () => {
+    const res = await SELF.fetch("http://example.com/robots.txt");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toMatch(/text\/plain/);
+    const body = await res.text();
+    // Must not have been run through HTMLRewriter.
+    expect(body).not.toContain('"@type":"NewsMediaOrganization"');
+  });
+});
+
+describe("GET /signals/:id — NOT intercepted by homepage handler", () => {
+  it("continues to serve the signal-page router response", async () => {
+    const res = await SELF.fetch(
+      `http://example.com/signals/${LEAD_ID}`
+    );
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    // Signal-page emits a NewsArticle (not NewsMediaOrganization as first JSON-LD).
+    expect(body).toContain('"@type":"NewsArticle"');
+  });
+});

--- a/src/__tests__/x402-rpc.test.ts
+++ b/src/__tests__/x402-rpc.test.ts
@@ -30,6 +30,7 @@ function makeEnv(
     // Stubs for required Env fields that are not exercised by verifyPayment
     NEWS_KV: {} as unknown as KVNamespace,
     NEWS_DO: {} as unknown as DurableObjectNamespace,
+    ASSETS: {} as unknown as Fetcher,
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import { beatEditorsRouter } from "./routes/beat-editors";
 import { editorEarningsRouter } from "./routes/editor-earnings";
 import { initRouter } from "./routes/init";
 import { seoRouter } from "./routes/seo";
+import { homeRouter } from "./routes/home-page";
 
 // Create Hono app with type safety
 const app = new Hono<{ Bindings: Env; Variables: AppVariables }>();
@@ -62,6 +63,10 @@ app.use("*", loggerMiddleware);
 
 // Mount SEO routes (robots.txt + sitemap family) early so they're not shadowed by static assets.
 app.route("/", seoRouter);
+
+// Mount homepage SSR — intercepts GET / (enabled by run_worker_first: ["/"]
+// in wrangler.jsonc). Other asset paths continue serving directly.
+app.route("/", homeRouter);
 
 // Mount init bundle (single request for initial page load) before other routes
 app.route("/", initRouter);
@@ -266,21 +271,8 @@ function healthHandler(c: AppContext) {
 app.get("/health", healthHandler);
 app.get("/api/health", healthHandler);
 
-// Root endpoint - service info
-app.get("/", (c) => {
-  return c.json({
-    service: "agent-news",
-    version: VERSION,
-    description: "AI agent news aggregation and briefing service",
-    endpoints: {
-      health: "GET /health - Health check",
-      apiHealth: "GET /api/health - API health check",
-    },
-    related: {
-      github: "https://github.com/aibtcdev/agent-news",
-    },
-  });
-});
+// (The old GET / JSON service-info handler was removed — homepage SSR owns
+// the root path now. Service metadata lives at /api/health.)
 
 // 404 handler
 app.notFound((c) => {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -95,6 +95,10 @@ export interface Logger {
 export interface Env {
   NEWS_KV: KVNamespace;
   NEWS_DO: DurableObjectNamespace;
+  // Static assets fetcher — bound via wrangler `assets.binding = "ASSETS"`.
+  // Used by the homepage SSR handler to fetch public/index.html before
+  // transforming it with HTMLRewriter.
+  ASSETS: Fetcher;
   // LOGS is a service binding to worker-logs RPC, typed loosely to avoid complex Service<> generics
   LOGS?: unknown;
   // X402_RELAY is a service binding to x402-sponsor-relay RPC (RelayRPC WorkerEntrypoint)

--- a/src/routes/home-page.ts
+++ b/src/routes/home-page.ts
@@ -1,0 +1,257 @@
+/**
+ * Homepage SSR — GET /.
+ *
+ * The homepage's existing client JS (public/index.html) is a rich SPA that
+ * fetches /api/init and paints every surface (brief, ticker, beats, wire).
+ * We do NOT want to touch that code path. Instead, this handler transforms
+ * the static shell in-flight with HTMLRewriter to inject SEO-grade
+ * dynamic metadata + JSON-LD into the initial HTML response, so:
+ *
+ *   - Google / Discover / Top Stories see real today's content immediately.
+ *   - Social cards (Twitter, Slack, Facebook, LinkedIn) render today's
+ *     lead headline instead of the generic "News for agents..." fallback.
+ *   - Once the client JS boots, it overrides the DOM as usual — users see
+ *     the same interactive homepage they always have.
+ *
+ * Safety model:
+ *   1. Fetch shell via env.ASSETS.fetch(). If that fails → 503.
+ *   2. Only transform 2xx + text/html responses. 404 / redirects pass through.
+ *   3. Fetch brief + signals in parallel with Promise.allSettled so one
+ *      slow or failing DO call does not block the other. On total failure,
+ *      pass through the untouched asset — SEO takes a hit but UX is fine.
+ *   4. HTMLRewriter only targets specific head tags + the closing </head>.
+ *      Body DOM / scripts are not touched.
+ *   5. Explicit Cache-Control — Cloudflare does NOT auto-cache Worker
+ *      responses, so we set public,s-maxage=300 (matches signal-page).
+ */
+
+import { Hono } from "hono";
+import type { Env, AppVariables, Signal, Brief } from "../lib/types";
+import { getLatestBrief, listFrontPage } from "../lib/do-client";
+
+const SITE_URL = "https://aibtc.news";
+const SITE_NAME = "AIBTC News";
+const OG_IMAGE = `${SITE_URL}/og-image.png`;
+
+const DEFAULT_TITLE = `${SITE_NAME} — News for agents that use Bitcoin`;
+const DEFAULT_DESCRIPTION =
+  "News written by AI agents and permanently inscribed on Bitcoin. Daily briefs, live signals, and a verifiable on-chain record of every report.";
+
+// Cap the ItemList — 10 is enough for Google to understand "this is a list
+// of today's top stories" without turning JSON-LD into a firehose.
+const ITEM_LIST_CAP = 10;
+
+const homeRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface HomepageData {
+  brief: Brief | null;
+  signals: Signal[];
+}
+
+async function fetchHomepageData(env: Env): Promise<HomepageData> {
+  const [briefResult, signalsResult] = await Promise.allSettled([
+    getLatestBrief(env),
+    listFrontPage(env),
+  ]);
+  return {
+    brief: briefResult.status === "fulfilled" ? briefResult.value : null,
+    signals:
+      signalsResult.status === "fulfilled" ? signalsResult.value : [],
+  };
+}
+
+function truncate(s: string, max: number): string {
+  const clean = s.replace(/\s+/g, " ").trim();
+  if (clean.length <= max) return clean;
+  return `${clean.slice(0, max).trim()}…`;
+}
+
+function buildTitle(data: HomepageData): string {
+  const lead = data.signals[0];
+  if (lead?.headline) {
+    return `${truncate(lead.headline, 70)} — ${SITE_NAME}`;
+  }
+  return DEFAULT_TITLE;
+}
+
+function buildDescription(data: HomepageData): string {
+  if (data.brief?.text) return truncate(data.brief.text, 200);
+  if (data.signals.length > 0) {
+    const top = data.signals
+      .slice(0, 3)
+      .map((s) => s.headline)
+      .join(" · ");
+    return truncate(`Today on ${SITE_NAME}: ${top}`, 200);
+  }
+  return DEFAULT_DESCRIPTION;
+}
+
+// ---------------------------------------------------------------------------
+// JSON-LD builders
+// ---------------------------------------------------------------------------
+
+interface Jsonish {
+  [k: string]: unknown;
+}
+
+function buildOrganizationJsonLd(): Jsonish {
+  return {
+    "@context": "https://schema.org",
+    "@type": "NewsMediaOrganization",
+    "@id": `${SITE_URL}/#org`,
+    name: SITE_NAME,
+    url: `${SITE_URL}/`,
+    description: DEFAULT_DESCRIPTION,
+    logo: {
+      "@type": "ImageObject",
+      url: OG_IMAGE,
+      width: 1200,
+      height: 630,
+    },
+    publishingPrinciples: `${SITE_URL}/about/`,
+  };
+}
+
+function buildWebsiteJsonLd(): Jsonish {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "@id": `${SITE_URL}/#website`,
+    name: SITE_NAME,
+    url: `${SITE_URL}/`,
+    publisher: { "@id": `${SITE_URL}/#org` },
+    inLanguage: "en",
+  };
+}
+
+function buildItemListJsonLd(signals: Signal[]): Jsonish | null {
+  const trimmed = signals.slice(0, ITEM_LIST_CAP);
+  if (trimmed.length === 0) return null;
+  return {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: `${SITE_NAME} — Front Page`,
+    numberOfItems: trimmed.length,
+    itemListOrder: "https://schema.org/ItemListOrderDescending",
+    itemListElement: trimmed.map((s, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      url: `${SITE_URL}/signals/${encodeURIComponent(s.id)}`,
+      name: s.headline,
+    })),
+  };
+}
+
+/** Same `</script>` escape trick we use on signal-page.ts. */
+function escJsonLd(s: string): string {
+  return s.replace(/</g, "\\u003c");
+}
+
+function jsonLdScript(obj: Jsonish): string {
+  return `\n  <script type="application/ld+json">${escJsonLd(
+    JSON.stringify(obj)
+  )}</script>`;
+}
+
+function buildJsonLdBlocks(data: HomepageData): string {
+  const blocks = [buildOrganizationJsonLd(), buildWebsiteJsonLd()];
+  const list = buildItemListJsonLd(data.signals);
+  if (list) blocks.push(list);
+  return blocks.map(jsonLdScript).join("");
+}
+
+// ---------------------------------------------------------------------------
+// Response helpers
+// ---------------------------------------------------------------------------
+
+/** Copy headers, set Cache-Control, force text/html. Worker responses are
+ *  not auto-cached at the edge, so this is the only thing that keeps the
+ *  homepage fast under load. Matches the signal-page pattern. */
+function withCacheHeaders(res: Response): Response {
+  const headers = new Headers(res.headers);
+  headers.set("Cache-Control", "public, max-age=60, s-maxage=300");
+  headers.set("Content-Type", "text/html; charset=utf-8");
+  return new Response(res.body, {
+    status: res.status,
+    statusText: res.statusText,
+    headers,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Route
+// ---------------------------------------------------------------------------
+
+homeRouter.get("/", async (c) => {
+  const logger = c.get("logger");
+
+  // 1. Fetch the static shell. If this fails we have nothing to serve.
+  let assetResponse: Response;
+  try {
+    assetResponse = await c.env.ASSETS.fetch(c.req.raw);
+  } catch (err) {
+    logger.error("homepage: ASSETS.fetch failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return c.text("Service unavailable", 503);
+  }
+
+  // 2. Only transform successful HTML responses. Anything else (404,
+  //    redirect, binary asset) passes through unmodified.
+  const contentType = assetResponse.headers.get("content-type") ?? "";
+  if (!assetResponse.ok || !contentType.includes("text/html")) {
+    return assetResponse;
+  }
+
+  // 3. Fetch dynamic data. On ANY failure we pass through the untouched
+  //    shell — SEO loses freshness but the page still works perfectly.
+  let data: HomepageData;
+  try {
+    data = await fetchHomepageData(c.env);
+  } catch (err) {
+    logger.warn("homepage: data fetch failed, passing through shell", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return withCacheHeaders(assetResponse);
+  }
+
+  // 4. Transform the head. Body, scripts, and placeholder divs are not
+  //    touched — the client-side boot code runs unchanged.
+  const title = buildTitle(data);
+  const description = buildDescription(data);
+  const jsonLdBlocks = buildJsonLdBlocks(data);
+
+  const setContent = (content: string) => ({
+    element(el: Element) {
+      el.setAttribute("content", content);
+    },
+  });
+
+  const rewriter = new HTMLRewriter()
+    .on("title", {
+      element(el) {
+        el.setInnerContent(title);
+      },
+    })
+    .on('meta[name="description"]', setContent(description))
+    .on('meta[property="og:title"]', setContent(title))
+    .on('meta[property="og:description"]', setContent(description))
+    .on('meta[name="twitter:title"]', setContent(title))
+    .on('meta[name="twitter:description"]', setContent(description))
+    .on("head", {
+      element(el) {
+        // Append JSON-LD blocks at the end of <head> — after the existing
+        // canonical, OG, and stylesheet tags, before the body starts.
+        el.append(jsonLdBlocks, { html: true });
+      },
+    });
+
+  const transformed = rewriter.transform(assetResponse);
+  return withCacheHeaders(transformed);
+});
+
+export { homeRouter };

--- a/src/routes/home-page.ts
+++ b/src/routes/home-page.ts
@@ -21,13 +21,17 @@
  *      pass through the untouched asset — SEO takes a hit but UX is fine.
  *   4. HTMLRewriter only targets specific head tags + the closing </head>.
  *      Body DOM / scripts are not touched.
- *   5. Explicit Cache-Control — Cloudflare does NOT auto-cache Worker
- *      responses, so we set public,s-maxage=300 (matches signal-page).
+ *   5. Actually cache at the edge via the Workers Cache API (caches.default
+ *      through src/lib/edge-cache.ts). `Cache-Control` alone does not
+ *      populate the edge cache for Worker responses in this zone — we
+ *      have to put-and-match explicitly. Matches the pattern used by
+ *      /api/init and /api/beats.
  */
 
 import { Hono } from "hono";
 import type { Env, AppVariables, Signal, Brief } from "../lib/types";
 import { getLatestBrief, listFrontPage } from "../lib/do-client";
+import { edgeCacheMatch, edgeCachePut } from "../lib/edge-cache";
 
 const SITE_URL = "https://aibtc.news";
 const SITE_NAME = "AIBTC News";
@@ -73,7 +77,11 @@ function truncate(s: string, max: number): string {
 function buildTitle(data: HomepageData): string {
   const lead = data.signals[0];
   if (lead?.headline) {
-    return `${truncate(lead.headline, 70)} — ${SITE_NAME}`;
+    // Cap the headline at 55 chars so the full title (+" — AIBTC News")
+    // stays under ~68 chars and fits Google's desktop display window
+    // (which truncates around 60-65). Longer headlines would otherwise
+    // get cut mid-word in SERPs.
+    return `${truncate(lead.headline, 55)} — ${SITE_NAME}`;
   }
   return DEFAULT_TITLE;
 }
@@ -94,9 +102,7 @@ function buildDescription(data: HomepageData): string {
 // JSON-LD builders
 // ---------------------------------------------------------------------------
 
-interface Jsonish {
-  [k: string]: unknown;
-}
+type Jsonish = Record<string, unknown>;
 
 function buildOrganizationJsonLd(): Jsonish {
   return {
@@ -168,11 +174,27 @@ function buildJsonLdBlocks(data: HomepageData): string {
 // Response helpers
 // ---------------------------------------------------------------------------
 
-/** Copy headers, set Cache-Control, force text/html. Worker responses are
- *  not auto-cached at the edge, so this is the only thing that keeps the
- *  homepage fast under load. Matches the signal-page pattern. */
+/**
+ * Rebuild the response with our Cache-Control + text/html content type.
+ *
+ * Validator headers (ETag, Last-Modified, Content-Length) are explicitly
+ * stripped because HTMLRewriter modifies the body — those values refer to
+ * the *original* static asset and would otherwise make conditional
+ * requests serve stale bytes (304 Not Modified with the old HTML) or
+ * make the Content-Length mismatch the actual payload.
+ *
+ * Cache-Control here is advisory — it tells browsers + downstream caches
+ * how long the response is valid. Actual edge caching happens via
+ * `edgeCachePut` in the route handler (Workers Cache API), since
+ * `Cache-Control` alone doesn't populate the Cloudflare edge cache for
+ * Worker responses.
+ */
 function withCacheHeaders(res: Response): Response {
   const headers = new Headers(res.headers);
+  // Drop original-asset validators — the transformed body won't match.
+  headers.delete("ETag");
+  headers.delete("Last-Modified");
+  headers.delete("Content-Length");
   headers.set("Cache-Control", "public, max-age=60, s-maxage=300");
   headers.set("Content-Type", "text/html; charset=utf-8");
   return new Response(res.body, {
@@ -189,7 +211,12 @@ function withCacheHeaders(res: Response): Response {
 homeRouter.get("/", async (c) => {
   const logger = c.get("logger");
 
-  // 1. Fetch the static shell. If this fails we have nothing to serve.
+  // 1. Edge cache short-circuit. Keeps the homepage at <50ms TTFB on
+  //    warm hits under load. Cache key is the canonical request URL.
+  const cached = await edgeCacheMatch(c);
+  if (cached) return cached;
+
+  // 2. Fetch the static shell. If this fails we have nothing to serve.
   let assetResponse: Response;
   try {
     assetResponse = await c.env.ASSETS.fetch(c.req.raw);
@@ -200,26 +227,29 @@ homeRouter.get("/", async (c) => {
     return c.text("Service unavailable", 503);
   }
 
-  // 2. Only transform successful HTML responses. Anything else (404,
+  // 3. Only transform successful HTML responses. Anything else (404,
   //    redirect, binary asset) passes through unmodified.
   const contentType = assetResponse.headers.get("content-type") ?? "";
   if (!assetResponse.ok || !contentType.includes("text/html")) {
     return assetResponse;
   }
 
-  // 3. Fetch dynamic data. On ANY failure we pass through the untouched
-  //    shell — SEO loses freshness but the page still works perfectly.
+  // 4. Fetch dynamic data. `fetchHomepageData` uses Promise.allSettled
+  //    internally and degrades to null/empty on per-source failures, so
+  //    it cannot reject under normal conditions. The try/catch below is
+  //    defensive against *synchronous* throws (e.g. if a DO binding is
+  //    ever missing at boot) — rare but cheap to guard.
   let data: HomepageData;
   try {
     data = await fetchHomepageData(c.env);
   } catch (err) {
-    logger.warn("homepage: data fetch failed, passing through shell", {
+    logger.warn("homepage: unexpected sync error in data fetch, passing through shell", {
       error: err instanceof Error ? err.message : String(err),
     });
     return withCacheHeaders(assetResponse);
   }
 
-  // 4. Transform the head. Body, scripts, and placeholder divs are not
+  // 5. Transform the head. Body, scripts, and placeholder divs are not
   //    touched — the client-side boot code runs unchanged.
   const title = buildTitle(data);
   const description = buildDescription(data);
@@ -251,7 +281,15 @@ homeRouter.get("/", async (c) => {
     });
 
   const transformed = rewriter.transform(assetResponse);
-  return withCacheHeaders(transformed);
+  const response = withCacheHeaders(transformed);
+
+  // 6. Store in the edge cache so subsequent hits within s-maxage skip
+  //    the ASSETS fetch + DO calls + HTMLRewriter pipeline. edgeCachePut
+  //    uses `executionCtx.waitUntil` so we don't pay any latency for the
+  //    store. Cache entry at rest doesn't carry the X-Edge-Cache: MISS
+  //    marker (only the live response the caller receives does).
+  edgeCachePut(c, response);
+  return response;
 });
 
 export { homeRouter };

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -41,8 +41,18 @@
   // reducing Worker→DO network round-trip latency instead of running at the user's edge.
   "placement": { "mode": "smart" },
 
-  // Static frontend assets
-  "assets": { "directory": "./public" },
+  // Static frontend assets.
+  //   - binding: `env.ASSETS.fetch()` lets the Worker pull static files
+  //     (used by the homepage SSR handler to transform public/index.html).
+  //   - run_worker_first: ["/"]  → Worker intercepts ONLY the root. All other
+  //     asset paths (sections, CSS, JS) still serve directly from the static
+  //     asset server with zero Worker overhead. The `/` pattern is a literal
+  //     exact match per Cloudflare docs — it does NOT match `/signals/abc`.
+  "assets": {
+    "directory": "./public",
+    "binding": "ASSETS",
+    "run_worker_first": ["/"]
+  },
 
   /**
    * Secrets (set via `wrangler secret put`):
@@ -96,7 +106,11 @@
       ],
 
       // No custom domain for staging — use workers.dev URL
-      "assets": { "directory": "./public" }
+      "assets": {
+        "directory": "./public",
+        "binding": "ASSETS",
+        "run_worker_first": ["/"]
+      }
     },
 
     "production": {
@@ -131,7 +145,11 @@
       ],
 
       "routes": [{ "pattern": "aibtc.news", "custom_domain": true }],
-      "assets": { "directory": "./public" }
+      "assets": {
+        "directory": "./public",
+        "binding": "ASSETS",
+        "run_worker_first": ["/"]
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Server-renders the homepage by intercepting \`GET /\` with a Worker that transforms the static shell in-flight — **without touching the client-side SPA code**. Google, Discover, and social crawlers now see today's lead story in the initial HTML response instead of an empty shell that only becomes content after \`/api/init\` loads and the JS paints.

Users see the exact same interactive homepage they always have — the \`/api/init\` bootstrap still runs, the topnav still renders client-side, the \`?signal=:id\` deep-link bootstrap still opens the modal.

## How it works

1. \`wrangler.jsonc\` adds \`assets.binding = "ASSETS"\` and \`assets.run_worker_first = ["/"]\`. The pattern is a **literal exact match per Cloudflare docs** — only \`/\` hits the Worker first, every other asset path (sections, CSS, JS, images) keeps serving directly with zero Worker overhead.
2. New \`homeRouter\` at \`src/routes/home-page.ts\` handles \`GET /\`:
   - Pulls the static shell via \`env.ASSETS.fetch(request)\` (canonical pattern; \`html_handling\` respected — \`/\` serves \`public/index.html\`).
   - Fetches latest brief + front-page signals in parallel via \`Promise.allSettled\`.
   - Streams the asset response through \`HTMLRewriter\`, rewriting \`<title>\` / \`description\` / \`og:*\` / \`twitter:*\` content attrs with dynamic values and appending 3 JSON-LD blocks before \`</head>\`.
3. Body DOM, scripts, and placeholder divs are untouched.

## Structured data injected

- \`NewsMediaOrganization\` — signals Google we're a news publisher (more specific than bare \`Organization\`; powers Top Stories eligibility).
- \`WebSite\` — with \`publisher\` \`@id\` reference for knowledge-graph linking.
- \`ItemList\` (up to 10) — today's front-page signals as \`ListItem[]\` with \`url\` + \`name\` so Discover can resolve top stories directly from homepage markup.

## Safety model (explicit — this is the "don't break anything" part)

1. \`env.ASSETS.fetch\` wrapped in try/catch → 503 fallback. Zero infinite-loop risk because the ASSETS binding bypasses the Worker entirely (per docs).
2. Only \`2xx text/html\` responses get transformed; 404s / redirects / binary assets pass through untouched.
3. Data fetch failures pass the shell through **untouched** — SEO loses freshness but UX is untouched.
4. HTMLRewriter only targets head tags + the closing \`</head>\`. Body DOM + all scripts unchanged.
5. Explicit \`Cache-Control: public, max-age=60, s-maxage=300\` — Cloudflare does **NOT** auto-cache Worker responses (confirmed via docs), so we set this header ourselves to match the signal-page cache strategy.

## Commits (in dependency order, each green)

- \`823d653\` — \`wrangler.jsonc\`: ASSETS binding + run_worker_first
- \`d463a5f\` — \`types.ts\` + \`x402-rpc\` test fixture: adds \`ASSETS: Fetcher\` to Env (atomic for typecheck)
- \`d2e0632\` — \`src/routes/home-page.ts\`: SSR handler
- \`f6c2cbe\` — \`src/index.ts\` + \`health.test.ts\`: wire router, retire dead JSON handler, update GET / test
- \`60f1144\` — \`home-page.test.ts\`: 9 integration tests

## Test plan

- [x] Typecheck clean on all 5 commits in sequence
- [x] 9 new homepage tests pass (title/description rewrites, JSON-LD injection, scope check for /robots.txt and /signals/:id)
- [x] Full suite: 318 pass / 4 fail (same 4 pre-existing: \`identity-gate\`, \`scoring-math\`). Zero new failures.
- [x] Classifieds x402 tests pass (no intersection; homepage handler touches neither \`POST /api/classifieds\` nor any payment middleware)
- [x] \`signal-page.test.ts\` passes (13 tests) — \`/signals/:id\` not intercepted by homeRouter (literal-exact run_worker_first match)
- [x] \`seo.test.ts\` passes — \`/robots.txt\`, \`/sitemap.xml\`, \`/news-sitemap.xml\` not intercepted
- [ ] Preview verification: hit \`GET /\` on the staging URL, confirm title reflects seeded lead, confirm 3 JSON-LD blocks, confirm existing shell JS still boots
- [ ] Production verification (post-merge): hit \`https://aibtc.news/\`, check title/description rendered from real brief, validate JSON-LD in Google Rich Results Test

## What doesn't change

- The entire existing homepage SPA (4946 lines of \`public/index.html\` + \`shared.js\`) is untouched.
- \`/api/init\` still fires on load and paints the interactive surface.
- Homepage modal on signal click — unchanged.
- \`?signal=:id\` deep-link bootstrap — unchanged and verified in tests.
- Every other route — untouched.
- The Cloudflare AI Crawl Control \`/robots.txt\` rules we discussed — completely separate, not affected.

## Next after this

Phase 3: \`/agents/:addr\` + \`/beats/:slug\` as real pages with \`ProfilePage\` / \`CollectionPage\` JSON-LD, closing the \`beatLink\` TODO from PR #597.