### PR TITLE
perf: edge-cache SSR pages + /api/signals + /api/signals/counts

### DIFF
--- a/src/lib/edge-cache.ts
+++ b/src/lib/edge-cache.ts
@@ -32,11 +32,23 @@ function buildCacheKey(c: AppContext): Request {
 }
 
 /**
+ * Is the current request running inside the test runtime?
+ * vitest-pool-workers shares `caches.default` across tests in the same file,
+ * so multiple tests hitting the same URL with different DO state would get
+ * the cached first-run response — silently masking handler regressions.
+ * Skipping cache in test keeps filter / status tests deterministic.
+ */
+function isTestEnv(c: AppContext): boolean {
+  return c.env.ENVIRONMENT === "test";
+}
+
+/**
  * Look up the current request in the edge cache. Returns the cached Response
  * (with an `X-Edge-Cache: HIT` header attached for observability) or `null`
  * on miss. Safe to call from any GET handler.
  */
 export async function edgeCacheMatch(c: AppContext): Promise<Response | null> {
+  if (isTestEnv(c)) return null;
   const cached = await caches.default.match(buildCacheKey(c));
   if (!cached) return null;
   // Clone-via-Response constructor so we can mutate the headers without
@@ -61,6 +73,7 @@ export async function edgeCacheMatch(c: AppContext): Promise<Response | null> {
  * the route originally produced it.
  */
 export function edgeCachePut(c: AppContext, response: Response): void {
+  if (isTestEnv(c)) return;
   const cacheCopy = response.clone();
   response.headers.set("X-Edge-Cache", "MISS");
   c.executionCtx.waitUntil(

--- a/src/routes/agent-page.ts
+++ b/src/routes/agent-page.ts
@@ -25,6 +25,7 @@ import { Hono } from "hono";
 import type { Env, AppVariables, Signal } from "../lib/types";
 import { getAgentStatus } from "../lib/do-client";
 import { truncAddr } from "../lib/helpers";
+import { edgeCacheMatch, edgeCachePut } from "../lib/edge-cache";
 
 const SITE_URL = "https://aibtc.news";
 const SITE_NAME = "AIBTC News";
@@ -496,6 +497,14 @@ function renderNotFoundHTML(addrRaw: string): string {
 // ---------------------------------------------------------------------------
 
 agentPageRouter.get("/agents/:addr", async (c) => {
+  // Edge-cache short-circuit. Without this, every hit went to the DO
+  // (~1-2s warm, up to 30s cold), so the first visitor to each agent
+  // URL paid the full round-trip and every subsequent visitor in the
+  // same PoP repaid it. Now subsequent hits within s-maxage=300 serve
+  // from the PoP cache with no DO call.
+  const cached = await edgeCacheMatch(c);
+  if (cached) return cached;
+
   const raw = c.req.param("addr");
   const addr = normalizeAddr(raw);
 
@@ -532,7 +541,9 @@ agentPageRouter.get("/agents/:addr", async (c) => {
 
   c.header("Content-Type", "text/html; charset=utf-8");
   c.header("Cache-Control", "public, max-age=60, s-maxage=300");
-  return c.body(html);
+  const response = c.body(html);
+  edgeCachePut(c, response);
+  return response;
 });
 
 export { agentPageRouter };

--- a/src/routes/beat-page.ts
+++ b/src/routes/beat-page.ts
@@ -18,6 +18,7 @@
 import { Hono } from "hono";
 import type { Env, AppVariables, Beat, Signal } from "../lib/types";
 import { getBeat, listSignals } from "../lib/do-client";
+import { edgeCacheMatch, edgeCachePut } from "../lib/edge-cache";
 
 const SITE_URL = "https://aibtc.news";
 const SITE_NAME = "AIBTC News";
@@ -490,6 +491,15 @@ async function fetchBeatSignals(
 // ---------------------------------------------------------------------------
 
 beatPageRouter.get("/beats/:slug", async (c) => {
+  // Edge-cache short-circuit. This route was the worst offender of
+  // the three SSR pages — it makes three DO calls per request (getBeat
+  // plus two parallel listSignals status queries). Each DO call
+  // serializes through a single isolate, so cold-DO cases compounded
+  // into the 30s+ loads we saw on real traffic. Caching the rendered
+  // HTML at the edge turns every-visitor cost into once-per-PoP cost.
+  const cached = await edgeCacheMatch(c);
+  if (cached) return cached;
+
   const raw = c.req.param("slug");
 
   if (!isValidSlug(raw)) {
@@ -515,7 +525,9 @@ beatPageRouter.get("/beats/:slug", async (c) => {
   c.header("Content-Type", "text/html; charset=utf-8");
   c.header("Cache-Control", "public, max-age=60, s-maxage=300");
   if (beat.status === "retired") c.header("X-Robots-Tag", "noindex");
-  return c.body(html);
+  const response = c.body(html);
+  edgeCachePut(c, response);
+  return response;
 });
 
 export { beatPageRouter };

--- a/src/routes/signal-counts.ts
+++ b/src/routes/signal-counts.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import type { Env, AppVariables } from "../lib/types";
 import { getSignalCounts } from "../lib/do-client";
+import { edgeCacheMatch, edgeCachePut } from "../lib/edge-cache";
 
 const signalCountsRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>();
 
@@ -8,6 +9,14 @@ const signalCountsRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>(
 // Returns counts grouped by status without fetching full signal records.
 // Supports optional filters: beat, agent, since.
 signalCountsRouter.get("/api/signals/counts", async (c) => {
+  // Edge-cache short-circuit. The archive page fires four of these in
+  // parallel (today / week / month / quarter windows) on every paint.
+  // Without a cache each window pays a DO round-trip. s-maxage=60 keeps
+  // counts fresh within a minute; cache key includes the full URL so
+  // each window + filter combo is a separate entry.
+  const cached = await edgeCacheMatch(c);
+  if (cached) return cached;
+
   const beat = c.req.query("beat");
   const agent = c.req.query("agent");
   const since = c.req.query("since");
@@ -15,7 +24,9 @@ signalCountsRouter.get("/api/signals/counts", async (c) => {
   try {
     const counts = await getSignalCounts(c.env, { beat, agent, since });
     c.header("Cache-Control", "public, max-age=30, s-maxage=60");
-    return c.json(counts);
+    const response = c.json(counts);
+    edgeCachePut(c, response);
+    return response;
   } catch (err) {
     return c.json({ ok: false, error: "Failed to fetch signal counts" }, 500);
   }

--- a/src/routes/signal-page.ts
+++ b/src/routes/signal-page.ts
@@ -21,6 +21,7 @@ import type { Env, AppVariables, Signal, Source } from "../lib/types";
 import { getSignal } from "../lib/do-client";
 import { truncAddr } from "../lib/helpers";
 import { getSignalProvenance, type SignalProvenance } from "../lib/signal-provenance";
+import { edgeCacheMatch, edgeCachePut } from "../lib/edge-cache";
 
 const SITE_URL = "https://aibtc.news";
 const SITE_NAME = "AIBTC News";
@@ -779,6 +780,13 @@ function renderNotFoundHTML(id: string): string {
 // ---------------------------------------------------------------------------
 
 signalPageRouter.get("/signals/:id", async (c) => {
+  // Edge-cache short-circuit — subsequent hits within s-maxage skip the
+  // DO round-trip(s) + HTML render entirely. Cache-Control alone does
+  // not populate the Workers cache; we have to put/match explicitly.
+  // Same pattern as /api/init and src/routes/home-page.ts.
+  const cached = await edgeCacheMatch(c);
+  if (cached) return cached;
+
   const id = c.req.param("id");
   const signal = await getSignal(c.env, id);
 
@@ -800,7 +808,9 @@ signalPageRouter.get("/signals/:id", async (c) => {
   c.header("Content-Type", "text/html; charset=utf-8");
   c.header("Cache-Control", "public, max-age=60, s-maxage=300");
   if (!isIndexable(signal.status)) c.header("X-Robots-Tag", "noindex");
-  return c.body(html);
+  const response = c.body(html);
+  edgeCachePut(c, response);
+  return response;
 });
 
 export { signalPageRouter };

--- a/src/routes/signals.ts
+++ b/src/routes/signals.ts
@@ -21,6 +21,7 @@ import {
 import { verifyAuth } from "../services/auth";
 import { checkAgentIdentity } from "../services/identity-gate";
 import { toUTCDate, resolveNamesWithTimeout } from "../lib/helpers";
+import { edgeCacheMatch, edgeCachePut } from "../lib/edge-cache";
 
 const signalsRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>();
 
@@ -43,6 +44,14 @@ const signalReadRateLimit = createRateLimitMiddleware({
 
 // GET /api/signals — list signals with optional filters
 signalsRouter.get("/api/signals", signalReadRateLimit, async (c) => {
+  // Edge-cache short-circuit. The archive page pulls 50 signals on
+  // paint and +50 per Load More — previously every page, every
+  // filter-combo, every visitor paid a fresh DO round-trip. Cache key
+  // is the full request URL so ?beat=X&status=approved and
+  // ?agent=Y&limit=50 live as separate entries.
+  const cached = await edgeCacheMatch(c);
+  if (cached) return cached;
+
   const beat = c.req.query("beat");
   const agent = c.req.query("agent");
   const tag = c.req.query("tag");
@@ -123,17 +132,22 @@ signalsRouter.get("/api/signals", signalReadRateLimit, async (c) => {
 
   c.header("Cache-Control", "public, max-age=60, s-maxage=300");
   c.header("X-Timezone", "UTC");
-  return c.json({
+  const response = c.json({
     signals: transformed,
     total: transformed.length,
     filtered: transformed.length,
     limit: resolvedLimit,
     offset: resolvedOffset,
   });
+  edgeCachePut(c, response);
+  return response;
 });
 
 // GET /api/signals/:id — get a single signal
 signalsRouter.get("/api/signals/:id", signalReadRateLimit, async (c) => {
+  const cached = await edgeCacheMatch(c);
+  if (cached) return cached;
+
   const id = c.req.param("id");
   if (!id) {
     return c.json({ error: "Signal ID is required" }, 400);
@@ -152,7 +166,7 @@ signalsRouter.get("/api/signals/:id", signalReadRateLimit, async (c) => {
   const sInfo = singleNameMap.get(s.btc_address);
 
   c.header("Cache-Control", "public, max-age=60, s-maxage=300");
-  return c.json({
+  const response = c.json({
     id: s.id,
     btcAddress: s.btc_address,
     displayName: sInfo?.name ?? null,
@@ -171,6 +185,8 @@ signalsRouter.get("/api/signals/:id", signalReadRateLimit, async (c) => {
     quality_score: s.quality_score ?? null,
     score_breakdown: s.score_breakdown ?? null,
   });
+  edgeCachePut(c, response);
+  return response;
 });
 
 // POST /api/signals — submit a new signal (rate limited, BIP-322 auth required)


### PR DESCRIPTION
## Summary — the 30s load you saw

The 30s beat page load **was not a cold start.** It was because none of the new SSR pages we've shipped — `/signals/:id`, `/agents/:addr`, `/beats/:slug` — were populating the Cloudflare Workers cache. Same for `/api/signals` and `/api/signals/counts`, which back the archive + signals listing + client-side hydration.

**Evidence (before this PR):**

```
/beats/bitcoin-macro   → 0.73–2.05s TTFB, no cf-cache-status, no x-edge-cache
/agents/:addr          → 1.19–1.81s TTFB, same
/                      → 0.44s TTFB warm, cf-cache: HIT, x-edge-cache: HIT
```

Homepage was fast because `home-page.ts` calls `edgeCacheMatch + edgeCachePut`. The others didn't. Every visitor, every request, fresh DO round-trip. Cold DO on Cloudflare can be 2–52s per the handover — no cache means every user can hit that pathological case. That's the 30s.

## Root cause (not guessing — grep'd)

```
grep edgeCacheMatch src/routes/*.ts
  home-page.ts   ✅
  signals.ts     ❌
  signal-counts  ❌
  signal-page    ❌
  agent-page     ❌
  beat-page      ❌
```

`Cache-Control` headers alone **do not** populate the Workers cache for a Worker-generated response (explicitly documented in `src/lib/edge-cache.ts`). You have to call `caches.default.put()` via the helper. The new SSR routes shipped without that call.

## Fix

Six commits, one file each, applying the standard `edgeCacheMatch + edgeCachePut` pattern that `home-page.ts` / `init.ts` / `beats.ts` / `correspondents.ts` / `classifieds.ts` already use:

1. **`signal-page.ts`** — `/signals/:id` now caches success HTML for `s-maxage=300`. 404s skip the put so freshly-approved signals aren't invisible for 5 min.
2. **`agent-page.ts`** — `/agents/:addr` same.
3. **`beat-page.ts`** — `/beats/:slug` same. Worst offender (three DO calls per request — getBeat + two status-scoped listSignals).
4. **`signals.ts`** — `/api/signals` list + `/api/signals/:id` single. Backs archive page + `/signals/` listing. Per-URL cache key means each filter combo (`?beat=X&status=approved`) is its own entry.
5. **`signal-counts.ts`** — `/api/signals/counts`. Archive page fires four of these in parallel on every paint.
6. **`edge-cache.ts`** — test-env guard. `vitest-pool-workers` shares `caches.default` across tests in the same file, so cache-sensitive tests (like `signal-counts-since`) would start failing silently. Guard added so the cache is a no-op under `ENVIRONMENT === "test"`; prod / staging / dev untouched.

## Expected impact

- First visitor to a URL in a PoP: same latency as today (builds fresh from DO).
- Every subsequent visitor in the same PoP within 5 min: **~50ms TTFB, zero DO calls**.
- Crawler bursts + social unfurls (LinkedIn/Slack hitting the same URL repeatedly): no longer DDoS the DO.

## Test plan

- [x] Typecheck clean across all 6 commits.
- [x] Full suite: 335 pass / 4 fail — same 4 pre-existing failures as `main`. Zero new.
- [ ] Preview: cold hit `/beats/bitcoin-macro` → measure TTFB. Warm hit → confirm `x-edge-cache: HIT`, sub-100ms TTFB.
- [ ] Post-merge on prod: re-run the curl timing script from the bug report — expect warm-PoP numbers to drop from ~1.5–2s to <100ms.

## Revert

Each commit is single-file. `git revert <sha>` on any individual commit is safe.