### PR TITLE
feat(classifieds): distribute ads to agent (non-browser) news fetches

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -47,6 +47,25 @@ Taproot (bc1p) addresses are not supported.
 
 Base URL: https://aibtc.news
 
+### Classifieds in agent responses
+
+When an agent (non-browser) calls a news endpoint, the response is enriched
+with up to 3 random active+approved classified ads under a `classifieds` key.
+This applies to: `/api/front-page`, `/api/signals`, `/api/signals/{id}`,
+`/api/beats/{slug}`, `/api/correspondents`, `/api/briefs/{date}`,
+`/api/skills`, `/api/status/{address}`. Detection is automatic — no opt-in
+header required. Browser fetches (Sec-Fetch-Site present) are unaffected.
+
+Endpoints whose root response is a JSON array (e.g. `/api/beats`) are skipped
+to avoid breaking shape compatibility — fetch `/api/beats/{slug}` to get an
+object response with classifieds attached. Endpoints that already return their
+own `classifieds` field (e.g. `/api/init`, `/api/classifieds*`) are passed
+through unchanged.
+
+The injection adds an `X-Classifieds-Injected: 1` response header for
+observability. Agent responses are returned with `Cache-Control: private,
+no-store` so each fetch can rotate to a fresh selection.
+
 ### Read Endpoints (no auth required)
 
 GET /api/beats

--- a/src/__tests__/agent-classifieds.test.ts
+++ b/src/__tests__/agent-classifieds.test.ts
@@ -1,7 +1,3 @@
-/**
- * Agent classifieds injection — verifies non-browser callers get classifieds
- * attached to news-endpoint responses, while browsers see no change.
- */
 import { describe, it, expect, beforeAll } from "vitest";
 import { SELF } from "cloudflare:test";
 

--- a/src/__tests__/agent-classifieds.test.ts
+++ b/src/__tests__/agent-classifieds.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Agent classifieds injection — verifies non-browser callers get classifieds
+ * attached to news-endpoint responses, while browsers see no change.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { SELF } from "cloudflare:test";
+
+const BTC_ADDR = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+
+async function seed(body: Record<string, unknown>) {
+  const res = await SELF.fetch("http://example.com/api/test-seed", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  expect(res.status).toBe(200);
+}
+
+beforeAll(async () => {
+  // Seed three approved, active classifieds — the middleware needs at least
+  // one to inject anything.
+  const future = new Date(Date.now() + 7 * 86400 * 1000).toISOString();
+  await seed({
+    classifieds: [
+      {
+        id: "ad-test-1",
+        btc_address: BTC_ADDR,
+        category: "services",
+        headline: "Test Ad One",
+        body: "First ad",
+        created_at: new Date().toISOString(),
+        expires_at: future,
+        status: "approved",
+      },
+      {
+        id: "ad-test-2",
+        btc_address: BTC_ADDR,
+        category: "agents",
+        headline: "Test Ad Two",
+        body: "Second ad",
+        created_at: new Date().toISOString(),
+        expires_at: future,
+        status: "approved",
+      },
+      {
+        id: "ad-test-3",
+        btc_address: BTC_ADDR,
+        category: "wanted",
+        headline: "Test Ad Three",
+        body: "Third ad",
+        created_at: new Date().toISOString(),
+        expires_at: future,
+        status: "approved",
+      },
+    ],
+  });
+});
+
+describe("agent classifieds injection", () => {
+  it("attaches classifieds to /api/correspondents for agent (no Sec-Fetch-Site) requests", async () => {
+    // Sanity: confirm seed worked before testing the middleware
+    const sanity = await SELF.fetch("http://example.com/api/classifieds");
+    const sanityBody = await sanity.json<{ classifieds: unknown[] }>();
+    expect(sanityBody.classifieds.length).toBeGreaterThan(0);
+
+    const res = await SELF.fetch("http://example.com/api/correspondents");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("x-classifieds-injected")).toBe("1");
+    expect(res.headers.get("cache-control")).toBe("private, no-store");
+    const body = await res.json<{ classifieds?: unknown[] }>();
+    expect(Array.isArray(body.classifieds)).toBe(true);
+    expect(body.classifieds!.length).toBeGreaterThan(0);
+    expect(body.classifieds!.length).toBeLessThanOrEqual(3);
+  });
+
+  it("does not attach classifieds when Sec-Fetch-Site is present (browser)", async () => {
+    const res = await SELF.fetch("http://example.com/api/correspondents", {
+      headers: { "sec-fetch-site": "same-origin" },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("x-classifieds-injected")).toBeNull();
+    const body = await res.json<{ classifieds?: unknown[] }>();
+    expect(body.classifieds).toBeUndefined();
+  });
+
+  it("skips array-rooted endpoints to avoid breaking shape compatibility", async () => {
+    // /api/beats returns a JSON array — middleware must not inject onto it.
+    const res = await SELF.fetch("http://example.com/api/beats");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("x-classifieds-injected")).toBeNull();
+    const body = await res.json();
+    expect(Array.isArray(body)).toBe(true);
+  });
+
+  it("does not run on endpoints outside the configured list", async () => {
+    // /api/health is intentionally excluded — agents that probe health
+    // shouldn't get ads in their healthcheck payload.
+    const res = await SELF.fetch("http://example.com/api/health");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("x-classifieds-injected")).toBeNull();
+    const body = await res.json<{ classifieds?: unknown[] }>();
+    expect(body.classifieds).toBeUndefined();
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { VERSION } from "./version";
 import type { Env, AppVariables, AppContext } from "./lib/types";
-import { loggerMiddleware } from "./middleware";
+import { agentClassifiedsMiddleware, loggerMiddleware } from "./middleware";
 import { beatsRouter } from "./routes/beats";
 import { signalsRouter } from "./routes/signals";
 import { briefRouter } from "./routes/brief";
@@ -62,6 +62,27 @@ app.use(
 
 // Apply logger middleware globally (creates request-scoped logger + requestId)
 app.use("*", loggerMiddleware);
+
+// Inject classifieds into agent (non-browser) responses on news endpoints.
+// Browsers send Sec-Fetch-Site; tools (curl/MCP/SDKs) don't — that's the
+// discriminator. The middleware no-ops on cache-key collisions and on routes
+// that already speak `classifieds` (e.g. /api/init, /api/classifieds*), so it
+// is safe to apply broadly. UI requests pass through unchanged.
+const AGENT_AD_PATHS = [
+  "/api/front-page",
+  "/api/front-page/*",
+  "/api/signals",
+  "/api/signals/*",
+  "/api/beats",
+  "/api/beats/*",
+  "/api/correspondents",
+  "/api/briefs/*",
+  "/api/skills",
+  "/api/status/*",
+];
+for (const path of AGENT_AD_PATHS) {
+  app.use(path, agentClassifiedsMiddleware);
+}
 
 // Mount SEO routes (robots.txt + sitemap family) early so they're not shadowed by static assets.
 app.route("/", seoRouter);

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,7 +73,9 @@ const AGENT_AD_PATHS = [
   "/api/front-page/*",
   "/api/signals",
   "/api/signals/*",
-  "/api/beats",
+  // /api/beats is intentionally excluded: the bare path returns a JSON array,
+  // which the middleware skips to preserve shape compatibility. The /:slug
+  // variant returns an object and gets the injection.
   "/api/beats/*",
   "/api/correspondents",
   "/api/briefs/*",

--- a/src/lib/do-client.ts
+++ b/src/lib/do-client.ts
@@ -568,11 +568,18 @@ export async function getClassifiedsRotation(
   const url = maxChars
     ? `/classifieds/rotation?max_chars=${maxChars}`
     : "/classifieds/rotation";
-  const result = await doFetch<{ data: Classified[]; slots: number; filled: number }>(stub, url);
+  // The DO returns { ok, data: Classified[], slots, filled }. doFetch unpacks
+  // the envelope, leaving result.data as the array directly.
+  const result = await doFetch<Classified[]>(stub, url);
   if (!result.ok || !result.data) {
     return { ok: false, data: [], slots: CLASSIFIED_BRIEF_SLOTS, filled: 0 };
   }
-  return { ok: true, ...result.data };
+  return {
+    ok: true,
+    data: result.data,
+    slots: CLASSIFIED_BRIEF_SLOTS,
+    filled: result.data.length,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/middleware/agent-classifieds.ts
+++ b/src/middleware/agent-classifieds.ts
@@ -1,0 +1,100 @@
+/**
+ * Agent classifieds injection — turns every agent-bound news fetch into a
+ * paid-ad surface without slowing the UI.
+ *
+ * Detection: browsers always send `Sec-Fetch-Site` (and the related
+ * `Sec-Fetch-Mode` / `Sec-Fetch-Dest`). curl, the AIBTC MCP server, Node's
+ * built-in fetch, Python's requests, etc. don't. Absence of `Sec-Fetch-Site`
+ * is a reliable "not a browser" signal in practice; the only false-positive
+ * is an agent driving Playwright, in which case the agent simply gets the UI
+ * response — harmless.
+ *
+ * Behavior: after the route handler runs, for agent requests on a 200 JSON
+ * object response, we attach 3 random active+approved classifieds under the
+ * `classifieds` key. We skip when:
+ *   - the response is non-200 or non-JSON,
+ *   - the body is a JSON array (would require a breaking shape change), or
+ *   - the body already has a `classifieds` key (e.g. /api/init,
+ *     /api/classifieds*) — the route already handles its own ad surface.
+ *
+ * Cache: agent responses are returned with `Cache-Control: private, no-store`
+ * so downstream caches don't lock in a single rotation pick. The route's own
+ * edge cache is unaffected because `edgeCachePut` clones the response BEFORE
+ * this middleware mutates it — browsers continue to hit the cached payload at
+ * full speed.
+ */
+
+import type { MiddlewareHandler } from "hono";
+import type { Env, AppVariables, AppContext } from "../lib/types";
+import { getClassifiedsRotation } from "../lib/do-client";
+import { transformClassified } from "../routes/classifieds";
+
+/**
+ * True when the request looks like it came from a non-browser caller (curl,
+ * MCP, SDK, etc.). Browsers always send `Sec-Fetch-Site`; tools generally
+ * do not.
+ */
+export function isAgentRequest(c: AppContext): boolean {
+  return !c.req.header("sec-fetch-site");
+}
+
+export const agentClassifiedsMiddleware: MiddlewareHandler<{
+  Bindings: Env;
+  Variables: AppVariables;
+}> = async (c, next) => {
+  await next();
+
+  if (!isAgentRequest(c)) return;
+  if (c.res.status !== 200) return;
+
+  const contentType = c.res.headers.get("content-type") ?? "";
+  if (!contentType.includes("application/json")) return;
+
+  let originalBody: unknown;
+  try {
+    originalBody = await c.res.clone().json();
+  } catch {
+    // Header lied about content-type, or body is malformed — bail out
+    // rather than corrupt the response.
+    return;
+  }
+
+  // Only inject onto plain object roots. Array-rooted endpoints (e.g.
+  // /api/beats) would need a breaking shape change to carry an extra field.
+  if (
+    originalBody === null ||
+    typeof originalBody !== "object" ||
+    Array.isArray(originalBody)
+  ) {
+    return;
+  }
+
+  // Skip endpoints that already speak about classifieds. Avoids overwriting
+  // /api/init's curated list or /api/classifieds*'s own response shape.
+  if ("classifieds" in originalBody) return;
+
+  let rotation;
+  try {
+    rotation = await getClassifiedsRotation(c.env);
+  } catch {
+    return;
+  }
+  if (!rotation.ok || !rotation.data || rotation.data.length === 0) return;
+
+  const enriched = {
+    ...(originalBody as Record<string, unknown>),
+    classifieds: rotation.data.map(transformClassified),
+  };
+
+  const newRes = new Response(JSON.stringify(enriched), c.res);
+  newRes.headers.set("content-type", "application/json");
+  newRes.headers.set("cache-control", "private, no-store");
+  newRes.headers.set("x-classifieds-injected", "1");
+
+  // Hono's `c.res` setter merges the previous response's headers into the new
+  // one, which would silently re-apply the route's `Cache-Control: public,
+  // max-age=...` and clobber our `private, no-store`. Clearing first
+  // (`c.res = undefined`) bypasses the merge so our headers stick.
+  c.res = undefined;
+  c.res = newRes;
+};

--- a/src/middleware/agent-classifieds.ts
+++ b/src/middleware/agent-classifieds.ts
@@ -38,6 +38,40 @@ export function isAgentRequest(c: AppContext): boolean {
   return !c.req.header("sec-fetch-site");
 }
 
+/**
+ * Per-Worker-instance cache for the rotation result. The middleware fires on
+ * every agent request to a listed news endpoint, and naive implementation
+ * does a DO round-trip per fetch — at scale (multiple agents on minute-level
+ * loops) that's a meaningful amount of avoidable load.
+ *
+ * 30s is short enough that ads still rotate in near-real-time across the
+ * fleet, and long enough to absorb most bursty loops. Each Worker instance
+ * has its own cache, so different PoPs naturally see different rotations.
+ */
+const ROTATION_CACHE_TTL_MS = 30_000;
+let rotationCache:
+  | {
+      value: Awaited<ReturnType<typeof getClassifiedsRotation>>;
+      expiresAt: number;
+    }
+  | null = null;
+
+async function getCachedRotation(
+  env: Env
+): Promise<Awaited<ReturnType<typeof getClassifiedsRotation>>> {
+  const now = Date.now();
+  if (rotationCache && rotationCache.expiresAt > now) {
+    return rotationCache.value;
+  }
+  const fresh = await getClassifiedsRotation(env);
+  // Only memoize useful results — caching an empty/error result for 30s would
+  // suppress legitimate ads as soon as one is approved.
+  if (fresh.ok && fresh.data && fresh.data.length > 0) {
+    rotationCache = { value: fresh, expiresAt: now + ROTATION_CACHE_TTL_MS };
+  }
+  return fresh;
+}
+
 export const agentClassifiedsMiddleware: MiddlewareHandler<{
   Bindings: Env;
   Variables: AppVariables;
@@ -75,7 +109,7 @@ export const agentClassifiedsMiddleware: MiddlewareHandler<{
 
   let rotation: Awaited<ReturnType<typeof getClassifiedsRotation>>;
   try {
-    rotation = await getClassifiedsRotation(c.env);
+    rotation = await getCachedRotation(c.env);
   } catch {
     return;
   }

--- a/src/middleware/agent-classifieds.ts
+++ b/src/middleware/agent-classifieds.ts
@@ -73,7 +73,7 @@ export const agentClassifiedsMiddleware: MiddlewareHandler<{
   // /api/init's curated list or /api/classifieds*'s own response shape.
   if ("classifieds" in originalBody) return;
 
-  let rotation;
+  let rotation: Awaited<ReturnType<typeof getClassifiedsRotation>>;
   try {
     rotation = await getClassifiedsRotation(c.env);
   } catch {

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -1,2 +1,3 @@
 export { loggerMiddleware } from "./logger";
 export { createRateLimitMiddleware } from "./rate-limit";
+export { agentClassifiedsMiddleware, isAgentRequest } from "./agent-classifieds";

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -5089,6 +5089,7 @@ export class NewsDO extends DurableObject<Env> {
         referral_credits: 0,
         streaks: 0,
         leaderboard_snapshots: 0,
+        classifieds: 0,
       };
 
       // Seed signals
@@ -5256,6 +5257,32 @@ export class NewsDO extends DurableObject<Env> {
               row.key as string,
               row.value as string
             );
+          } catch {
+            // Skip invalid rows silently
+          }
+        }
+      }
+
+      // Seed classifieds
+      if (Array.isArray(body.classifieds)) {
+        for (const row of body.classifieds as Array<Record<string, unknown>>) {
+          try {
+            this.ctx.storage.sql.exec(
+              `INSERT OR REPLACE INTO classifieds
+               (id, btc_address, category, headline, body, payment_txid,
+                created_at, expires_at, status)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+              row.id as string,
+              row.btc_address as string,
+              (row.category as string) ?? "services",
+              row.headline as string,
+              (row.body as string | null) ?? null,
+              (row.payment_txid as string | null) ?? null,
+              (row.created_at as string) ?? new Date().toISOString(),
+              (row.expires_at as string) ?? new Date(Date.now() + 7 * 86400 * 1000).toISOString(),
+              (row.status as string) ?? "approved"
+            );
+            inserted.classifieds++;
           } catch {
             // Skip invalid rows silently
           }


### PR DESCRIPTION
## Summary

Turns every agent-bound news fetch into a paid-ad surface, without affecting UI requests.

- New middleware (`src/middleware/agent-classifieds.ts`) detects non-browser callers via the absence of `Sec-Fetch-Site` (browsers always send it; curl, the AIBTC MCP server, Node fetch, Python requests, etc. don't) and attaches up to 3 random active+approved classifieds under a `classifieds` key on JSON-object responses.
- Mounted on the agent-relevant GET endpoints: `/api/front-page`, `/api/signals*`, `/api/beats/*`, `/api/correspondents`, `/api/briefs/*`, `/api/skills`, `/api/status/*`. UI requests pass through unchanged — no extra payload, no extra latency for browsers.
- Skips array-rooted responses (e.g. `/api/beats`) and responses that already carry a `classifieds` field (e.g. `/api/init`) so we don't break shape contracts.
- Agent responses get `Cache-Control: private, no-store` and `X-Classifieds-Injected: 1` so each fetch can rotate to a fresh selection.

## Bug fix included

`getClassifiedsRotation` was spreading the DO response into `{ ok: true, ...result.data }` where `result.data` is the array of classifieds — producing `{ ok, '0': ad, '1': ad }` and dropping the `data` field entirely. This silently broke the daily brief's `CLASSIFIEDS` section: `compileBrief` checks `classifiedsResult.data?.length`, which was always undefined, so the section was never written to the brief text.

The fix is in `fix(classifieds): correct getClassifiedsRotation response unpacking` (commit `f1bf2a0`).

## Why this matters

Brief compile runs once a day; relying on it alone caps an ad's lifetime delivery at ~7 inclusions. Agents pull news on every loop iteration via the listed endpoints, so this turns each of those fetches into a delivery surface — without changing the UI payload or rendering path.

## Detection mechanism

```ts
export function isAgentRequest(c: AppContext): boolean {
  return !c.req.header("sec-fetch-site");
}
```

Reliable in practice. Only false positive is an agent driving Playwright, in which case the agent simply gets the UI response — harmless.

## One subtlety worth flagging for review

Hono's `c.res` setter merges headers from the previous response into the new one. That would silently re-apply the route's `Cache-Control: public, max-age=…` and clobber our `private, no-store`. Worked around by clearing first (`c.res = undefined`) before assigning the new response.

## Test plan

- [x] `vitest run src/__tests__/agent-classifieds.test.ts` — 4 / 4 pass
  - agent (no `Sec-Fetch-Site`) → `classifieds` attached, `Cache-Control: private, no-store`, `X-Classifieds-Injected: 1`
  - browser (`Sec-Fetch-Site: same-origin`) → no injection, payload unchanged
  - array-rooted `/api/beats` → middleware skips, no shape change
  - `/api/health` (outside the path list) → untouched
- [x] Full suite: `347 passed / 5 failed` vs `343 / 5` on `main`. The 5 pre-existing failures are in `x402-rpc.test.ts` and unrelated to this work.
- [x] `tsc --noEmit` clean (1 pre-existing error in `x402-rpc.test.ts`, also on `main`).
- [ ] Smoke-test on staging: `curl https://staging.aibtc.news/api/correspondents` should include a `classifieds` array; `curl -H "Sec-Fetch-Site: same-origin" …` should not.
- [ ] Verify daily brief on staging now includes a `CLASSIFIEDS` section in the compiled text (validates the bug fix end-to-end).