### PR TITLE
fix(modal): let article text fill the full modal width

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1609,6 +1609,10 @@
       color: var(--text);
       margin-bottom: var(--space-3);
       overflow-wrap: anywhere;
+      /* Drop the homepage column max-widths (e.g. .lead-content: 680px)
+         so article text fills the 90vw modal instead of hugging the left. */
+      max-width: none !important;
+      width: 100%;
     }
     .signal-modal .brief-text-headline,
     .signal-modal .column-headline,

--- a/public/shared.css
+++ b/public/shared.css
@@ -1074,6 +1074,10 @@ mark, .hl {
   color: var(--text);
   margin-bottom: var(--space-3);
   overflow-wrap: anywhere;
+  /* Drop the homepage column max-widths (e.g. .lead-content: 680px)
+     so article text fills the 90vw modal instead of hugging the left. */
+  max-width: none !important;
+  width: 100%;
 }
 .signal-modal .brief-text-headline,
 .signal-modal .column-headline,


### PR DESCRIPTION
## Summary

Follow-up to #616. The modal is 90vw now, but the article body still hugged the left ~55–65% of the card (visible in the screenshot on that PR).

**Cause:** `.lead-content` has `max-width: 680px` in the homepage CSS — right for the narrow lead column on `/`, wrong when the same DOM node is reused inside a 90vw modal.

**Fix:** add `max-width: none !important; width: 100%` to all four article-content classes (`.lead-content`, `.story-content`, `.column-content`, `.brief-text-content`) scoped inside `.signal-modal`. Applied in both `shared.css` (non-homepage pages) and the inline modal block in `index.html` (homepage) — these are duplicated copies that need to stay in sync.

The other three content classes don't carry a hard cap today, but bundling them in the same selector is cheap defense against any future narrow-column CSS leaking into the modal.

## Test plan

- Click any signal on `/` → modal opens → text wraps at the right edge of the card, not at 680px.
- Same on `/signals/`, `/archive/`, `/wire/` (which use shared.css).
- Mobile (≤640px) unchanged — that media query overrides everything with a full-screen modal anyway.

## Revert

Pure CSS, two files, four lines each. Trivial.