### PR TITLE
feat(news): derive paymentIdentifier from txHex for V2 RPC idempotency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -358,6 +358,19 @@
         "node": ">=12"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/runtime": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
@@ -365,6 +378,18 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "agent-news",
       "version": "1.24.0",
       "dependencies": {
-        "@aibtc/tx-schemas": "^0.5.2",
+        "@aibtc/tx-schemas": "^1.1.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "@noble/secp256k1": "^2.1.0",
@@ -28,9 +28,9 @@
       }
     },
     "node_modules/@aibtc/tx-schemas": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@aibtc/tx-schemas/-/tx-schemas-0.5.2.tgz",
-      "integrity": "sha512-/LTRJqAwsEARZuMkxT+dNVIhKF9F7Jb2HHgCNd13FX/BqIFfO5ylSwXsX8wbWc7OdLanhHJC2SRwhlclKhRQtQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@aibtc/tx-schemas/-/tx-schemas-1.1.0.tgz",
+      "integrity": "sha512-jCautY4s8xT6oYC6l5d5tR9pbKTIziyny3YFI77mcmkoCzZzw7oedARYARuw1DSyxcHpXVoRTL0VM6MlTYA3LQ==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.3.6"
@@ -358,19 +358,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/runtime": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
@@ -378,18 +365,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "vite": "8.0.5"
   },
   "dependencies": {
-    "@aibtc/tx-schemas": "^0.5.2",
+    "@aibtc/tx-schemas": "^1.1.0",
     "@noble/curves": "^2.0.1",
     "@noble/hashes": "^2.0.1",
     "@noble/secp256k1": "^2.1.0",

--- a/src/__tests__/helpers.test.ts
+++ b/src/__tests__/helpers.test.ts
@@ -8,6 +8,7 @@ import {
   generateId,
   formatUTCShort,
   toUTCDate,
+  derivePaymentIdentifier,
 } from "../lib/helpers";
 
 describe("getUTCDate", () => {
@@ -193,5 +194,37 @@ describe("toUTCDate", () => {
   it("returns a string in YYYY-MM-DD format", () => {
     const result = toUTCDate("2024-06-15T12:00:00Z");
     expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});
+
+describe("derivePaymentIdentifier", () => {
+  it("produces a pay_<28-hex-char> string", async () => {
+    const id = await derivePaymentIdentifier("bitcoin", "SP1PMPPVCMVW96FSWFV30KJQ4MNBMZ8MRWR3JWQ7", "42");
+    expect(id).toMatch(/^pay_[a-f0-9]{28}$/);
+  });
+
+  it("is deterministic for the same inputs", async () => {
+    const id1 = await derivePaymentIdentifier("bitcoin", "SP1PMPPVCMVW96FSWFV30KJQ4MNBMZ8MRWR3JWQ7", "42");
+    const id2 = await derivePaymentIdentifier("bitcoin", "SP1PMPPVCMVW96FSWFV30KJQ4MNBMZ8MRWR3JWQ7", "42");
+    expect(id1).toBe(id2);
+  });
+
+  it("produces different identifiers for different inputs", async () => {
+    const id1 = await derivePaymentIdentifier("bitcoin", "SP1PMPPVCMVW96FSWFV30KJQ4MNBMZ8MRWR3JWQ7", "42");
+    const id2 = await derivePaymentIdentifier("ethereum", "SP1PMPPVCMVW96FSWFV30KJQ4MNBMZ8MRWR3JWQ7", "42");
+    expect(id1).not.toBe(id2);
+  });
+
+  it("satisfies PaymentIdentifierSchema constraints: [a-zA-Z0-9_-]{16,128}", async () => {
+    const id = await derivePaymentIdentifier("deadbeef0123456789abcdef");
+    // pay_ (4) + 28 hex chars = 32 total
+    expect(id.length).toBe(32);
+    expect(id).toMatch(/^[a-zA-Z0-9_-]{16,128}$/);
+  });
+
+  it("works with a single long tx hex input (covers the RPC submitPayment use case)", async () => {
+    const txHex = "0".repeat(128);
+    const id = await derivePaymentIdentifier(txHex);
+    expect(id).toMatch(/^pay_[a-f0-9]{28}$/);
   });
 });

--- a/src/__tests__/x402-error-mapping.test.ts
+++ b/src/__tests__/x402-error-mapping.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from "vitest";
 import { mapVerificationError } from "../services/x402";
-import type { PaymentVerifyResult } from "../services/x402";
 
 describe("mapVerificationError", () => {
   // =========================================================================
@@ -150,6 +149,21 @@ describe("mapVerificationError", () => {
 
       expect(result.status).toBe(402);
       expect(result.body.retryable).toBe(false);
+    });
+
+    it("maps PAYMENT_IDENTIFIER_CONFLICT to 402 non-retryable client error", () => {
+      // Same identifier submitted with a different transaction: client must use a new tx.
+      const result = mapVerificationError({
+        valid: false,
+        errorCode: "PAYMENT_IDENTIFIER_CONFLICT",
+        retryable: false,
+      });
+
+      expect(result.status).toBe(402);
+      expect(result.body.code).toBe("PAYMENT_IDENTIFIER_CONFLICT");
+      expect(result.body.retryable).toBe(false);
+      // PAYMENT_IDENTIFIER_CONFLICT is not a nonce conflict — no 409 or Retry-After
+      expect(result.headers).toBeUndefined();
     });
   });
 });

--- a/src/__tests__/x402-rpc.test.ts
+++ b/src/__tests__/x402-rpc.test.ts
@@ -22,7 +22,7 @@ function makePaymentHeader(txHex = "deadbeefdeadbeef"): string {
 
 /** Build a minimal Env mock with a mocked X402_RELAY binding. */
 function makeEnv(
-  submitPayment: (txHex: string, settle?: unknown) => Promise<SubmitPaymentResult>,
+  submitPayment: (txHex: string, settle?: unknown, paymentIdentifier?: string) => Promise<SubmitPaymentResult>,
   checkPayment: (paymentId: string) => Promise<CheckPaymentResult>
 ): Env {
   return {
@@ -379,5 +379,93 @@ describe("verifyPayment — RPC path — relay errors", () => {
     expect(second.paymentId).toBe("pay_duplicate");
     expect(first.paymentStatus).toBe("pending");
     expect(second.paymentStatus).toBe("pending");
+  });
+});
+
+// =============================================================================
+// Payment identifier — V2 RPC idempotency
+// =============================================================================
+
+describe("verifyPayment — RPC path — payment identifier", () => {
+  it("passes a pay_<hex> paymentIdentifier as third arg to submitPayment", async () => {
+    vi.useFakeTimers();
+
+    const txHex = "deadbeef0123456789abcdef";
+    const submitPayment = vi.fn<Parameters<typeof makeEnv>[0]>().mockResolvedValue({
+      accepted: true,
+      paymentId: "pay_ident_001",
+      status: "queued",
+    });
+
+    const checkPayment = vi.fn<Parameters<typeof makeEnv>[1]>().mockResolvedValue({
+      paymentId: "pay_ident_001",
+      status: "confirmed",
+      txid: "d".repeat(64),
+    });
+
+    const env = makeEnv(submitPayment, checkPayment);
+    const resultPromise = verifyPayment(makePaymentHeader(txHex), 100, env);
+    await vi.runAllTimersAsync();
+    await resultPromise;
+
+    expect(submitPayment).toHaveBeenCalledOnce();
+    const [calledTxHex, _settle, calledIdentifier] = submitPayment.mock.calls[0];
+    expect(calledTxHex).toBe(txHex);
+    // Identifier must match pay_<28-hex-chars> and be deterministic for this txHex
+    expect(calledIdentifier).toMatch(/^pay_[a-f0-9]{28}$/);
+  });
+
+  it("derives the same identifier for the same txHex (deterministic across retries)", async () => {
+    vi.useFakeTimers();
+
+    const txHex = "cafebabe0000000011111111";
+    const submitPayment = vi.fn<Parameters<typeof makeEnv>[0]>().mockResolvedValue({
+      accepted: true,
+      paymentId: "pay_retry_001",
+      status: "queued",
+    });
+
+    const checkPayment = vi.fn<Parameters<typeof makeEnv>[1]>().mockResolvedValue({
+      paymentId: "pay_retry_001",
+      status: "confirmed",
+      txid: "e".repeat(64),
+    });
+
+    const env = makeEnv(submitPayment, checkPayment);
+
+    const firstPromise = verifyPayment(makePaymentHeader(txHex), 100, env);
+    await vi.runAllTimersAsync();
+    await firstPromise;
+
+    const secondPromise = verifyPayment(makePaymentHeader(txHex), 100, env);
+    await vi.runAllTimersAsync();
+    await secondPromise;
+
+    const [, , firstIdentifier] = submitPayment.mock.calls[0];
+    const [, , secondIdentifier] = submitPayment.mock.calls[1];
+    // Both calls derive the same identifier from the same txHex
+    expect(firstIdentifier).toBe(secondIdentifier);
+    expect(firstIdentifier).toMatch(/^pay_[a-f0-9]{28}$/);
+  });
+
+  it("maps PAYMENT_IDENTIFIER_CONFLICT to 402 non-retryable", async () => {
+    const submitPayment = vi.fn<Parameters<typeof makeEnv>[0]>().mockResolvedValue({
+      accepted: false,
+      code: "PAYMENT_IDENTIFIER_CONFLICT",
+      error: "Same identifier submitted with a different transaction",
+      retryable: false,
+    });
+
+    const checkPayment = vi.fn<Parameters<typeof makeEnv>[1]>();
+
+    const env = makeEnv(submitPayment, checkPayment);
+    const result = await verifyPayment(makePaymentHeader(), 100, env);
+
+    expect(result.valid).toBe(false);
+    expect(result.errorCode).toBe("PAYMENT_IDENTIFIER_CONFLICT");
+    expect(result.retryable).toBe(false);
+    // Should NOT be treated as a relay error
+    expect(result.relayError).toBeUndefined();
+    expect(checkPayment).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -43,6 +43,28 @@ export function generateId(): string {
 }
 
 /**
+ * Derive a deterministic payment identifier for x402 V2 RPC idempotency.
+ *
+ * Produces a stable `pay_<28-hex-char>` string from any combination of
+ * caller-provided inputs. Same inputs across retries → same identifier,
+ * so the relay's 5-minute idempotency window deduplicates legitimate
+ * re-submissions without confusing them with double-spends.
+ *
+ * The output satisfies PaymentIdentifierSchema: [a-zA-Z0-9_-]{16,128}.
+ * `pay_` (4) + 28 hex chars = 32 chars total.
+ *
+ * @param parts - Ordered components that uniquely identify this payment
+ *   (e.g. beatId, senderAddress, nonce or txHex)
+ */
+export async function derivePaymentIdentifier(...parts: string[]): Promise<string> {
+  const input = parts.join("|");
+  const encoded = new TextEncoder().encode(input);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", encoded);
+  const hashHex = [...new Uint8Array(hashBuffer)].map((b) => b.toString(16).padStart(2, "0")).join("");
+  return `pay_${hashHex.slice(0, 28)}`;
+}
+
+/**
  * Returns the date string for the day after the given YYYY-MM-DD string
  */
 export function getNextDate(date: string): string {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -71,11 +71,14 @@ export type PaymentTrackedState = TrackedPaymentState;
  * Defined locally since x402-sponsor-relay isn't a published package.
  * Matches the WorkerEntrypoint methods exposed by RelayRPC in x402-sponsor-relay/src/rpc.ts.
  *
- * submitPayment(txHex, settle) — enqueue a sponsored transaction, returns immediately with paymentId.
+ * submitPayment(txHex, settle, paymentIdentifier) — enqueue a sponsored transaction, returns immediately with paymentId.
+ *   paymentIdentifier is an optional caller-controlled idempotency key (pay_<28-hex-chars>).
+ *   Same identifier + same tx hex → relay returns cached paymentId (idempotent retry).
+ *   Same identifier + different tx hex → relay rejects with PAYMENT_IDENTIFIER_CONFLICT.
  * checkPayment(paymentId)      — poll for settlement result.
  */
 export interface RelayRPC {
-  submitPayment(txHex: string, settle?: SettleOptions): Promise<SubmitPaymentResult>;
+  submitPayment(txHex: string, settle?: SettleOptions, paymentIdentifier?: string): Promise<SubmitPaymentResult>;
   checkPayment(paymentId: string): Promise<CheckPaymentResult>;
 }
 

--- a/src/services/x402.ts
+++ b/src/services/x402.ts
@@ -27,6 +27,7 @@ import {
 } from "../lib/constants";
 import type { Env, RelayRPC, SettleOptions, SubmitPaymentResult, CheckPaymentResult, PaymentStatusResponse, Logger } from "../lib/types";
 import { logPaymentEvent } from "../lib/payment-logging";
+import { derivePaymentIdentifier } from "../lib/helpers";
 
 // ── In-memory circuit breaker for relay calls ──
 // Prevents cascading failures when the relay is down by fast-failing after
@@ -54,6 +55,9 @@ const RPC_ERROR_TO_TERMINAL_REASON: Partial<Record<string, PaymentTerminalReason
   TX_BROADCAST_ERROR: "broadcast_failure",
   SETTLEMENT_FAILED: "chain_abort",
   INTERNAL_ERROR: "internal_error",
+  // Idempotency key conflict: same identifier submitted with a different transaction.
+  // Non-retryable client error — the caller must use a new transaction or identifier.
+  PAYMENT_IDENTIFIER_CONFLICT: "unknown_payment_identity",
 };
 
 function shouldFastFail(): boolean {
@@ -451,11 +455,15 @@ export async function verifyPayment(
       minAmount: paymentRequirements.amount,
     };
 
+    // Derive a deterministic idempotency key from the transaction hex.
+    // Same tx resubmitted on retry → same identifier → relay returns cached paymentId.
+    const paymentIdentifier = await derivePaymentIdentifier(txHex);
+
     // Step 1: Submit the payment to the relay queue.
     let submitResult: SubmitPaymentResult;
     try {
       console.log("[x402] using RPC path via X402_RELAY service binding");
-      submitResult = parseSubmitPaymentResult(await env.X402_RELAY.submitPayment(txHex, settle));
+      submitResult = parseSubmitPaymentResult(await env.X402_RELAY.submitPayment(txHex, settle, paymentIdentifier));
     } catch (err) {
       // RPC call failure is a relay error — do not penalise the payer
       console.error("[x402] RPC submitPayment threw:", err);


### PR DESCRIPTION
## Summary

- Derives a deterministic `paymentIdentifier` from the transaction hex using Web Crypto SHA-256, producing `pay_<28-hex-chars>` per `PaymentIdentifierSchema`
- Passes the identifier as the third arg to `X402_RELAY.submitPayment(txHex, settle, paymentIdentifier)` — same tx on retry → same identifier → relay returns cached `paymentId` idempotently
- Maps `PAYMENT_IDENTIFIER_CONFLICT` to a non-retryable 402 (client error, no Retry-After header)
- Bumps `@aibtc/tx-schemas` to `^1.1.0` (ships `RpcSubmitPaymentRequestSchema.paymentIdentifier` and `PAYMENT_IDENTIFIER_CONFLICT` error code)

## Context

Closes #624. Brings agent-news RPC path to canonical x402 V2 idempotency parity — the same contract already live in:
- [aibtcdev/x402-sponsor-relay#355](https://github.com/aibtcdev/x402-sponsor-relay/pull/355) — relay routes RPC `submitPayment` through `PaymentIdService`
- [aibtcdev/tx-schemas#29](https://github.com/aibtcdev/tx-schemas/pull/29) — `RpcSubmitPaymentRequestSchema.paymentIdentifier` field + `PAYMENT_IDENTIFIER_CONFLICT` error code (shipped as tx-schemas 1.1.0)

### Deterministic key composition

```ts
// In src/lib/helpers.ts — derivePaymentIdentifier(txHex)
const input = txHex;  // same tx on retry → same identifier
const hashHex = sha256hex(input);
return `pay_${hashHex.slice(0, 28)}`;  // 32 chars, satisfies [a-zA-Z0-9_-]{16,128}
```

The identifier is derived from `txHex` alone (extracted from the payment header inside `verifyPayment()`). The same pre-signed transaction resubmitted on network timeout produces an identical identifier, allowing the relay to return the cached `paymentId` without duplicate nonce consumption.

## Test plan

- [x] `derivePaymentIdentifier` is deterministic for the same inputs
- [x] `derivePaymentIdentifier` produces different outputs for different inputs
- [x] Identifier matches `^pay_[a-f0-9]{28}$` (satisfies `PaymentIdentifierSchema`)
- [x] `submitPayment` receives the derived identifier as third arg (mock-verified)
- [x] Retry with the same txHex produces the same identifier (determinism across calls)
- [x] `PAYMENT_IDENTIFIER_CONFLICT` maps to 402 non-retryable with no Retry-After
- [x] All existing x402-rpc, x402-error-mapping, and helpers tests still pass (60 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)