### PR TITLE
fix(beat-page): query signals by status directly

### DIFF
--- a/src/routes/beat-page.ts
+++ b/src/routes/beat-page.ts
@@ -465,15 +465,24 @@ async function fetchBeatSignals(
   env: Env,
   slug: string
 ): Promise<Signal[]> {
-  try {
-    const signals = await listSignals(env, {
-      beat: slug,
-      limit: SIGNAL_LIST_CAP * 2,
-    });
-    return signals.filter((s) => isPubliclyVisible(s.status));
-  } catch {
-    return [];
-  }
+  // Query by status directly — a generic `?beat=slug` query sorted by
+  // created_at DESC returns the N most-recent rows including all the
+  // in-review `submitted` signals, which would push older approved +
+  // brief_included ones out of the window and leave the beat page
+  // showing "No signals" on active beats. Two parallel status-scoped
+  // calls → merged, sorted, capped.
+  const [approvedRes, briefRes] = await Promise.allSettled([
+    listSignals(env, { beat: slug, status: "approved", limit: SIGNAL_LIST_CAP }),
+    listSignals(env, { beat: slug, status: "brief_included", limit: SIGNAL_LIST_CAP }),
+  ]);
+  const approved = approvedRes.status === "fulfilled" ? approvedRes.value : [];
+  const brief = briefRes.status === "fulfilled" ? briefRes.value : [];
+  // Defensive re-filter: `isPubliclyVisible` still runs in case the DO
+  // ever returns a status we didn't ask for.
+  return [...approved, ...brief]
+    .filter((s) => isPubliclyVisible(s.status))
+    .sort((a, b) => (a.created_at < b.created_at ? 1 : -1))
+    .slice(0, SIGNAL_LIST_CAP);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Post-merge verification of #614 surfaced a real-data bug: `/beats/bitcoin-macro` on prod rendered the "No signals filed on this beat yet" empty state, even though 10+ approved + 10+ brief_included signals exist on that beat.

**Cause:** active beats carry a backlog of unreviewed `submitted` signals. The old query asked the DO for the 40 most-recent rows on the beat (sorted by `created_at DESC`) and then filtered to `approved` + `brief_included` in-memory. On bitcoin-macro the 50 newest rows are all `submitted`, so the filter dropped everything — older approved ones were outside the window.

**Fix:** query by status directly — two parallel `status=approved` + `status=brief_included` calls, merge, sort, cap. `Promise.allSettled` keeps one failing query from blanking the whole list. The defensive `isPubliclyVisible` re-filter stays in case the DO ever returns a status we didn't ask for.

## Verify post-merge

```
curl -s https://aibtc.news/beats/bitcoin-macro | grep -c 'bp-signal"'   # was 0, expect ≥1
curl -s https://aibtc.news/beats/bitcoin-macro | grep -c 'ld+json'       # was 3, expect 4 (ItemList returns)
```

## Tests

- [x] Typecheck clean.
- [x] 9 beat-page tests pass (seed data uses `approved`, so it exercises the new `status=approved` path).
- No new tests needed — this scenario was already covered by the existing "renders seeded signals in the recent list" test; the prod bug was status-mix-specific and only surfaced against real traffic.