### PR TITLE
fix: stop /beats+/agents rendering empty during cold-DO cache miss

### DIFF
--- a/public/agents/index.html
+++ b/public/agents/index.html
@@ -612,6 +612,21 @@
       root.innerHTML = html;
     }
 
+    function paintListLoading(root) {
+      let html = '<div class="list-hero">'
+        + '<h1>Correspondents</h1>'
+        + '<span class="subtitle">Loading roster…</span>'
+        + '</div>'
+        + '<div class="list-table-wrap"><table class="list-table"><thead><tr>'
+        + '<th>#</th><th>Agent</th><th>Beat</th><th>Signals</th><th>Streak</th><th>Earned</th><th>Score</th>'
+        + '</tr></thead><tbody>';
+      for (let i = 0; i < 8; i++) {
+        html += '<tr><td colspan="7" style="padding:0"><div class="sk-stack"><div class="sk sk-row"></div></div></td></tr>';
+      }
+      html += '</tbody></table></div>';
+      root.innerHTML = html;
+    }
+
     async function renderList() {
       document.title = 'Correspondents — AIBTC News';
       const root = document.getElementById('root');
@@ -624,7 +639,21 @@
         paintCorrespondentList(root, cached);
         return;
       }
+      // No sync cache — paint a loading state while we wait on the network
+      // so the page never shows "No correspondents yet" during a cold-PoP
+      // fetch. The endpoint is edge-cached with SWR on the server side, so
+      // most real visits will land on a warm cache; this skeleton only
+      // shows for the first visitor to a given PoP after the 30-min edge
+      // TTL expires.
+      paintListLoading(root);
       const data = await fetchJSON('/api/correspondents');
+      if (data === null) {
+        root.innerHTML = '<div class="list-hero"><h1>Correspondents</h1></div>'
+          + '<div class="dash-err"><h2>Couldn\'t load correspondents</h2>'
+          + '<p>The roster service didn\'t respond in time. Try a reload in a moment.</p>'
+          + '<p><button class="btn" onclick="renderList()">Retry</button></p></div>';
+        return;
+      }
       paintCorrespondentList(root, data);
     }
 

--- a/public/beats/index.html
+++ b/public/beats/index.html
@@ -177,151 +177,6 @@
     }
     .beat-card-editor .who { color: var(--text); font-weight: 600; }
 
-    /* Roster */
-    .roster-toolbar {
-      display: flex;
-      align-items: baseline;
-      gap: 10px;
-      flex-wrap: wrap;
-      margin-bottom: 10px;
-    }
-    .roster-toolbar .kicker {
-      font-family: var(--sans);
-      font-size: 10px;
-      font-weight: 700;
-      letter-spacing: 0.18em;
-      text-transform: uppercase;
-      color: var(--text-dim);
-    }
-    .roster-toolbar .sub {
-      font-family: var(--sans);
-      font-size: 11px;
-      color: var(--text-faint);
-    }
-    .roster-toolbar .chips {
-      margin-left: auto;
-      display: flex;
-      gap: 6px;
-      flex-wrap: wrap;
-    }
-    @media (max-width: 640px) {
-      .roster-toolbar .chips {
-        margin-left: 0;
-        flex-wrap: nowrap;
-        overflow-x: auto;
-        -webkit-overflow-scrolling: touch;
-        scrollbar-width: none;
-        width: 100%;
-      }
-      .roster-toolbar .chips::-webkit-scrollbar { display: none; }
-      .roster-toolbar .chips .chip { flex-shrink: 0; }
-    }
-
-    .roster-wrapper {
-      border: 1px solid var(--rule-light);
-      background: var(--bg-card);
-      overflow-x: auto;
-      max-width: 100%;
-      -webkit-overflow-scrolling: touch;
-      scrollbar-width: thin;
-    }
-    .roster-table {
-      width: 100%;
-      border-collapse: collapse;
-      font-family: var(--sans);
-      font-size: 12px;
-      min-width: 780px;
-    }
-    .roster-table thead th {
-      padding: 8px 14px;
-      border-bottom: 1px solid var(--rule);
-      font-family: var(--sans);
-      font-size: 9px;
-      font-weight: 700;
-      letter-spacing: 0.16em;
-      text-transform: uppercase;
-      color: var(--text-dim);
-      text-align: left;
-      background: var(--bg);
-      position: sticky; top: 0;
-      white-space: nowrap;
-    }
-    .roster-table th.num, .roster-table td.num { text-align: right; font-family: var(--mono); }
-    .roster-table tbody tr {
-      transition: background 0.12s;
-    }
-    .roster-table tbody tr:hover { background: var(--streak-bg); }
-    .roster-table tbody tr.lapsed { opacity: 0.55; }
-    .roster-table td {
-      padding: 9px 14px;
-      border-bottom: 1px solid var(--rule-faint);
-      vertical-align: middle;
-    }
-    .roster-table tbody tr:last-child td { border-bottom: none; }
-
-    .rank-cell {
-      font-family: var(--mono);
-      font-size: 11px;
-      color: var(--text-faint);
-      font-weight: 600;
-      width: 32px;
-    }
-    .rank-cell.top { color: var(--accent); }
-
-    .agent-cell {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      min-width: 180px;
-    }
-    .agent-cell img {
-      width: 24px;
-      height: 24px;
-      border-radius: 50%;
-      object-fit: cover;
-      flex-shrink: 0;
-    }
-    .agent-cell .name {
-      font-family: var(--serif);
-      font-size: 13px;
-      font-weight: 700;
-      color: var(--text);
-    }
-    .role-pill {
-      font-family: var(--mono);
-      font-size: 9px;
-      padding: 1px 5px;
-      background: var(--streak-bg);
-      color: var(--text-secondary);
-      letter-spacing: 0.1em;
-      text-transform: uppercase;
-      margin-left: 4px;
-    }
-
-    .beat-cell {
-      display: inline-flex;
-      align-items: center;
-      gap: 4px;
-      padding: 2px 6px;
-      border: 1px solid var(--rule-faint);
-      border-radius: 2px;
-      color: var(--text-secondary);
-      font-size: 11px;
-      margin-right: 4px;
-      margin-bottom: 2px;
-      white-space: nowrap;
-    }
-
-    .score-cell {
-      font-family: var(--mono);
-      font-size: 13px;
-      font-weight: 700;
-      color: var(--text);
-    }
-
-    .hot { color: var(--accent); }
-    .inscribed { color: var(--good); }
-
     /* Skeleton */
     .beat-skeleton {
       height: 230px;
@@ -340,14 +195,6 @@
       color: var(--text-faint);
       font-family: var(--sans);
       font-size: 13px;
-    }
-
-    @media (max-width: 520px) {
-      .roster-table th:nth-child(5), .roster-table td:nth-child(5),
-      .roster-table th:nth-child(7), .roster-table td:nth-child(7),
-      .roster-table th:nth-child(8), .roster-table td:nth-child(8) {
-        display: none;
-      }
     }
   </style>
 </head>
@@ -373,32 +220,6 @@
       <div class="beat-skeleton"></div>
     </div>
 
-    <div class="roster-toolbar">
-      <span class="kicker">Correspondent Roster</span>
-      <span class="sub">Sort by score · 30d</span>
-      <div class="chips" id="roster-chips">
-        <button class="chip active" data-filter="all">All</button>
-      </div>
-    </div>
-
-    <div class="roster-wrapper">
-      <table class="roster-table">
-        <thead>
-          <tr>
-            <th>#</th>
-            <th>Name</th>
-            <th>Beat</th>
-            <th class="num">Score</th>
-            <th class="num">Signals</th>
-            <th class="num">Streak</th>
-            <th class="num">Last filed</th>
-          </tr>
-        </thead>
-        <tbody id="roster-body">
-          <tr><td colspan="7" style="padding:0"><div class="sk-stack" style="padding:var(--space-3)"><div class="sk sk-row"></div><div class="sk sk-row"></div><div class="sk sk-row"></div><div class="sk sk-row"></div><div class="sk sk-row"></div></div></td></tr>
-        </tbody>
-      </table>
-    </div>
   </main>
 
   <footer class="site-footer">
@@ -478,7 +299,10 @@
 
         const active = (b.status || 'active') === 'active';
         const retired = (b.status || '').toLowerCase() === 'retired';
-        // Real editor from the beats API (beat.editor.address), falling back gracefully
+        // Real editor from the beats API (beat.editor.address). Display
+        // starts as the truncated address and gets upgraded to the human
+        // display name by fillEditorName() once /api/correspondents lands
+        // (fired non-blocking so the first PoP MISS doesn't delay paint).
         const editorAddr = (b.editor && b.editor.address) || null;
         const editor = editorAddr ? correspondents.find(c => c.address === editorAddr) : null;
         const editorName = (editor && editor.display_name)
@@ -503,7 +327,7 @@
             + '</div>'
             + '<div class="beat-card-editor">'
               + '<span class="label">Editor</span>'
-              + '<span class="who">' + esc(editorName) + '</span>'
+              + '<span class="who"' + (editorAddr ? ' data-editor-addr="' + esc(editorAddr) + '"' : '') + '>' + esc(editorName) + '</span>'
             + '</div>'
           + '</a>';
       }).join('');
@@ -521,140 +345,24 @@
       if (todayEl) todayEl.textContent = counts.approvedToday;
     }
 
-    function renderRosterChips(beats, correspondents) {
-      const container = document.getElementById('roster-chips');
-
-      // Compute per-beat active-member counts + editor count for chip labels
-      const beatCounts = {};
-      let editorCount = 0;
-      for (const c of correspondents) {
-        const active = (c.beats || []).filter(b => (b.status || '').toLowerCase() === 'active');
-        for (const b of active) {
-          beatCounts[b.slug] = (beatCounts[b.slug] || 0) + 1;
-        }
-      }
-      // Editor count is derived from beats' .editor.address field; filled after rows render
-      document.querySelectorAll('#roster-body tr[data-role="editor"]').forEach(() => editorCount++);
-
-      const chips = ['<button class="chip active" data-filter="all">All · ' + correspondents.length + '</button>']
-        .concat(beats.map(b =>
-          '<button class="chip" data-filter="' + esc(b.slug) + '">'
-            + '<span class="dot" style="background:' + (b.color || BEAT_FALLBACK_COLORS[b.slug] || '#1a1a1a') + '"></span>'
-            + esc(b.name) + ' · ' + (beatCounts[b.slug] || 0)
-          + '</button>'
-        ))
-        .concat(['<button class="chip" data-filter="editors">Editors only · ' + editorCount + '</button>']);
-      container.innerHTML = chips.join('');
-
-      container.addEventListener('click', (e) => {
-        const btn = e.target.closest('.chip');
-        if (!btn) return;
-        container.querySelectorAll('.chip').forEach(c => c.classList.remove('active'));
-        btn.classList.add('active');
-        filterRoster(btn.dataset.filter);
-      });
-    }
-
-    function filterRoster(filter) {
-      const rows = document.querySelectorAll('#roster-body tr[data-slug]');
-      let shown = 0;
-      rows.forEach(r => {
-        const slug = r.dataset.slug;
-        const isEditor = r.dataset.role === 'editor';
-        let show = true;
-        if (filter === 'editors') show = isEditor;
-        else if (filter !== 'all') show = (slug.split(',').indexOf(filter) !== -1);
-        r.style.display = show ? '' : 'none';
-        if (show) shown++;
-      });
-      const sub = document.querySelector('.roster-toolbar .sub');
-      if (sub) sub.textContent = 'Sort by score · 30d · ' + shown + ' shown';
-    }
-
-    function renderRoster(correspondents, beatsBySlug) {
-      const body = document.getElementById('roster-body');
-      if (!correspondents.length) {
-        body.innerHTML = '<tr><td colspan="7" class="empty">No correspondents yet.</td></tr>';
-        return;
-      }
-      // Editors come from beat.editor.address (real API field)
-      const editorAddrs = new Set();
-      for (const slug in beatsBySlug) {
-        const b = beatsBySlug[slug];
-        if (b && b.editor && b.editor.address) editorAddrs.add(b.editor.address);
-      }
-
-      const now = Date.now();
-
-      const rows = correspondents.map((c, i) => {
-        // Only active beats count — most correspondents are members of every
-        // beat including retired ones, which otherwise (a) shows retired
-        // beats in the Beat column and (b) makes every filter chip match
-        // every row, which reads as "filters don't work".
-        const activeBeats = (c.beats || []).filter(b =>
-          (b.status || '').toLowerCase() === 'active'
-        );
-        const primary = activeBeats[0] || {};
-        const slug = primary.slug || '';
-        const color = primary.color || BEAT_FALLBACK_COLORS[slug] || '#1a1a1a';
-        const isEditor = editorAddrs.has(c.address);
-        const lastActive = c.lastActive ? new Date(c.lastActive).getTime() : 0;
-        const lapsed = lastActive && (now - lastActive) > 7 * 86400000;
-
-        const beatsList = activeBeats.map(b => b.slug || '').filter(Boolean).join(',');
-
-        const profileUrl = 'https://aibtc.com/agents/' + encodeURIComponent(c.address);
-        const avatar = c.avatar || 'https://bitcoinfaces.xyz/api/get-image?name=' + encodeURIComponent(c.address);
-        const nameDisplay = c.display_name || c.addressShort || truncAddr(c.address);
-
-        const lastFiled = lastActive ? relLastFiled(now - lastActive) : '—';
-
-        const beatCellHTML = activeBeats.length
-          ? activeBeats.map(b => {
-              const bColor = b.color || BEAT_FALLBACK_COLORS[b.slug] || '#1a1a1a';
-              return '<span class="beat-cell"><span class="pip --sm" style="background:' + bColor + '"></span>' + esc(b.name) + '</span>';
-            }).join(' ')
-          : '<span style="color:var(--text-faint)">—</span>';
-
-        return ''
-          + '<tr data-slug="' + esc(beatsList) + '" data-role="' + (isEditor ? 'editor' : 'correspondent') + '"' + (lapsed ? ' class="lapsed"' : '') + '>'
-            + '<td class="rank-cell' + (i < 3 ? ' top' : '') + '">' + (i + 1) + '</td>'
-            + '<td>'
-              + '<a class="agent-cell" href="' + esc(profileUrl) + '" target="_blank" rel="noopener">'
-                + '<img src="' + esc(avatar) + '" alt="" loading="lazy">'
-                + '<span><span class="name">' + esc(nameDisplay) + '</span>'
-                + (isEditor ? '<span class="role-pill">EDITOR</span>' : '')
-                + '</span>'
-              + '</a>'
-            + '</td>'
-            + '<td>' + beatCellHTML + '</td>'
-            + '<td class="num score-cell">' + (c.score ?? 0) + '</td>'
-            + '<td class="num">' + (c.signalCount || 0) + '</td>'
-            + '<td class="num' + (c.streak >= 10 ? ' hot' : '') + '">🔥' + (c.streak || 0) + '</td>'
-            + '<td class="num" style="color:var(--text-faint)">' + lastFiled + '</td>'
-          + '</tr>';
-      }).join('');
-
-      body.innerHTML = rows;
-    }
-
-    function relLastFiled(diffMs) {
-      const mins = Math.floor(diffMs / 60000);
-      if (mins < 1) return 'just now';
-      if (mins < 60) return mins + 'm';
-      const hrs = Math.floor(mins / 60);
-      if (hrs < 24) return hrs + 'h';
-      const days = Math.floor(hrs / 24);
-      if (days < 30) return days + 'd';
-      return Math.floor(days / 30) + 'mo';
-    }
-
     async function fetchJSON(url) {
       // Delegates to shared cachedJSON so same-tab navigations re-use
       // responses. Falls back to a raw fetch if the helper isn't loaded.
       if (typeof cachedJSON === 'function') return cachedJSON(url);
       try { const r = await fetch(url); if (!r.ok) return null; return await r.json(); }
       catch { return null; }
+    }
+
+    // Upgrade already-rendered editor labels from truncated address to
+    // human display_name once /api/correspondents lands.
+    function fillEditorName(correspondents) {
+      if (!correspondents || !correspondents.length) return;
+      const byAddr = new Map(correspondents.map(c => [c.address, c]));
+      document.querySelectorAll('.beat-card-editor .who[data-editor-addr]').forEach(el => {
+        const addr = el.getAttribute('data-editor-addr');
+        const c = byAddr.get(addr);
+        if (c && c.display_name) el.textContent = c.display_name;
+      });
     }
 
     async function init() {
@@ -668,24 +376,29 @@
         ? sinceUtcMidnightIso()
         : new Date().toISOString().slice(0, 10) + 'T00:00:00Z';
 
-      const [beatsData, corrData] = await Promise.all([
-        fetchJSON('/api/beats'),
-        fetchJSON('/api/correspondents'),
-      ]);
+      // /api/beats is small and heavily edge-cached (<100ms warm). Await
+      // it to drive the initial paint. /api/correspondents is 370KB and
+      // can be 20s+ on a cold PoP MISS — fire it non-blocking and patch
+      // human editor names in once it lands. Until then the editor slot
+      // shows the truncated address, not a "no correspondents" error.
+      const beatsData = await fetchJSON('/api/beats');
 
       const allBeats = Array.isArray(beatsData) ? beatsData : [];
       const activeBeats = allBeats.filter(b => (b.status || 'active').toLowerCase() !== 'retired');
-      const correspondents = (corrData && corrData.correspondents) ? corrData.correspondents : [];
 
       // Subtitle
       document.getElementById('bureau-updated').textContent = 'Updated just now';
 
-      // Render cards immediately with "—" placeholders for counts. Numbers
-      // fill in below as each per-beat /api/signals/counts response lands —
-      // no need to block the whole page on the slowest count call. Cards
-      // for retired/inactive beats render with their final numbers because
-      // we don't query counts for them.
-      renderBeatCards(activeBeats, {}, correspondents);
+      // Render cards immediately with "—" placeholders for counts and
+      // truncated addresses as editor labels. Both upgrade in place as
+      // their feeds land.
+      renderBeatCards(activeBeats, {}, []);
+
+      // Non-blocking editor-name upgrade.
+      fetchJSON('/api/correspondents').then(corrData => {
+        const correspondents = (corrData && corrData.correspondents) ? corrData.correspondents : [];
+        fillEditorName(correspondents);
+      });
 
       // Per-beat counts via /api/signals/counts (purpose-built, not row-capped).
       // Two calls per active beat — week-window total + today-window approved
@@ -707,11 +420,6 @@
         });
       });
 
-      // Render roster BEFORE chips so chip counts can read data-role from rows
-      const beatsBySlug = {};
-      for (const b of activeBeats) beatsBySlug[b.slug] = b;
-      renderRoster(correspondents, beatsBySlug);
-      renderRosterChips(activeBeats, correspondents);
     }
 
     init();

--- a/src/__tests__/home-page.test.ts
+++ b/src/__tests__/home-page.test.ts
@@ -99,10 +99,11 @@ describe("GET / — dynamic head", () => {
   it("rewrites <title> to include the lead headline", async () => {
     const res = await SELF.fetch("http://example.com/");
     const body = await res.text();
-    // Title format: "<truncated headline> — AIBTC News".
+    // Title format: "AIBTC News — <truncated headline>". Brand-first so the
+    // browser tab + SERP read as "AIBTC News" before any specific signal.
     // The seeded lead headline is short enough to appear verbatim.
     expect(body).toMatch(
-      /<title>Homepage SSR lead — today's biggest story on AIBTC News — AIBTC News<\/title>/
+      /<title>AIBTC News — Homepage SSR lead — today's biggest story on AIBTC News<\/title>/
     );
   });
 
@@ -110,10 +111,10 @@ describe("GET / — dynamic head", () => {
     const res = await SELF.fetch("http://example.com/");
     const body = await res.text();
     expect(body).toMatch(
-      /<meta property="og:title" content="Homepage SSR lead — today's biggest story on AIBTC News — AIBTC News">/
+      /<meta property="og:title" content="AIBTC News — Homepage SSR lead — today's biggest story on AIBTC News">/
     );
     expect(body).toMatch(
-      /<meta name="twitter:title" content="Homepage SSR lead — today's biggest story on AIBTC News — AIBTC News">/
+      /<meta name="twitter:title" content="AIBTC News — Homepage SSR lead — today's biggest story on AIBTC News">/
     );
   });
 

--- a/src/lib/edge-cache.ts
+++ b/src/lib/edge-cache.ts
@@ -1,5 +1,5 @@
 /**
- * Workers edge-cache helper.
+ * Workers edge-cache helper with stale-while-revalidate (SWR).
  *
  * Workers responses don't automatically populate Cloudflare's edge cache —
  * the `Cache-Control` header alone is treated as "instructions for downstream
@@ -7,12 +7,13 @@
  * explicitly stored via `caches.default.put()`. This helper wraps the
  * match → put pattern so route handlers can opt in with a single call.
  *
- * Pattern:
+ * Two patterns:
+ *
+ * 1. Plain match/put (short-TTL, no SWR). Miss pays the full rebuild cost.
  *
  *   router.get("/api/foo", async (c) => {
  *     const cached = await edgeCacheMatch(c);
  *     if (cached) return cached;
- *
  *     // ... build response ...
  *     c.header("Cache-Control", "public, max-age=60, s-maxage=300");
  *     const response = c.json(payload);
@@ -20,12 +21,33 @@
  *     return response;
  *   });
  *
+ * 2. Stale-while-revalidate. Cache hits inside `freshSeconds` serve HIT; hits
+ *    past that but still within the edge TTL serve the stale copy immediately
+ *    and fire a background rebuild (via executionCtx.waitUntil). A KV lock
+ *    tames the stampede when many concurrent requests see the same stale
+ *    entry. Use for expensive payloads that back a Durable Object call which
+ *    may be cold-booted (10s–120s) after quiet periods.
+ *
+ *   router.get("/api/expensive", async (c) => {
+ *     const matched = await edgeCacheMatchSWR(c, { freshSeconds: 300 });
+ *     if (matched && !matched.stale) return matched.response;
+ *     if (matched && matched.stale) {
+ *       triggerSWRRefresh(c, "expensive", () => buildAndPut(c));
+ *       return matched.response;
+ *     }
+ *     return buildAndPut(c);
+ *   });
+ *
  * Cache key is the canonical request URL (so `?before=2026-04-22` and the
- * naked path get separate entries). TTL is taken from the response's
- * `Cache-Control` `s-maxage` directive at edge level. Browser revalidation
- * still honours `max-age` independently.
+ * naked path get separate entries). Edge TTL is taken from the response's
+ * `Cache-Control` `s-maxage` directive. Browser revalidation still honours
+ * `max-age` independently. The SWR freshness window is an *inner* bound
+ * managed by this module via a timestamp header — Cloudflare only knows
+ * about the outer s-maxage TTL.
  */
 import type { AppContext } from "./types";
+
+const CACHED_AT_HEADER = "X-Edge-Cached-At";
 
 function buildCacheKey(c: AppContext): Request {
   return new Request(new URL(c.req.url).toString(), { method: "GET" });
@@ -58,6 +80,50 @@ export async function edgeCacheMatch(c: AppContext): Promise<Response | null> {
   return hit;
 }
 
+export interface SWRHit {
+  response: Response;
+  stale: boolean;
+  ageSeconds: number;
+}
+
+export interface SWRMatchOptions {
+  /**
+   * How long a cached entry counts as "fresh". Past this, the entry is still
+   * served (stale-while-revalidate) but callers should fire a background
+   * rebuild. Should be well below the outer s-maxage edge TTL.
+   */
+  freshSeconds: number;
+}
+
+/**
+ * Match the request against the edge cache, classifying the result as fresh
+ * or stale based on a timestamp header we wrote at put-time.
+ *
+ * Returns:
+ *   - null           → cache miss, caller must rebuild.
+ *   - { stale=false }→ fresh hit, serve as-is.
+ *   - { stale=true } → stale hit, serve immediately AND trigger a background
+ *                      refresh via triggerSWRRefresh().
+ *
+ * When the cached entry lacks the timestamp header (e.g. left over from
+ * pre-SWR deployments), we treat it as stale so the next request kicks off
+ * a refresh — strictly better than treating it as fresh forever.
+ */
+export async function edgeCacheMatchSWR(
+  c: AppContext,
+  options: SWRMatchOptions
+): Promise<SWRHit | null> {
+  if (isTestEnv(c)) return null;
+  const cached = await caches.default.match(buildCacheKey(c));
+  if (!cached) return null;
+  const cachedAt = Number(cached.headers.get(CACHED_AT_HEADER) ?? "0");
+  const ageSeconds = cachedAt > 0 ? (Date.now() - cachedAt) / 1000 : Number.POSITIVE_INFINITY;
+  const stale = ageSeconds >= options.freshSeconds;
+  const response = new Response(cached.body, cached);
+  response.headers.set("X-Edge-Cache", stale ? "STALE" : "HIT");
+  return { response, stale, ageSeconds };
+}
+
 /**
  * Store the response in the edge cache for the duration of its
  * `Cache-Control` `s-maxage`. Tags an `X-Edge-Cache: MISS` header on the
@@ -65,18 +131,64 @@ export async function edgeCacheMatch(c: AppContext): Promise<Response | null> {
  * happened). The actual cache write runs via `executionCtx.waitUntil` so
  * the user doesn't pay any latency for it.
  *
- * The `MISS` header is set on the live response *after* cloning the
- * about-to-be-stored copy, so the cached entry at rest does not carry the
- * misleading `X-Edge-Cache: MISS` header — only what comes back from the
- * subsequent edgeCacheMatch() call has the status header (overwritten to
- * `HIT` there). Inspecting the raw cache entry now shows the response as
- * the route originally produced it.
+ * An `X-Edge-Cached-At` timestamp header is written to the stored copy so
+ * edgeCacheMatchSWR() can classify hits as fresh or stale on subsequent
+ * requests. The live response returned to the current caller also carries
+ * the stamp (harmless; helps debugging).
  */
 export function edgeCachePut(c: AppContext, response: Response): void {
   if (isTestEnv(c)) return;
+  response.headers.set(CACHED_AT_HEADER, String(Date.now()));
   const cacheCopy = response.clone();
   response.headers.set("X-Edge-Cache", "MISS");
+  c.executionCtx.waitUntil(caches.default.put(buildCacheKey(c), cacheCopy));
+}
+
+/**
+ * Fire a background rebuild for a stale cache entry, guarded by a short KV
+ * lock so concurrent stale hits don't hammer the upstream (e.g. a cold
+ * Durable Object) with duplicate rebuilds.
+ *
+ * The lock key is scoped by the `bucket` argument plus the request URL, so
+ * different query combinations get their own locks — one stale `/foo?a=1`
+ * rebuild doesn't block a concurrent stale `/foo?a=2` rebuild. TTL matches
+ * the expected rebuild cost ceiling (cold DO ~120s in the worst case).
+ *
+ * KV is eventually consistent, so under a brief flurry of concurrent stale
+ * hits 2–3 rebuilds may still fire in parallel. That is acceptable —
+ * strict single-flight isn't worth a Durable Object's coordination cost
+ * for a best-effort refresh.
+ */
+export function triggerSWRRefresh(
+  c: AppContext,
+  bucket: string,
+  rebuild: () => Promise<unknown>
+): void {
+  if (isTestEnv(c)) return;
+  const lockKey = `swr-lock:${bucket}:${new URL(c.req.url).pathname}${new URL(c.req.url).search}`;
   c.executionCtx.waitUntil(
-    caches.default.put(buildCacheKey(c), cacheCopy)
+    (async () => {
+      try {
+        const existing = await c.env.NEWS_KV.get(lockKey);
+        if (existing) return; // Another rebuild is already in-flight.
+        await c.env.NEWS_KV.put(lockKey, "1", { expirationTtl: 120 });
+        await rebuild();
+      } catch (err) {
+        const logger = c.get("logger");
+        logger.warn("SWR rebuild failed", {
+          bucket,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      } finally {
+        // Release the lock eagerly on success so the next refresh window
+        // doesn't wait for the 120s TTL to expire. Swallow delete errors —
+        // the TTL is the backstop.
+        try {
+          await c.env.NEWS_KV.delete(lockKey);
+        } catch {
+          /* noop */
+        }
+      }
+    })()
   );
 }

--- a/src/routes/correspondents.ts
+++ b/src/routes/correspondents.ts
@@ -1,32 +1,43 @@
 /**
  * Correspondents route — list active agents with signal counts and resolved names.
+ *
+ * Edge-cached with stale-while-revalidate. This endpoint ships a ~370 KB
+ * payload built from a Durable Object query that can take 3–130s depending
+ * on whether the DO is warm, warming, or cold-booting after a quiet window.
+ *
+ * Cache layout:
+ *   - s-maxage=1800 — Cloudflare holds the entry at the edge for 30 minutes.
+ *   - freshSeconds=300 — within 5 minutes of writing, served as a plain HIT.
+ *   - 300s < age ≤ 1800s — served immediately as a STALE hit, AND a
+ *     background rebuild fires (guarded by a KV lock so concurrent stale
+ *     hits don't all hammer the DO). User never waits for the cold boot.
+ *   - age > 1800s — CF evicts the entry; next request pays the MISS cost.
  */
 
 import { Hono } from "hono";
-import type { Env, AppVariables } from "../lib/types";
+import type { Env, AppVariables, AppContext } from "../lib/types";
 import { getCorrespondentsBundle } from "../lib/do-client";
 import { truncAddr, buildBeatsByAddress, resolveNamesWithTimeout } from "../lib/helpers";
-import { edgeCacheMatch, edgeCachePut } from "../lib/edge-cache";
+import {
+  edgeCacheMatchSWR,
+  edgeCachePut,
+  triggerSWRRefresh,
+} from "../lib/edge-cache";
 
 const correspondentsRouter = new Hono<{
   Bindings: Env;
   Variables: AppVariables;
 }>();
 
-// GET /api/correspondents — ranked correspondents with signal counts, streaks, and names.
-// Edge-cached: production response is ~371 KB and the DO round-trip costs ~3s
-// without the cache. Single put per s-maxage window then sub-100ms thereafter.
-correspondentsRouter.get("/api/correspondents", async (c) => {
-  const cached = await edgeCacheMatch(c);
-  if (cached) return cached;
+const FRESH_SECONDS = 300;
 
-  // Single DO round-trip fetches correspondents, beats, and leaderboard together
+async function buildCorrespondentsResponse(c: AppContext): Promise<Response> {
   const bundle = await getCorrespondentsBundle(c.env);
   const rows = bundle.correspondents;
   const beats = bundle.beats;
   const leaderboardEntries = bundle.leaderboard;
 
-  // Build address → leaderboard score map and earnings map
+  // Build address → leaderboard score / earnings maps
   const scoreMap = new Map<string, number>();
   const earningsMap = new Map<string, number>();
   const unpaidMap = new Map<string, number>();
@@ -44,7 +55,6 @@ correspondentsRouter.get("/api/correspondents", async (c) => {
     (p) => c.executionCtx.waitUntil(p)
   );
 
-  // Transform to match frontend expectations (camelCase, computed fields)
   const correspondents = rows.map((row) => {
     const signalCount = Number(row.signal_count) || 0;
     const streak = Number(row.current_streak) || 0;
@@ -66,7 +76,11 @@ correspondentsRouter.get("/api/correspondents", async (c) => {
       daysActive,
       lastActive: row.last_signal_date ?? null,
       score,
-      earnings: { total: earningsMap.get(row.btc_address) ?? 0, unpaidSats: unpaidMap.get(row.btc_address) ?? 0, recentPayments: [] as unknown[] },
+      earnings: {
+        total: earningsMap.get(row.btc_address) ?? 0,
+        unpaidSats: unpaidMap.get(row.btc_address) ?? 0,
+        recentPayments: [] as unknown[],
+      },
       display_name: info?.name ?? null,
       avatar: `https://bitcoinfaces.xyz/api/get-image?name=${encodeURIComponent(avatarAddr)}`,
       registered: info?.name !== null && info?.name !== undefined,
@@ -82,10 +96,27 @@ correspondentsRouter.get("/api/correspondents", async (c) => {
       a.address.localeCompare(b.address),
   );
 
-  c.header("Cache-Control", "public, max-age=60, s-maxage=300");
-  const response = c.json({ correspondents, total: correspondents.length });
+  const body = JSON.stringify({ correspondents, total: correspondents.length });
+  const response = new Response(body, {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json; charset=UTF-8",
+      "Cache-Control": "public, max-age=60, s-maxage=1800",
+    },
+  });
   edgeCachePut(c, response);
   return response;
+}
+
+// GET /api/correspondents — ranked correspondents with signal counts, streaks, and names.
+correspondentsRouter.get("/api/correspondents", async (c) => {
+  const hit = await edgeCacheMatchSWR(c, { freshSeconds: FRESH_SECONDS });
+  if (hit && !hit.stale) return hit.response;
+  if (hit && hit.stale) {
+    triggerSWRRefresh(c, "correspondents", () => buildCorrespondentsResponse(c));
+    return hit.response;
+  }
+  return buildCorrespondentsResponse(c);
 });
 
 export { correspondentsRouter };

--- a/src/routes/home-page.ts
+++ b/src/routes/home-page.ts
@@ -77,11 +77,12 @@ function truncate(s: string, max: number): string {
 function buildTitle(data: HomepageData): string {
   const lead = data.signals[0];
   if (lead?.headline) {
-    // Cap the headline at 55 chars so the full title (+" — AIBTC News")
-    // stays under ~68 chars and fits Google's desktop display window
-    // (which truncates around 60-65). Longer headlines would otherwise
-    // get cut mid-word in SERPs.
-    return `${truncate(lead.headline, 55)} — ${SITE_NAME}`;
+    // Brand first, headline second. The browser tab + SERP display the
+    // start of the title, and the homepage should read as "AIBTC News"
+    // before any specific signal — it's the brand landing, not an
+    // individual article. Headline gets capped so the full title fits
+    // the ~68-char SERP display window ("AIBTC News — " is 13 chars).
+    return `${SITE_NAME} — ${truncate(lead.headline, 55)}`;
   }
   return DEFAULT_TITLE;
 }


### PR DESCRIPTION
## Summary

Three fixes to the data-fetch pain reported after #620 landed.

### 1. SWR on `/api/correspondents`

The `/api/correspondents` DO query was observed at **22s–146s** on a cold-PoP MISS (measured with cache-busted query strings: `146s`, `3.4s`, `25s` across three consecutive cold fetches). The DO hibernates during quiet windows and cold-boots on the next access.

With the prior 5-min edge TTL, every PoP paid that cost after every quiet window, and both `/beats` and `/agents` sat staring at a spinner — or rendered `No correspondents yet` if the browser gave up.

- `src/lib/edge-cache.ts` grows `edgeCacheMatchSWR()` + `triggerSWRRefresh()`.
- Cache layout: `s-maxage=1800` (30 min edge TTL), `freshSeconds=300`.
  - age ≤ 300s → serve HIT.
  - 300s < age ≤ 1800s → serve STALE immediately, fire a background rebuild guarded by a KV lock so concurrent stale hits don't stampede the DO.
  - age > 1800s → CF evicts; next request pays the full MISS cost.
- Only the very first visitor to a PoP after a full 30-min absence pays the cold-boot cost. Everyone else either gets fresh HITs or instant STALE hits while the rebuild runs in the background.

### 2. `/beats` no longer blocks on `/api/correspondents`

Previously `Promise.all([/api/beats, /api/correspondents])` blocked first paint on the 370 KB correspondents payload. If the browser gave up mid-flight, the page rendered `No beats found.`

- The "Correspondent Roster · Sort by score · 30d" section is removed (per request). `-358 / +44` lines on the page.
- Beat cards still show a human editor name. `/api/correspondents` fires non-blocking; editor labels on already-rendered cards are upgraded in place via `fillEditorName()` once it lands.
- The page now paints on `/api/beats` alone (≤50ms warm) and never shows `No beats found` during a slow correspondents fetch.

### 3. `/agents` listing shows a skeleton instead of "No correspondents yet"

The list view jumped straight to `No correspondents yet` when the fetch was still in flight. Now it paints a skeleton during the fetch and only shows an error (with a retry button) if `/api/correspondents` actually returns `null`.

### 4. Homepage `<title>` now reads brand-first

Was: `arxiv 2604.19481 Ships 'Walking Cat'… — AIBTC News`
Now: `AIBTC News — arxiv 2604.19481 Ships 'Walking Cat'…`

Browser tabs and SERPs display the leading characters, so the homepage should identify as AIBTC News before any individual signal headline. Applied to `<title>`, `og:title`, `twitter:title`. Test in `home-page.test.ts` updated to match.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — no new warnings in touched files
- [x] `npm test` — 335 pass / 4 fail (same pre-existing failures as `main`, per #620's commit note)
- [x] `home-page.test.ts` — all 9 tests pass with the new brand-first title format
- [ ] After deploy: confirm `/api/correspondents` shows `X-Edge-Cache: STALE` during a background refresh window
- [ ] After deploy: confirm `/beats` renders cards immediately even when correspondents is cold
- [ ] After deploy: confirm `/agents/` shows a loading skeleton instead of `No correspondents yet`
- [ ] After deploy: confirm homepage title reads `AIBTC News — …` (may take up to 5 min per PoP for old cached homepage HTML to expire, or purge via CF dashboard)