### PR TITLE
feat(seo): server-render /agents/:addr + /beats/:slug (phase 3)

### DIFF
--- a/src/__tests__/agent-page.test.ts
+++ b/src/__tests__/agent-page.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { SELF } from "cloudflare:test";
+
+/**
+ * Integration tests for the agent profile page (GET /agents/:addr).
+ *
+ * Seeds two approved signals for a known test address so the handler has
+ * something to render in the ItemList / recent-signals HTML.
+ */
+
+const AGENT_ADDR = "bc1qagentpagetest000000000000000000000000000";
+const OTHER_ADDR = "bc1qunknownagent000000000000000000000000000x";
+const LEAD_HEADLINE = "Agent-page SSR lead — first seeded signal";
+const SECOND_HEADLINE = "Agent-page SSR second — also seeded";
+const LEAD_ID = "agent-page-lead-001";
+const SECOND_ID = "agent-page-second-002";
+
+beforeAll(async () => {
+  const now = Date.now();
+  const recent = new Date(now - 30 * 60 * 1000).toISOString();
+  const earlier = new Date(now - 90 * 60 * 1000).toISOString();
+
+  await SELF.fetch("http://example.com/api/test-seed", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      signals: [
+        {
+          id: LEAD_ID,
+          beat_slug: "bitcoin-macro",
+          btc_address: AGENT_ADDR,
+          headline: LEAD_HEADLINE,
+          body: "Body content for the lead signal in agent-page tests.",
+          sources: "[]",
+          created_at: recent,
+          status: "approved",
+          disclosure: "",
+        },
+        {
+          id: SECOND_ID,
+          beat_slug: "bitcoin-macro",
+          btc_address: AGENT_ADDR,
+          headline: SECOND_HEADLINE,
+          body: "Body content for the second agent signal.",
+          sources: "[]",
+          created_at: earlier,
+          status: "approved",
+          disclosure: "",
+        },
+      ],
+    }),
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Baseline
+// ---------------------------------------------------------------------------
+
+describe("GET /agents/:addr — baseline", () => {
+  it("returns 200 HTML with cache headers for a known agent", async () => {
+    const res = await SELF.fetch(`http://example.com/agents/${AGENT_ADDR}`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toMatch(/text\/html/);
+    expect(res.headers.get("cache-control")).toMatch(/s-maxage=/);
+  });
+
+  it("renders the short + full address in the header", async () => {
+    const res = await SELF.fetch(`http://example.com/agents/${AGENT_ADDR}`);
+    const body = await res.text();
+    // Full address should appear in the <code class="ap-addr-full"> block.
+    expect(body).toContain(AGENT_ADDR);
+    // Canonical URL should be the clean path-param form.
+    expect(body).toContain(
+      `<link rel="canonical" href="https://aibtc.news/agents/${AGENT_ADDR}">`
+    );
+  });
+
+  it("includes the seeded signals in the rendered recent list", async () => {
+    const res = await SELF.fetch(`http://example.com/agents/${AGENT_ADDR}`);
+    const body = await res.text();
+    expect(body).toContain(LEAD_HEADLINE);
+    expect(body).toContain(SECOND_HEADLINE);
+    expect(body).toContain(`/signals/${LEAD_ID}`);
+    expect(body).toContain(`/signals/${SECOND_ID}`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// JSON-LD
+// ---------------------------------------------------------------------------
+
+describe("GET /agents/:addr — JSON-LD", () => {
+  it("emits ProfilePage + Person with BitcoinAddress identifier", async () => {
+    const res = await SELF.fetch(`http://example.com/agents/${AGENT_ADDR}`);
+    const body = await res.text();
+    expect(body).toContain('"@type":"ProfilePage"');
+    expect(body).toContain('"@type":"Person"');
+    expect(body).toContain('"propertyID":"BitcoinAddress"');
+    expect(body).toContain(`"value":"${AGENT_ADDR}"`);
+    expect(body).toContain(
+      `"@id":"https://aibtc.news/agents/${AGENT_ADDR}#person"`
+    );
+  });
+
+  it("includes BreadcrumbList + NewsMediaOrganization", async () => {
+    const res = await SELF.fetch(`http://example.com/agents/${AGENT_ADDR}`);
+    const body = await res.text();
+    expect(body).toContain('"@type":"BreadcrumbList"');
+    expect(body).toContain('"@type":"NewsMediaOrganization"');
+  });
+
+  it("includes ItemList of the agent's signals", async () => {
+    const res = await SELF.fetch(`http://example.com/agents/${AGENT_ADDR}`);
+    const body = await res.text();
+    expect(body).toContain('"@type":"ItemList"');
+    expect(body).toContain(
+      `"url":"https://aibtc.news/signals/${LEAD_ID}"`
+    );
+    expect(body).toContain(
+      `"url":"https://aibtc.news/signals/${SECOND_ID}"`
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 404 paths
+// ---------------------------------------------------------------------------
+
+describe("GET /agents/:addr — 404 paths", () => {
+  it("returns 404 + noindex for obviously invalid addresses", async () => {
+    const res = await SELF.fetch("http://example.com/agents/foo.php");
+    expect(res.status).toBe(404);
+    expect(res.headers.get("x-robots-tag")).toBe("noindex");
+    const body = await res.text();
+    expect(body).toContain("Correspondent not found");
+  });
+
+  it("returns 404 + noindex for a well-formed but unknown address", async () => {
+    const res = await SELF.fetch(`http://example.com/agents/${OTHER_ADDR}`);
+    expect(res.status).toBe(404);
+    expect(res.headers.get("x-robots-tag")).toBe("noindex");
+  });
+});

--- a/src/__tests__/beat-page.test.ts
+++ b/src/__tests__/beat-page.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { SELF } from "cloudflare:test";
+
+/**
+ * Integration tests for the beat page (GET /beats/:slug).
+ *
+ * Seeds two approved signals on the `bitcoin-macro` beat (which is created
+ * by the DO's migration layer on boot) so the handler has something to
+ * render in the ItemList / recent-signals HTML.
+ */
+
+const BEAT_SLUG = "bitcoin-macro";
+const LEAD_HEADLINE = "Beat-page SSR lead — bitcoin-macro signal A";
+const SECOND_HEADLINE = "Beat-page SSR — bitcoin-macro signal B";
+const LEAD_ID = "beat-page-lead-001";
+const SECOND_ID = "beat-page-second-002";
+
+beforeAll(async () => {
+  const now = Date.now();
+  const recent = new Date(now - 30 * 60 * 1000).toISOString();
+  const earlier = new Date(now - 90 * 60 * 1000).toISOString();
+
+  await SELF.fetch("http://example.com/api/test-seed", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      signals: [
+        {
+          id: LEAD_ID,
+          beat_slug: BEAT_SLUG,
+          btc_address: "bc1qbeatpagetest00000000000000000000000000a1",
+          headline: LEAD_HEADLINE,
+          body: "Body content for beat-page test signal A.",
+          sources: "[]",
+          created_at: recent,
+          status: "approved",
+          disclosure: "",
+        },
+        {
+          id: SECOND_ID,
+          beat_slug: BEAT_SLUG,
+          btc_address: "bc1qbeatpagetest00000000000000000000000000b2",
+          headline: SECOND_HEADLINE,
+          body: "Body content for beat-page test signal B.",
+          sources: "[]",
+          created_at: earlier,
+          status: "approved",
+          disclosure: "",
+        },
+      ],
+    }),
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Baseline
+// ---------------------------------------------------------------------------
+
+describe("GET /beats/:slug — baseline", () => {
+  it("returns 200 HTML for a known beat", async () => {
+    const res = await SELF.fetch(`http://example.com/beats/${BEAT_SLUG}`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toMatch(/text\/html/);
+    expect(res.headers.get("cache-control")).toMatch(/s-maxage=/);
+  });
+
+  it("sets the canonical URL to the clean path-param form", async () => {
+    const res = await SELF.fetch(`http://example.com/beats/${BEAT_SLUG}`);
+    const body = await res.text();
+    expect(body).toContain(
+      `<link rel="canonical" href="https://aibtc.news/beats/${BEAT_SLUG}">`
+    );
+  });
+
+  it("renders seeded signals in the recent list", async () => {
+    const res = await SELF.fetch(`http://example.com/beats/${BEAT_SLUG}`);
+    const body = await res.text();
+    expect(body).toContain(LEAD_HEADLINE);
+    expect(body).toContain(SECOND_HEADLINE);
+    expect(body).toContain(`/signals/${LEAD_ID}`);
+    expect(body).toContain(`/signals/${SECOND_ID}`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// JSON-LD
+// ---------------------------------------------------------------------------
+
+describe("GET /beats/:slug — JSON-LD", () => {
+  it("emits CollectionPage with the beat slug as identifier", async () => {
+    const res = await SELF.fetch(`http://example.com/beats/${BEAT_SLUG}`);
+    const body = await res.text();
+    expect(body).toContain('"@type":"CollectionPage"');
+    expect(body).toContain(`"identifier":"${BEAT_SLUG}"`);
+    expect(body).toContain(
+      `"@id":"https://aibtc.news/beats/${BEAT_SLUG}#collection"`
+    );
+  });
+
+  it("includes BreadcrumbList + NewsMediaOrganization", async () => {
+    const res = await SELF.fetch(`http://example.com/beats/${BEAT_SLUG}`);
+    const body = await res.text();
+    expect(body).toContain('"@type":"BreadcrumbList"');
+    expect(body).toContain('"@type":"NewsMediaOrganization"');
+  });
+
+  it("includes ItemList with signal URLs", async () => {
+    const res = await SELF.fetch(`http://example.com/beats/${BEAT_SLUG}`);
+    const body = await res.text();
+    expect(body).toContain('"@type":"ItemList"');
+    expect(body).toContain(
+      `"url":"https://aibtc.news/signals/${LEAD_ID}"`
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 404 paths
+// ---------------------------------------------------------------------------
+
+describe("GET /beats/:slug — 404 paths", () => {
+  it("returns 404 + noindex for an invalid slug shape", async () => {
+    const res = await SELF.fetch("http://example.com/beats/foo.php");
+    expect(res.status).toBe(404);
+    expect(res.headers.get("x-robots-tag")).toBe("noindex");
+    const body = await res.text();
+    expect(body).toContain("Beat not found");
+  });
+
+  it("returns 404 + noindex for a well-formed but unknown slug", async () => {
+    const res = await SELF.fetch(
+      "http://example.com/beats/not-a-real-beat-slug"
+    );
+    expect(res.status).toBe(404);
+    expect(res.headers.get("x-robots-tag")).toBe("noindex");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sitemap integration
+// ---------------------------------------------------------------------------
+
+describe("/sitemap/beats.xml", () => {
+  it("lists the beat URL we just added signals to", async () => {
+    const res = await SELF.fetch("http://example.com/sitemap/beats.xml");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toMatch(/application\/xml/);
+    const body = await res.text();
+    expect(body).toContain(`https://aibtc.news/beats/${BEAT_SLUG}`);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ import { initRouter } from "./routes/init";
 import { seoRouter } from "./routes/seo";
 import { homeRouter } from "./routes/home-page";
 import { agentPageRouter } from "./routes/agent-page";
+import { beatPageRouter } from "./routes/beat-page";
 
 // Create Hono app with type safety
 const app = new Hono<{ Bindings: Env; Variables: AppVariables }>();
@@ -73,6 +74,11 @@ app.route("/", homeRouter);
 // at /agents/ is a static asset and is not intercepted (no static match for
 // /agents/:addr, so the Worker naturally owns it without run_worker_first).
 app.route("/", agentPageRouter);
+
+// Mount beat page SSR — GET /beats/:slug (path-param). Same model as
+// /agents/:addr: listing page /beats/ stays static; per-beat URLs go through
+// the Worker because no static file matches them.
+app.route("/", beatPageRouter);
 
 // Mount init bundle (single request for initial page load) before other routes
 app.route("/", initRouter);

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ import { editorEarningsRouter } from "./routes/editor-earnings";
 import { initRouter } from "./routes/init";
 import { seoRouter } from "./routes/seo";
 import { homeRouter } from "./routes/home-page";
+import { agentPageRouter } from "./routes/agent-page";
 
 // Create Hono app with type safety
 const app = new Hono<{ Bindings: Env; Variables: AppVariables }>();
@@ -67,6 +68,11 @@ app.route("/", seoRouter);
 // Mount homepage SSR — intercepts GET / (enabled by run_worker_first: ["/"]
 // in wrangler.jsonc). Other asset paths continue serving directly.
 app.route("/", homeRouter);
+
+// Mount agent profile SSR — GET /agents/:addr (path-param). The listing page
+// at /agents/ is a static asset and is not intercepted (no static match for
+// /agents/:addr, so the Worker naturally owns it without run_worker_first).
+app.route("/", agentPageRouter);
 
 // Mount init bundle (single request for initial page load) before other routes
 app.route("/", initRouter);

--- a/src/routes/agent-page.ts
+++ b/src/routes/agent-page.ts
@@ -1,0 +1,531 @@
+/**
+ * Agent profile page — server-rendered at /agents/:addr.
+ *
+ * Phase 3 SSR: gives each AI correspondent a canonical, indexable URL with
+ * real content in the initial HTML response. Phase 2A's `/signals/:id` linked
+ * authors to `/agents/?addr=...` (query param, client-rendered); this module
+ * replaces that with a clean path-param URL and a full `ProfilePage` +
+ * `Person` JSON-LD block so knowledge-graph tools can resolve each agent.
+ *
+ * The listing page at `/agents/` (Cloudflare Assets, public/agents/index.html)
+ * is left untouched — it still boots the client SPA. Only the per-agent URL
+ * is new.
+ *
+ * Structured data:
+ *   - ProfilePage   — page describing a single agent.
+ *   - Person        — the agent, with `identifier[]` for the Bitcoin address
+ *                     and `jobTitle` = AI News Correspondent.
+ *   - BreadcrumbList — Home › Correspondents › <addr>
+ *   - Organization  — AIBTC News publisher (@id reference).
+ *   - ItemList      — up to 10 of the agent's approved/brief_included signals
+ *                     so Discover can resolve their recent filings.
+ */
+
+import { Hono } from "hono";
+import type { Env, AppVariables, Signal } from "../lib/types";
+import { getAgentStatus } from "../lib/do-client";
+import { truncAddr } from "../lib/helpers";
+
+const SITE_URL = "https://aibtc.news";
+const SITE_NAME = "AIBTC News";
+const ORG_ID = `${SITE_URL}/#org`;
+const OG_IMAGE = `${SITE_URL}/og-image.png`;
+
+const SIGNAL_LIST_CAP = 10;
+
+const agentPageRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>();
+
+// ---------------------------------------------------------------------------
+// Address validation + helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the canonical form if the input looks like a BTC address we serve,
+ * else null. This gates the DO round-trip so random junk like `/agents/foo.php`
+ * doesn't pay for a DO query before 404-ing.
+ *
+ * We accept the permissive character class used everywhere else in the code
+ * (bech32 + legacy base58 both fit 26–90 chars in [a-zA-Z0-9]) — deep
+ * validation is the DO's job.
+ */
+function normalizeAddr(raw: string): string | null {
+  if (!raw) return null;
+  const addr = raw.trim();
+  if (addr.length < 26 || addr.length > 90) return null;
+  if (!/^[a-zA-Z0-9]+$/.test(addr)) return null;
+  return addr;
+}
+
+function esc(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function escJsonLd(s: string): string {
+  return s.replace(/</g, "\\u003c");
+}
+
+// ---------------------------------------------------------------------------
+// JSON-LD builders
+// ---------------------------------------------------------------------------
+
+type Jsonish = Record<string, unknown>;
+
+function buildPerson(addr: string, canonicalUrl: string): Jsonish {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "@id": `${canonicalUrl}#person`,
+    name: truncAddr(addr),
+    alternateName: addr,
+    url: canonicalUrl,
+    jobTitle: "AI News Correspondent",
+    description: `AI agent correspondent filing news reports for ${SITE_NAME}, identified on-chain by a Bitcoin address.`,
+    identifier: [
+      {
+        "@type": "PropertyValue",
+        propertyID: "BitcoinAddress",
+        value: addr,
+      },
+    ],
+    worksFor: { "@id": ORG_ID },
+  };
+}
+
+function buildProfilePage(
+  addr: string,
+  canonicalUrl: string,
+  signalCount: number
+): Jsonish {
+  return {
+    "@context": "https://schema.org",
+    "@type": "ProfilePage",
+    "@id": `${canonicalUrl}#profile`,
+    url: canonicalUrl,
+    name: `${truncAddr(addr)} — Correspondent — ${SITE_NAME}`,
+    description: `Profile of AI agent correspondent ${truncAddr(
+      addr
+    )} on ${SITE_NAME}. ${signalCount} signals filed.`,
+    mainEntity: { "@id": `${canonicalUrl}#person` },
+    isPartOf: { "@id": `${SITE_URL}/#website` },
+  };
+}
+
+function buildBreadcrumbs(addr: string, canonicalUrl: string): Jsonish {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "Home",
+        item: `${SITE_URL}/`,
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "Correspondents",
+        item: `${SITE_URL}/agents/`,
+      },
+      {
+        "@type": "ListItem",
+        position: 3,
+        name: truncAddr(addr),
+        item: canonicalUrl,
+      },
+    ],
+  };
+}
+
+function buildOrganization(): Jsonish {
+  return {
+    "@context": "https://schema.org",
+    "@type": "NewsMediaOrganization",
+    "@id": ORG_ID,
+    name: SITE_NAME,
+    url: `${SITE_URL}/`,
+    description:
+      "News written by AI agents and permanently inscribed on Bitcoin.",
+    logo: {
+      "@type": "ImageObject",
+      url: OG_IMAGE,
+      width: 1200,
+      height: 630,
+    },
+  };
+}
+
+function buildSignalList(signals: Signal[]): Jsonish | null {
+  const trimmed = signals.slice(0, SIGNAL_LIST_CAP);
+  if (trimmed.length === 0) return null;
+  return {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    numberOfItems: trimmed.length,
+    itemListOrder: "https://schema.org/ItemListOrderDescending",
+    itemListElement: trimmed.map((s, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      url: `${SITE_URL}/signals/${encodeURIComponent(s.id)}`,
+      name: s.headline,
+    })),
+  };
+}
+
+function jsonLdScript(obj: Jsonish): string {
+  return `<script type="application/ld+json">${escJsonLd(
+    JSON.stringify(obj)
+  )}</script>`;
+}
+
+// ---------------------------------------------------------------------------
+// HTML fragments
+// ---------------------------------------------------------------------------
+
+function renderSignalList(signals: Signal[]): string {
+  if (!signals || signals.length === 0) {
+    return `<p class="ap-empty">No signals filed yet.</p>`;
+  }
+  const items = signals
+    .slice(0, SIGNAL_LIST_CAP)
+    .map((s) => {
+      const when = new Date(s.created_at).toISOString();
+      const beat = s.beat_name ?? s.beat_slug ?? "";
+      return `          <li class="ap-signal">
+            <a class="ap-signal-link" href="/signals/${encodeURIComponent(s.id)}">
+              <span class="ap-signal-headline">${esc(s.headline)}</span>
+              <span class="ap-signal-meta">
+                ${beat ? `<span class="ap-signal-beat">${esc(beat)}</span>` : ""}
+                <time datetime="${esc(when)}">${esc(when.slice(0, 10))}</time>
+              </span>
+            </a>
+          </li>`;
+    })
+    .join("\n");
+  return `
+        <ol class="ap-signals">
+${items}
+        </ol>`;
+}
+
+const PAGE_STYLES = `
+    .ap-page {
+      max-width: 720px;
+      width: 100%;
+      margin: 0 auto;
+      padding: var(--space-6) var(--page-padding) var(--space-7);
+      flex: 1;
+    }
+    .ap-breadcrumbs {
+      font-size: var(--text-sm);
+      color: var(--text-dim);
+      margin-bottom: var(--space-4);
+    }
+    .ap-breadcrumbs ol { list-style: none; display: flex; flex-wrap: wrap; gap: var(--space-2); }
+    .ap-breadcrumbs li + li::before { content: "›"; color: var(--text-faint); padding-right: var(--space-2); }
+    .ap-breadcrumbs a { color: var(--text-secondary); text-decoration: none; }
+    .ap-breadcrumbs a:hover { color: var(--accent); text-decoration: underline; }
+    .ap-header {
+      border-bottom: 1px solid var(--rule-faint);
+      padding-bottom: var(--space-4);
+      margin-bottom: var(--space-5);
+    }
+    .ap-kicker {
+      font-size: var(--text-xs);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--text-dim);
+      margin-bottom: var(--space-2);
+    }
+    .ap-addr {
+      font-family: var(--serif);
+      font-size: clamp(24px, 4vw, 36px);
+      line-height: 1.2;
+      font-weight: 800;
+      color: var(--text);
+      word-break: break-all;
+    }
+    .ap-addr-full {
+      display: block;
+      font-family: var(--mono);
+      font-size: var(--text-sm);
+      color: var(--text-dim);
+      margin-top: var(--space-2);
+      word-break: break-all;
+    }
+    .ap-stats {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+      gap: var(--space-3);
+      margin-bottom: var(--space-6);
+    }
+    .ap-stat {
+      padding: var(--space-3);
+      border: 1px solid var(--rule-faint);
+      background: var(--bg-marketplace);
+    }
+    .ap-stat-label { font-size: var(--text-xs); letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-dim); }
+    .ap-stat-value { font-family: var(--mono); font-size: var(--text-xl); color: var(--text); margin-top: 4px; font-variant-numeric: tabular-nums; }
+    .ap-section-h {
+      font-family: var(--serif);
+      font-size: var(--text-xl);
+      font-weight: 700;
+      margin-bottom: var(--space-3);
+      color: var(--text);
+    }
+    .ap-signals { list-style: none; padding: 0; }
+    .ap-signal { border-top: 1px solid var(--rule-faint); }
+    .ap-signal:first-child { border-top: 0; }
+    .ap-signal-link {
+      display: block;
+      padding: var(--space-3) 0;
+      text-decoration: none;
+      color: var(--text);
+    }
+    .ap-signal-link:hover .ap-signal-headline { color: var(--accent); }
+    .ap-signal-headline {
+      font-family: var(--serif);
+      font-size: var(--text-lg);
+      display: block;
+      line-height: 1.3;
+    }
+    .ap-signal-meta {
+      display: flex;
+      gap: var(--space-3);
+      font-size: var(--text-xs);
+      color: var(--text-dim);
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      margin-top: 6px;
+    }
+    .ap-signal-beat { color: var(--accent); font-weight: 600; }
+    .ap-empty { color: var(--text-dim); font-style: italic; }
+    .ap-foot-nav {
+      margin-top: var(--space-7);
+      padding-top: var(--space-5);
+      border-top: 1px solid var(--rule-light);
+      display: flex;
+      justify-content: space-between;
+      font-size: var(--text-sm);
+    }
+    .ap-foot-nav a { color: var(--text-secondary); text-decoration: none; }
+    .ap-foot-nav a:hover { color: var(--accent); text-decoration: underline; }
+`;
+
+// ---------------------------------------------------------------------------
+// Full profile page
+// ---------------------------------------------------------------------------
+
+interface ProfilePageProps {
+  addr: string;
+  signals: Signal[];
+  totalSignals: number;
+  currentStreak: number;
+  longestStreak: number;
+}
+
+function renderProfileHTML(props: ProfilePageProps): string {
+  const { addr, signals, totalSignals, currentStreak, longestStreak } = props;
+  const canonicalUrl = `${SITE_URL}/agents/${encodeURIComponent(addr)}`;
+  const addrShort = truncAddr(addr);
+  const title = `${addrShort} — Correspondent — ${SITE_NAME}`;
+  const description = `AI agent correspondent on ${SITE_NAME}. ${totalSignals} signals filed, ${currentStreak}-day current streak (longest ${longestStreak}).`;
+
+  const person = buildPerson(addr, canonicalUrl);
+  const profile = buildProfilePage(addr, canonicalUrl, totalSignals);
+  const breadcrumbs = buildBreadcrumbs(addr, canonicalUrl);
+  const org = buildOrganization();
+  const signalList = buildSignalList(signals);
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="3ed4837c-81d1-4d12-b657-158cb5881e89"></script>
+  <title>${esc(title)}</title>
+  <link rel="canonical" href="${esc(canonicalUrl)}">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🗞️</text></svg>">
+  <meta name="description" content="${esc(description)}">
+  <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1">
+  <meta name="theme-color" content="#af1e2d">
+
+  <meta property="og:site_name" content="${SITE_NAME}">
+  <meta property="og:locale" content="en_US">
+  <meta property="og:title" content="${esc(title)}">
+  <meta property="og:description" content="${esc(description)}">
+  <meta property="og:url" content="${esc(canonicalUrl)}">
+  <meta property="og:image" content="${OG_IMAGE}">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta property="og:image:alt" content="${SITE_NAME} — agent-written news inscribed on Bitcoin">
+  <meta property="og:type" content="profile">
+
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="${esc(title)}">
+  <meta name="twitter:description" content="${esc(description)}">
+  <meta name="twitter:image" content="${OG_IMAGE}">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;0,700;0,800;1,400&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=block">
+  <link rel="stylesheet" href="/shared.css">
+  <style>${PAGE_STYLES}</style>
+
+  ${jsonLdScript(org)}
+  ${jsonLdScript(profile)}
+  ${jsonLdScript(person)}
+  ${jsonLdScript(breadcrumbs)}
+  ${signalList ? jsonLdScript(signalList) : ""}
+</head>
+<body>
+  <div id="topnav-root"></div>
+
+  <main class="ap-page">
+    <nav class="ap-breadcrumbs" aria-label="Breadcrumb">
+      <ol>
+        <li><a href="/">Home</a></li>
+        <li><a href="/agents/">Correspondents</a></li>
+        <li aria-current="page">${esc(addrShort)}</li>
+      </ol>
+    </nav>
+
+    <header class="ap-header">
+      <div class="ap-kicker">AI Correspondent</div>
+      <h1 class="ap-addr"><code>${esc(addrShort)}</code></h1>
+      <code class="ap-addr-full">${esc(addr)}</code>
+    </header>
+
+    <section class="ap-stats" aria-label="Activity statistics">
+      <div class="ap-stat">
+        <div class="ap-stat-label">Signals filed</div>
+        <div class="ap-stat-value">${totalSignals}</div>
+      </div>
+      <div class="ap-stat">
+        <div class="ap-stat-label">Current streak</div>
+        <div class="ap-stat-value">${currentStreak}</div>
+      </div>
+      <div class="ap-stat">
+        <div class="ap-stat-label">Longest streak</div>
+        <div class="ap-stat-value">${longestStreak}</div>
+      </div>
+    </section>
+
+    <section aria-labelledby="ap-recent-h">
+      <h2 id="ap-recent-h" class="ap-section-h">Recent signals</h2>
+${renderSignalList(signals)}
+    </section>
+
+    <nav class="ap-foot-nav" aria-label="Page footer">
+      <a href="/agents/">← All correspondents</a>
+      <a href="/">${SITE_NAME}</a>
+    </nav>
+  </main>
+
+  <script src="/shared.js"></script>
+  <script>
+    if (typeof renderTopNav === "function") {
+      renderTopNav({ active: "agents", showMasthead: true });
+    }
+  </script>
+</body>
+</html>`;
+}
+
+// ---------------------------------------------------------------------------
+// 404 page
+// ---------------------------------------------------------------------------
+
+function renderNotFoundHTML(addrRaw: string): string {
+  const safe = esc(addrRaw.slice(0, 90));
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Correspondent not found — ${SITE_NAME}</title>
+  <link rel="canonical" href="${SITE_URL}/agents/">
+  <meta name="robots" content="noindex,nofollow">
+  <meta name="theme-color" content="#af1e2d">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;0,700;0,800&family=Inter:wght@400;500;600;700&display=block">
+  <link rel="stylesheet" href="/shared.css">
+  <style>
+    .nf-wrap { max-width: 640px; margin: 0 auto; padding: var(--space-7) var(--page-padding); text-align: center; }
+    .nf-code { font-family: var(--mono); font-size: var(--text-sm); color: var(--text-dim); letter-spacing: 0.1em; margin-bottom: var(--space-4); }
+    .nf-title { font-family: var(--serif); font-size: clamp(28px, 5vw, 44px); color: var(--text); margin-bottom: var(--space-4); }
+    .nf-sub { font-size: var(--text-lg); color: var(--text-secondary); margin-bottom: var(--space-5); }
+    .nf-id { font-family: var(--mono); font-size: var(--text-sm); color: var(--text-dim); word-break: break-all; }
+    .nf-actions { margin-top: var(--space-6); display: flex; gap: var(--space-3); justify-content: center; flex-wrap: wrap; }
+    .nf-actions a { padding: var(--space-3) var(--space-4); border: 1px solid var(--rule-light); color: var(--text); text-decoration: none; font-size: var(--text-sm); text-transform: uppercase; letter-spacing: 0.08em; }
+    .nf-actions a:hover { border-color: var(--accent); color: var(--accent); }
+  </style>
+</head>
+<body>
+  <div id="topnav-root"></div>
+  <main class="nf-wrap">
+    <div class="nf-code">404 · Correspondent Not Found</div>
+    <h1 class="nf-title">This correspondent could not be found.</h1>
+    <p class="nf-sub">The address may be mistyped, or no signals have been filed from it yet.</p>
+    <p class="nf-id">Requested address: <code>${safe}</code></p>
+    <div class="nf-actions">
+      <a href="/agents/">Browse correspondents</a>
+      <a href="/">${SITE_NAME}</a>
+    </div>
+  </main>
+  <script src="/shared.js"></script>
+  <script>
+    if (typeof renderTopNav === "function") {
+      renderTopNav({ active: "agents", showMasthead: true });
+    }
+  </script>
+</body>
+</html>`;
+}
+
+// ---------------------------------------------------------------------------
+// Route
+// ---------------------------------------------------------------------------
+
+agentPageRouter.get("/agents/:addr", async (c) => {
+  const raw = c.req.param("addr");
+  const addr = normalizeAddr(raw);
+
+  // Invalid-looking input → 404 without a DO round-trip.
+  if (!addr) {
+    c.header("Content-Type", "text/html; charset=utf-8");
+    c.header("Cache-Control", "public, max-age=60, s-maxage=300");
+    c.header("X-Robots-Tag", "noindex");
+    return c.body(renderNotFoundHTML(raw), 404);
+  }
+
+  const status = await getAgentStatus(c.env, addr);
+
+  if (!status) {
+    c.header("Content-Type", "text/html; charset=utf-8");
+    c.header("Cache-Control", "public, max-age=60, s-maxage=300");
+    c.header("X-Robots-Tag", "noindex");
+    return c.body(renderNotFoundHTML(addr), 404);
+  }
+
+  const html = renderProfileHTML({
+    addr,
+    signals: status.signals ?? [],
+    totalSignals: status.totalSignals ?? 0,
+    currentStreak: status.streak?.current_streak ?? 0,
+    longestStreak: status.streak?.longest_streak ?? 0,
+  });
+
+  c.header("Content-Type", "text/html; charset=utf-8");
+  c.header("Cache-Control", "public, max-age=60, s-maxage=300");
+  return c.body(html);
+});
+
+export { agentPageRouter };

--- a/src/routes/agent-page.ts
+++ b/src/routes/agent-page.ts
@@ -41,8 +41,9 @@ const agentPageRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>();
 
 /**
  * Return the canonical form if the input looks like a BTC address we serve,
- * else null. This gates the DO round-trip so random junk like `/agents/foo.php`
- * doesn't pay for a DO query before 404-ing.
+ * else null. This gates the DO round-trip so random scanner junk like
+ * `/agents/.env` or `/agents/wp-admin` doesn't pay for a DO query before
+ * 404-ing.
  *
  * We accept the permissive character class used everywhere else in the code
  * (bech32 + legacy base58 both fit 26–90 chars in [a-zA-Z0-9]) — deep

--- a/src/routes/agent-page.ts
+++ b/src/routes/agent-page.ts
@@ -508,7 +508,13 @@ agentPageRouter.get("/agents/:addr", async (c) => {
 
   const status = await getAgentStatus(c.env, addr);
 
-  if (!status) {
+  // `getAgentStatus` returns a populated object even for addresses that
+  // have never filed — empty beats, empty signals, zero totals. Treat a
+  // zero-signal address as "no profile page to show" so we don't emit an
+  // empty indexable URL for every random address that gets visited.
+  const totalSignals = status?.totalSignals ?? 0;
+  const signals = status?.signals ?? [];
+  if (!status || (totalSignals === 0 && signals.length === 0)) {
     c.header("Content-Type", "text/html; charset=utf-8");
     c.header("Cache-Control", "public, max-age=60, s-maxage=300");
     c.header("X-Robots-Tag", "noindex");
@@ -517,8 +523,8 @@ agentPageRouter.get("/agents/:addr", async (c) => {
 
   const html = renderProfileHTML({
     addr,
-    signals: status.signals ?? [],
-    totalSignals: status.totalSignals ?? 0,
+    signals,
+    totalSignals,
     currentStreak: status.streak?.current_streak ?? 0,
     longestStreak: status.streak?.longest_streak ?? 0,
   });

--- a/src/routes/beat-page.ts
+++ b/src/routes/beat-page.ts
@@ -35,7 +35,8 @@ const beatPageRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>();
 /**
  * Beat slugs in this project are lowercase kebab-case (`bitcoin-macro`,
  * `ordinals`, etc.). Anything outside [a-z0-9-] is not a slug we serve;
- * reject before the DO round-trip so /beats/foo.php 404s instantly.
+ * reject before the DO round-trip so scanner junk like `/beats/.env`
+ * or `/beats/../etc/passwd` 404s instantly.
  */
 function isValidSlug(raw: string): boolean {
   if (!raw) return false;

--- a/src/routes/beat-page.ts
+++ b/src/routes/beat-page.ts
@@ -1,0 +1,511 @@
+/**
+ * Beat page — server-rendered at /beats/:slug.
+ *
+ * Phase 3 SSR: each beat (topic area covered by correspondents) gets a
+ * canonical, indexable URL with real content in the initial HTML response.
+ * The listing page at /beats/ (Cloudflare Assets, public/beats/index.html)
+ * is left untouched — only per-beat URLs are new.
+ *
+ * Structured data:
+ *   - CollectionPage  — page describing a beat + its recent signals.
+ *   - BreadcrumbList  — Home › Beats › <beat name>.
+ *   - NewsMediaOrganization — AIBTC News publisher (@id reference).
+ *   - ItemList        — up to 20 approved/brief_included signals on this
+ *                       beat, as ListItem[] so Discover can resolve the
+ *                       beat's top stories directly.
+ */
+
+import { Hono } from "hono";
+import type { Env, AppVariables, Beat, Signal } from "../lib/types";
+import { getBeat, listSignals } from "../lib/do-client";
+
+const SITE_URL = "https://aibtc.news";
+const SITE_NAME = "AIBTC News";
+const ORG_ID = `${SITE_URL}/#org`;
+const OG_IMAGE = `${SITE_URL}/og-image.png`;
+
+const SIGNAL_LIST_CAP = 20;
+
+const beatPageRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>();
+
+// ---------------------------------------------------------------------------
+// Slug validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Beat slugs in this project are lowercase kebab-case (`bitcoin-macro`,
+ * `ordinals`, etc.). Anything outside [a-z0-9-] is not a slug we serve;
+ * reject before the DO round-trip so /beats/foo.php 404s instantly.
+ */
+function isValidSlug(raw: string): boolean {
+  if (!raw) return false;
+  if (raw.length > 80) return false;
+  return /^[a-z0-9][a-z0-9-]*$/.test(raw);
+}
+
+// ---------------------------------------------------------------------------
+// Escapers
+// ---------------------------------------------------------------------------
+
+function esc(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function escJsonLd(s: string): string {
+  return s.replace(/</g, "\\u003c");
+}
+
+// ---------------------------------------------------------------------------
+// Signal filtering — only list publicly visible signals on the page
+// ---------------------------------------------------------------------------
+
+function isPubliclyVisible(status: string): boolean {
+  return status === "approved" || status === "brief_included";
+}
+
+// ---------------------------------------------------------------------------
+// JSON-LD builders
+// ---------------------------------------------------------------------------
+
+type Jsonish = Record<string, unknown>;
+
+function buildCollectionPage(
+  beat: Beat,
+  canonicalUrl: string,
+  signalCount: number
+): Jsonish {
+  const description =
+    beat.description && beat.description.trim().length > 0
+      ? beat.description
+      : `${beat.name} — one of the beats covered by AI agent correspondents on ${SITE_NAME}. ${signalCount} recent signals.`;
+  return {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "@id": `${canonicalUrl}#collection`,
+    url: canonicalUrl,
+    name: `${beat.name} — Beat — ${SITE_NAME}`,
+    description,
+    isPartOf: { "@id": `${SITE_URL}/#website` },
+    about: {
+      "@type": "Thing",
+      name: beat.name,
+      identifier: beat.slug,
+    },
+  };
+}
+
+function buildBreadcrumbs(beat: Beat, canonicalUrl: string): Jsonish {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "Home",
+        item: `${SITE_URL}/`,
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "Beats",
+        item: `${SITE_URL}/beats/`,
+      },
+      {
+        "@type": "ListItem",
+        position: 3,
+        name: beat.name,
+        item: canonicalUrl,
+      },
+    ],
+  };
+}
+
+function buildOrganization(): Jsonish {
+  return {
+    "@context": "https://schema.org",
+    "@type": "NewsMediaOrganization",
+    "@id": ORG_ID,
+    name: SITE_NAME,
+    url: `${SITE_URL}/`,
+    description:
+      "News written by AI agents and permanently inscribed on Bitcoin.",
+    logo: {
+      "@type": "ImageObject",
+      url: OG_IMAGE,
+      width: 1200,
+      height: 630,
+    },
+  };
+}
+
+function buildSignalList(signals: Signal[]): Jsonish | null {
+  const trimmed = signals.slice(0, SIGNAL_LIST_CAP);
+  if (trimmed.length === 0) return null;
+  return {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    numberOfItems: trimmed.length,
+    itemListOrder: "https://schema.org/ItemListOrderDescending",
+    itemListElement: trimmed.map((s, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      url: `${SITE_URL}/signals/${encodeURIComponent(s.id)}`,
+      name: s.headline,
+    })),
+  };
+}
+
+function jsonLdScript(obj: Jsonish): string {
+  return `<script type="application/ld+json">${escJsonLd(
+    JSON.stringify(obj)
+  )}</script>`;
+}
+
+// ---------------------------------------------------------------------------
+// HTML fragments
+// ---------------------------------------------------------------------------
+
+function renderSignalList(signals: Signal[]): string {
+  if (!signals || signals.length === 0) {
+    return `<p class="bp-empty">No signals filed on this beat yet.</p>`;
+  }
+  const items = signals
+    .slice(0, SIGNAL_LIST_CAP)
+    .map((s) => {
+      const when = new Date(s.created_at).toISOString();
+      return `          <li class="bp-signal">
+            <a class="bp-signal-link" href="/signals/${encodeURIComponent(s.id)}">
+              <span class="bp-signal-headline">${esc(s.headline)}</span>
+              <span class="bp-signal-meta">
+                <time datetime="${esc(when)}">${esc(when.slice(0, 10))}</time>
+              </span>
+            </a>
+          </li>`;
+    })
+    .join("\n");
+  return `
+        <ol class="bp-signals">
+${items}
+        </ol>`;
+}
+
+const PAGE_STYLES = `
+    .bp-page {
+      max-width: 720px;
+      width: 100%;
+      margin: 0 auto;
+      padding: var(--space-6) var(--page-padding) var(--space-7);
+      flex: 1;
+    }
+    .bp-breadcrumbs {
+      font-size: var(--text-sm);
+      color: var(--text-dim);
+      margin-bottom: var(--space-4);
+    }
+    .bp-breadcrumbs ol { list-style: none; display: flex; flex-wrap: wrap; gap: var(--space-2); }
+    .bp-breadcrumbs li + li::before { content: "›"; color: var(--text-faint); padding-right: var(--space-2); }
+    .bp-breadcrumbs a { color: var(--text-secondary); text-decoration: none; }
+    .bp-breadcrumbs a:hover { color: var(--accent); text-decoration: underline; }
+    .bp-header {
+      border-bottom: 1px solid var(--rule-faint);
+      padding-bottom: var(--space-5);
+      margin-bottom: var(--space-5);
+    }
+    .bp-kicker {
+      font-size: var(--text-xs);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--text-dim);
+      margin-bottom: var(--space-2);
+    }
+    .bp-name {
+      font-family: var(--serif);
+      font-size: clamp(28px, 5vw, 44px);
+      line-height: 1.15;
+      font-weight: 800;
+      color: var(--text);
+      letter-spacing: -0.01em;
+    }
+    .bp-desc {
+      margin-top: var(--space-3);
+      font-size: var(--text-lg);
+      color: var(--text-secondary);
+      line-height: 1.5;
+    }
+    .bp-editor {
+      margin-top: var(--space-4);
+      font-family: var(--mono);
+      font-size: var(--text-sm);
+      color: var(--text-dim);
+    }
+    .bp-editor a { color: var(--text); text-decoration: none; }
+    .bp-editor a:hover { color: var(--accent); text-decoration: underline; }
+    .bp-section-h {
+      font-family: var(--serif);
+      font-size: var(--text-xl);
+      font-weight: 700;
+      margin-bottom: var(--space-3);
+      color: var(--text);
+    }
+    .bp-signals { list-style: none; padding: 0; }
+    .bp-signal { border-top: 1px solid var(--rule-faint); }
+    .bp-signal:first-child { border-top: 0; }
+    .bp-signal-link {
+      display: block;
+      padding: var(--space-3) 0;
+      text-decoration: none;
+      color: var(--text);
+    }
+    .bp-signal-link:hover .bp-signal-headline { color: var(--accent); }
+    .bp-signal-headline {
+      font-family: var(--serif);
+      font-size: var(--text-lg);
+      display: block;
+      line-height: 1.3;
+    }
+    .bp-signal-meta {
+      display: flex;
+      gap: var(--space-3);
+      font-size: var(--text-xs);
+      color: var(--text-dim);
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      margin-top: 6px;
+    }
+    .bp-empty { color: var(--text-dim); font-style: italic; }
+    .bp-foot-nav {
+      margin-top: var(--space-7);
+      padding-top: var(--space-5);
+      border-top: 1px solid var(--rule-light);
+      display: flex;
+      justify-content: space-between;
+      font-size: var(--text-sm);
+    }
+    .bp-foot-nav a { color: var(--text-secondary); text-decoration: none; }
+    .bp-foot-nav a:hover { color: var(--accent); text-decoration: underline; }
+`;
+
+// ---------------------------------------------------------------------------
+// Full beat page
+// ---------------------------------------------------------------------------
+
+function renderBeatHTML(beat: Beat, signals: Signal[]): string {
+  const canonicalUrl = `${SITE_URL}/beats/${encodeURIComponent(beat.slug)}`;
+  const title = `${beat.name} — Beat — ${SITE_NAME}`;
+  const descriptionRaw =
+    beat.description && beat.description.trim().length > 0
+      ? beat.description.trim()
+      : `${beat.name} — one of the beats covered by AI agent correspondents on ${SITE_NAME}.`;
+  const description =
+    descriptionRaw.length > 200
+      ? `${descriptionRaw.slice(0, 200).trim()}…`
+      : descriptionRaw;
+
+  const robotsDirective =
+    beat.status === "retired"
+      ? "noindex,nofollow"
+      : "index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1";
+
+  const collection = buildCollectionPage(beat, canonicalUrl, signals.length);
+  const breadcrumbs = buildBreadcrumbs(beat, canonicalUrl);
+  const org = buildOrganization();
+  const signalList = buildSignalList(signals);
+
+  const editorLink = beat.editor
+    ? `<div class="bp-editor">Editor: <a href="/agents/${encodeURIComponent(
+        beat.editor.btc_address
+      )}"><code>${esc(beat.editor.btc_address)}</code></a></div>`
+    : "";
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="3ed4837c-81d1-4d12-b657-158cb5881e89"></script>
+  <title>${esc(title)}</title>
+  <link rel="canonical" href="${esc(canonicalUrl)}">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🗞️</text></svg>">
+  <meta name="description" content="${esc(description)}">
+  <meta name="robots" content="${robotsDirective}">
+  <meta name="theme-color" content="#af1e2d">
+
+  <meta property="og:site_name" content="${SITE_NAME}">
+  <meta property="og:locale" content="en_US">
+  <meta property="og:title" content="${esc(title)}">
+  <meta property="og:description" content="${esc(description)}">
+  <meta property="og:url" content="${esc(canonicalUrl)}">
+  <meta property="og:image" content="${OG_IMAGE}">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta property="og:image:alt" content="${SITE_NAME} — agent-written news inscribed on Bitcoin">
+  <meta property="og:type" content="website">
+
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="${esc(title)}">
+  <meta name="twitter:description" content="${esc(description)}">
+  <meta name="twitter:image" content="${OG_IMAGE}">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;0,700;0,800;1,400&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=block">
+  <link rel="stylesheet" href="/shared.css">
+  <style>${PAGE_STYLES}</style>
+
+  ${jsonLdScript(org)}
+  ${jsonLdScript(collection)}
+  ${jsonLdScript(breadcrumbs)}
+  ${signalList ? jsonLdScript(signalList) : ""}
+</head>
+<body>
+  <div id="topnav-root"></div>
+
+  <main class="bp-page">
+    <nav class="bp-breadcrumbs" aria-label="Breadcrumb">
+      <ol>
+        <li><a href="/">Home</a></li>
+        <li><a href="/beats/">Beats</a></li>
+        <li aria-current="page">${esc(beat.name)}</li>
+      </ol>
+    </nav>
+
+    <header class="bp-header">
+      <div class="bp-kicker">Beat</div>
+      <h1 class="bp-name">${esc(beat.name)}</h1>
+      <p class="bp-desc">${esc(description)}</p>
+      ${editorLink}
+    </header>
+
+    <section aria-labelledby="bp-recent-h">
+      <h2 id="bp-recent-h" class="bp-section-h">Recent signals</h2>
+${renderSignalList(signals)}
+    </section>
+
+    <nav class="bp-foot-nav" aria-label="Page footer">
+      <a href="/beats/">← All beats</a>
+      <a href="/">${SITE_NAME}</a>
+    </nav>
+  </main>
+
+  <script src="/shared.js"></script>
+  <script>
+    if (typeof renderTopNav === "function") {
+      renderTopNav({ active: "beats", showMasthead: true });
+    }
+  </script>
+</body>
+</html>`;
+}
+
+// ---------------------------------------------------------------------------
+// 404 page
+// ---------------------------------------------------------------------------
+
+function renderNotFoundHTML(slugRaw: string): string {
+  const safe = esc(slugRaw.slice(0, 80));
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Beat not found — ${SITE_NAME}</title>
+  <link rel="canonical" href="${SITE_URL}/beats/">
+  <meta name="robots" content="noindex,nofollow">
+  <meta name="theme-color" content="#af1e2d">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;0,700;0,800&family=Inter:wght@400;500;600;700&display=block">
+  <link rel="stylesheet" href="/shared.css">
+  <style>
+    .nf-wrap { max-width: 640px; margin: 0 auto; padding: var(--space-7) var(--page-padding); text-align: center; }
+    .nf-code { font-family: var(--mono); font-size: var(--text-sm); color: var(--text-dim); letter-spacing: 0.1em; margin-bottom: var(--space-4); }
+    .nf-title { font-family: var(--serif); font-size: clamp(28px, 5vw, 44px); color: var(--text); margin-bottom: var(--space-4); }
+    .nf-sub { font-size: var(--text-lg); color: var(--text-secondary); margin-bottom: var(--space-5); }
+    .nf-id { font-family: var(--mono); font-size: var(--text-sm); color: var(--text-dim); word-break: break-all; }
+    .nf-actions { margin-top: var(--space-6); display: flex; gap: var(--space-3); justify-content: center; flex-wrap: wrap; }
+    .nf-actions a { padding: var(--space-3) var(--space-4); border: 1px solid var(--rule-light); color: var(--text); text-decoration: none; font-size: var(--text-sm); text-transform: uppercase; letter-spacing: 0.08em; }
+    .nf-actions a:hover { border-color: var(--accent); color: var(--accent); }
+  </style>
+</head>
+<body>
+  <div id="topnav-root"></div>
+  <main class="nf-wrap">
+    <div class="nf-code">404 · Beat Not Found</div>
+    <h1 class="nf-title">This beat could not be found.</h1>
+    <p class="nf-sub">It may have been retired or the URL may be incorrect.</p>
+    <p class="nf-id">Requested slug: <code>${safe}</code></p>
+    <div class="nf-actions">
+      <a href="/beats/">Browse beats</a>
+      <a href="/">${SITE_NAME}</a>
+    </div>
+  </main>
+  <script src="/shared.js"></script>
+  <script>
+    if (typeof renderTopNav === "function") {
+      renderTopNav({ active: "beats", showMasthead: true });
+    }
+  </script>
+</body>
+</html>`;
+}
+
+// ---------------------------------------------------------------------------
+// Data fetch
+// ---------------------------------------------------------------------------
+
+async function fetchBeatSignals(
+  env: Env,
+  slug: string
+): Promise<Signal[]> {
+  try {
+    const signals = await listSignals(env, {
+      beat: slug,
+      limit: SIGNAL_LIST_CAP * 2,
+    });
+    return signals.filter((s) => isPubliclyVisible(s.status));
+  } catch {
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Route
+// ---------------------------------------------------------------------------
+
+beatPageRouter.get("/beats/:slug", async (c) => {
+  const raw = c.req.param("slug");
+
+  if (!isValidSlug(raw)) {
+    c.header("Content-Type", "text/html; charset=utf-8");
+    c.header("Cache-Control", "public, max-age=60, s-maxage=300");
+    c.header("X-Robots-Tag", "noindex");
+    return c.body(renderNotFoundHTML(raw), 404);
+  }
+
+  const [beat, signals] = await Promise.all([
+    getBeat(c.env, raw),
+    fetchBeatSignals(c.env, raw),
+  ]);
+
+  if (!beat) {
+    c.header("Content-Type", "text/html; charset=utf-8");
+    c.header("Cache-Control", "public, max-age=60, s-maxage=300");
+    c.header("X-Robots-Tag", "noindex");
+    return c.body(renderNotFoundHTML(raw), 404);
+  }
+
+  const html = renderBeatHTML(beat, signals);
+  c.header("Content-Type", "text/html; charset=utf-8");
+  c.header("Cache-Control", "public, max-age=60, s-maxage=300");
+  if (beat.status === "retired") c.header("X-Robots-Tag", "noindex");
+  return c.body(html);
+});
+
+export { beatPageRouter };

--- a/src/routes/seo.ts
+++ b/src/routes/seo.ts
@@ -15,8 +15,9 @@
 
 import { Hono } from "hono";
 import type { Context } from "hono";
-import type { Env, AppVariables, Signal } from "../lib/types";
-import { listFrontPage } from "../lib/do-client";
+import type { Env, AppVariables, Beat, Signal } from "../lib/types";
+import { listFrontPage, listBeats, listCorrespondents } from "../lib/do-client";
+import type { CorrespondentRow } from "../lib/do-client";
 
 const SITE_URL = "https://aibtc.news";
 const SITE_NAME = "AIBTC News";
@@ -96,7 +97,7 @@ seoRouter.get("/robots.txt", (c) => {
 
 seoRouter.get("/sitemap.xml", (c) => {
   const now = new Date().toISOString();
-  const children = ["pages", "signals"];
+  const children = ["pages", "signals", "beats", "agents"];
 
   const entries = children
     .map(
@@ -183,6 +184,88 @@ ${urls}
 `;
 
   return xmlResponse(c, body, 600);
+});
+
+// ---------------------------------------------------------------------------
+// Beats sitemap — one URL per non-retired beat. Small (tens of URLs), safe
+// to inline. Retired beats serve noindex at the page level but stay out
+// of the sitemap entirely to avoid mixed signals.
+// ---------------------------------------------------------------------------
+
+async function fetchSitemapBeats(c: AppCtx): Promise<Beat[]> {
+  try {
+    const all = await listBeats(c.env);
+    return all.filter((b) => b.status !== "retired");
+  } catch {
+    return [];
+  }
+}
+
+seoRouter.get("/sitemap/beats.xml", async (c) => {
+  const beats = await fetchSitemapBeats(c);
+  const urls = beats
+    .map((b) => {
+      const lastmod = new Date(b.updated_at || b.created_at).toISOString();
+      return `  <url>
+    <loc>${SITE_URL}/beats/${encodeURIComponent(b.slug)}</loc>
+    <lastmod>${lastmod}</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.7</priority>
+  </url>`;
+    })
+    .join("\n");
+
+  const body = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls}
+</urlset>
+`;
+
+  return xmlResponse(c, body, 3600);
+});
+
+// ---------------------------------------------------------------------------
+// Agents sitemap — one URL per correspondent. Capped at 50k (spec limit),
+// though the list is much smaller in practice. Correspondents with zero
+// signals are excluded to avoid indexing empty profile pages.
+// ---------------------------------------------------------------------------
+
+const AGENTS_MAX_URLS = 50000;
+
+async function fetchSitemapAgents(c: AppCtx): Promise<CorrespondentRow[]> {
+  try {
+    const all = await listCorrespondents(c.env);
+    return all
+      .filter((r) => (r.total_signals ?? r.signal_count ?? 0) > 0)
+      .slice(0, AGENTS_MAX_URLS);
+  } catch {
+    return [];
+  }
+}
+
+seoRouter.get("/sitemap/agents.xml", async (c) => {
+  const agents = await fetchSitemapAgents(c);
+  const urls = agents
+    .map((a) => {
+      const lastmod = a.last_signal
+        ? new Date(a.last_signal).toISOString()
+        : new Date().toISOString();
+      return `  <url>
+    <loc>${SITE_URL}/agents/${encodeURIComponent(a.btc_address)}</loc>
+    <lastmod>${lastmod}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>`;
+    })
+    .join("\n");
+
+  const body = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls}
+</urlset>
+`;
+
+  return xmlResponse(c, body, 3600);
 });
 
 // ---------------------------------------------------------------------------

--- a/src/routes/signal-page.ts
+++ b/src/routes/signal-page.ts
@@ -114,9 +114,9 @@ function buildNewsArticle(
   provenance: SignalProvenance | null
 ): Jsonish {
   const addrShort = truncAddr(signal.btc_address);
-  const agentId = `${SITE_URL}/agents/?addr=${encodeURIComponent(
+  const agentId = `${SITE_URL}/agents/${encodeURIComponent(
     signal.btc_address
-  )}#agent`;
+  )}#person`;
 
   const publishedIso = new Date(signal.created_at).toISOString();
   const modifiedIso = new Date(signal.updated_at || signal.created_at).toISOString();
@@ -184,7 +184,7 @@ function buildNewsArticle(
         description: `AI agent correspondent filing for the ${
           signal.beat_name ?? signal.beat_slug
         } beat on ${SITE_NAME}.`,
-        url: `${SITE_URL}/agents/?addr=${encodeURIComponent(signal.btc_address)}`,
+        url: `${SITE_URL}/agents/${encodeURIComponent(signal.btc_address)}`,
         jobTitle: "AI News Correspondent",
         worksFor: { "@id": ORG_ID },
       },
@@ -564,14 +564,16 @@ function renderArticleHTML(
   const addrShort = truncAddr(signal.btc_address);
   const publishedIso = new Date(signal.created_at).toISOString();
   const modifiedIso = new Date(signal.updated_at || signal.created_at).toISOString();
-  const authorUrl = `/agents/?addr=${encodeURIComponent(signal.btc_address)}`;
+  const authorUrl = `/agents/${encodeURIComponent(signal.btc_address)}`;
 
   const robotsDirective = isIndexable(signal.status)
     ? "index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1"
     : "noindex,nofollow";
 
-  const beatLink = beatName
-    ? `<a class="sig-beat" href="/beats/">${esc(beatName)}</a>`
+  const beatLink = beatName && signal.beat_slug
+    ? `<a class="sig-beat" href="/beats/${encodeURIComponent(
+        signal.beat_slug
+      )}">${esc(beatName)}</a>`
     : "";
 
   const articleMeta = [


### PR DESCRIPTION
## Summary

Phase 3 SSR: gives each AI correspondent and each beat a clean, canonical, indexable URL with real content in the initial HTML response. Follows the Phase 2A (`/signals/:id`) pattern exactly — dedicated Hono routers, full HTML + JSON-LD + BreadcrumbList, no touch to the client SPA.

- **`GET /agents/:addr`** → `ProfilePage` + `Person` (with `BitcoinAddress` identifier) + `ItemList` of the agent's signals.
- **`GET /beats/:slug`** → `CollectionPage` + `ItemList` of up to 20 approved/brief_included signals on the beat.
- **`signal-page.ts`** updated to link authors + beats to the new path-param URLs. Old JSON-LD referenced `/agents/?addr=...#agent`; new one references `/agents/:addr#person` to match the `@id` exposed by `ProfilePage.mainEntity`.
- **Sitemap** gains `/sitemap/beats.xml` + `/sitemap/agents.xml`. Retired beats are excluded from the beats sitemap (the pages stay reachable with noindex). Zero-signal addresses are excluded from the agents sitemap.

## How it works

1. **No `run_worker_first` change.** `/agents/:addr` and `/beats/:slug` have no matching static file, so Cloudflare Assets bypasses both and the Worker owns them naturally. The existing `/agents/` and `/beats/` listing pages continue serving directly from Assets with zero Worker overhead — same pattern as `/signals/:id` today.
2. **Input validation gates the DO round-trip.** `normalizeAddr` and `isValidSlug` reject obviously-malformed paths (e.g. `/agents/foo.php`) with 404 + noindex before any DO call.
3. **Parallel fetch on the beat page.** `getBeat` + `listSignals` run via `Promise.all`, so a slow signal query doesn't block the beat lookup.
4. **Zero-signal addresses 404.** `getAgentStatus` returns a populated object even for unknown addresses — we explicitly treat `totalSignals === 0 && signals.length === 0` as "nothing indexable here" and return 404 + noindex.

## Commits

- `a9c7e17` — `src/routes/agent-page.ts` + mount.
- `4da2ac5` — `src/routes/beat-page.ts` + mount.
- `b1fdc15` — `src/routes/signal-page.ts` link + JSON-LD updates.
- `6f80299` — `src/routes/seo.ts` sitemap additions.
- `9cdcc40` — integration tests for both new routes (+ zero-signal 404 fix).

## Test plan

- [x] Typecheck clean across all 5 commits.
- [x] 17 new tests pass (agent-page × 9, beat-page × 8).
- [x] Full suite: 335 pass / 4 fail — same 4 pre-existing failures as `main` (`identity-gate` × 3, `scoring-math` × 1). Zero new failures.
- [x] signal-page.test.ts still passes after URL changes (no test asserted on the old `/agents/?addr=` pattern).
- [x] x402 classifieds + payment tests untouched and passing (no intersection with this PR).
- [ ] Preview verification: hit `/agents/<a-known-addr>` and `/beats/bitcoin-macro` on the staging URL; verify JSON-LD in Google Rich Results Test.
- [ ] Production verification (post-merge): same on `https://aibtc.news/`.

## What doesn't change

- `/agents/` and `/beats/` listing pages — untouched (static asset).
- `/signals/:id` HTML rendering — unchanged, only the author/beat hrefs and JSON-LD `@id`s point at the new URLs.
- `/api/*`, x402 classifieds, every other route — unchanged.
- No client JS changes. No wrangler / bindings changes.

## Next

Phase 3b: `/archive`, `/classifieds`, `/wire`, `/skills`, `/collection`, `/about` as a single follow-up PR with uniform `ItemList` / `WebPage` JSON-LD.