### PR TITLE
fix(homepage): move 'as of' label to Today's Beats header

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4530,7 +4530,19 @@
         + '</a>';
       }).join('');
 
-      inner.innerHTML = '<div style="grid-column:1/-1"><div class="beat-tile-kicker">Today\'s Beats <span style="opacity:0.7;letter-spacing:0.08em">(UTC)</span></div></div>' + tileHTML;
+      // "as of Xm ago" — honest staleness indicator next to the section
+      // header. The edge cache can serve /api/init up to s-maxage old;
+      // this shows the user when the numbers inside the tiles were
+      // computed, regardless of cache age. Lives in the header (not
+      // Wire Status) because the counts it labels are in this section.
+      let kickerAgeLabel = '';
+      if (initGeneratedAt) {
+        const ageMs = Date.now() - new Date(initGeneratedAt).getTime();
+        const ageMin = Math.floor(ageMs / 60000);
+        const label = ageMin < 1 ? 'just now' : 'as of ' + ageMin + 'm ago';
+        kickerAgeLabel = ' <span style="opacity:0.6;letter-spacing:0.04em;font-weight:400;text-transform:none">· ' + label + '</span>';
+      }
+      inner.innerHTML = '<div style="grid-column:1/-1"><div class="beat-tile-kicker">Today\'s Beats <span style="opacity:0.7;letter-spacing:0.08em">(UTC)</span>' + kickerAgeLabel + '</div></div>' + tileHTML;
 
       const perHour = (hourlyCounts && typeof hourlyCounts.total === 'number') ? hourlyCounts.total : 0;
       // Initial agentsOnline placeholder — phase 2 swaps in the real number
@@ -4559,21 +4571,14 @@
       const mins = Math.floor((next - Date.now()) / 60000);
       const nextLabel = mins >= 60 ? Math.floor(mins / 60) + 'h ' + (mins % 60) + 'm' : mins + 'm';
 
-      // "Counts: Xm ago" — honest staleness indicator. The edge cache can
-      // serve /api/init up to s-maxage old; this shows the user exactly
-      // when the numbers above were computed, regardless of cache age.
-      let countsAgeLabel = 'just now';
-      if (initGeneratedAt) {
-        const ageMs = Date.now() - new Date(initGeneratedAt).getTime();
-        const ageMin = Math.floor(ageMs / 60000);
-        countsAgeLabel = ageMin < 1 ? 'just now' : ageMin + 'm ago';
-      }
+      // Staleness indicator lives on the Today's Beats kicker now (see
+      // above) — the counts label the numbers in that section, so it
+      // goes there rather than duplicating it here in Wire Status.
 
       status.innerHTML = ''
         + '<div class="wire-status-kicker">Wire Status</div>'
         + '<div class="wire-status-row"><span class="dot">●</span><span>' + agentsOnline + '</span><span class="k">agents active · 24h</span></div>'
         + '<div class="wire-status-row"><span class="dot">●</span><span>' + perHour + '</span><span class="k">signal' + (perHour === 1 ? '' : 's') + ' / hour</span></div>'
-        + '<div class="wire-status-row"><span class="dot">●</span><span>Counts:</span><span class="k">' + countsAgeLabel + '</span></div>'
         + '<div class="wire-status-row"><span class="dot">●</span><span>Next brief:</span><span class="k">' + nextLabel + '</span></div>'
         + '<div class="wire-status-row"><span class="dot">●</span><span>Last brief:</span><span class="k">' + lastBriefLabel + '</span></div>';
 


### PR DESCRIPTION
## Summary

Tiny follow-up to PR #603. User feedback: the \`Counts: Xm ago\` row in Wire Status was easy to miss — it visually belonged to Wire Status (agents / signals-per-hour) but was actually labeling the **beat-tile numbers above it**. Moved the label next to the \`Today's Beats (UTC)\` header where it unambiguously labels the counts in that section.

## Before / after

**Before** (label hidden in Wire Status):
\`\`\`
Today's Beats (UTC)           Wire Status
  AIBTC Network                 ● 85  agents active · 24h
    4 approved                  ● 0   signals / hour
    46 pending                  ● Counts: 2m ago   ← easy to miss
  ...                           ● Next brief: 12h 2m
                                ● Last brief: 2026-04-21
\`\`\`

**After** (label inline with the section it labels):
\`\`\`
Today's Beats (UTC) · as of 2m ago    ← here
  AIBTC Network
    4 approved
    46 pending
  ...
\`\`\`

Removed the now-redundant \`Counts:\` row from Wire Status. Wire Status keeps agents-active / signals-per-hour / Next brief / Last brief.

## Implementation

Single HTML/JS change in \`public/index.html\`:
- Build \`kickerAgeLabel\` from \`initGeneratedAt\` — "as of 2m ago" when known, empty when not.
- Append to the \`Today's Beats\` kicker \`innerHTML\`.
- Delete the old \`Counts:\` row from \`status.innerHTML\`.

## Test plan

- [x] Typecheck + lint clean.
- [x] Full suite: 309/313 (same 4 pre-existing).
- [ ] Preview: verify the label appears next to "Today's Beats (UTC)" header.

## Related

- Ships on top of PR #603 (generatedAt plumbing + 30-min s-maxage).