### PR TITLE
fix(archive): initial page size 200 → 50, load 50 per Load More

### DIFF
--- a/public/archive/index.html
+++ b/public/archive/index.html
@@ -468,11 +468,12 @@
       // reality for high-volume archives instead of ceilinging at 200.
       totalCounts: null,        // /api/signals/counts (all-time)
       timeRangeCounts: {},      // { today, week, month, quarter, all } → total
-      // Progressive loading state. The /api/signals page caps at 200 rows;
-      // loadMore() walks the offset window (max 10_000) appending pages so
-      // the user can scroll past the initial chunk.
-      pageSize: 200,
-      nextOffset: 200,
+      // Progressive loading state. Initial load is 50; loadMore() walks
+      // the offset window (max 10_000) appending pages of the same size
+      // so the user can scroll past the initial chunk on demand. The
+      // /api/signals page caps at 200 rows, so 50 is well under the cap.
+      pageSize: 50,
+      nextOffset: 50,
       hasMore: false,
       loading: false,
     };
@@ -1021,7 +1022,7 @@
       ]);
       const [beatsData, signalsData, totalCounts] = await Promise.all([
         fetchJSON('/api/beats'),
-        fetchJSON('/api/signals?limit=200'),
+        fetchJSON('/api/signals?limit=50'),
         fetchJSON('/api/signals/counts'),
       ]);
       state.allBeats = (Array.isArray(beatsData) ? beatsData : []).filter(b => (b.status || 'active').toLowerCase() !== 'retired');


### PR DESCRIPTION
## Summary

Archive page now loads 50 signals on first paint instead of 200, and each "Load More" click appends the next 50. Pagination infrastructure was already in place — just two value changes.

## Changes

- `state.pageSize: 200 → 50`
- Initial fetch: `/api/signals?limit=200` → `/api/signals?limit=50`
- Comment updated to reflect new behaviour.

## What's unchanged

- `MAX_OFFSET = 10000` cursor ceiling.
- `/api/signals` 200-row upper cap (we're well under it).
- `state.nextOffset` bootstraps from `state.allSignals.length` after the initial load, so it correctly reflects whatever the server returned.
- Filters, facet counts, search behaviour — untouched.
- `hasMore` gate still works: `next.length === state.pageSize` remains the "more pages exist" test.

## Test plan

- Open `/archive/` → stat line shows "N results" where N starts at 50 (or less, if that's the whole archive).
- Click "Load More" → list grows by 50 (or less on the final page).
- Apply a filter → search still scopes the currently-loaded signals (unchanged — filtering is in-memory on `state.allSignals`).