### PR TITLE
fix(homepage): mix signal ordering by timestamp instead of clumping by beat

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3937,31 +3937,29 @@
 
       // Helper: convert signals array to section items for mosaic rendering
       function signalsToItems(sigs) {
-        const sections = sigs.map(s => ({
-          id: s.id || null,
-          beat: s.beat,
-          beatSlug: s.beatSlug || s.beat,
-          correspondent: s.btcAddress,
-          correspondentName: s.displayName || null,
-          correspondentShort: truncAddr(s.btcAddress),
-          timestamp: s.timestamp,
-          headline: s.headline || null,
-          content: s.content,
-          sources: s.sources || null,
-          tags: s.tags || null,
-          streak: 0,
-          correction: s.correction || null,
-          correctedAt: s.correctedAt || null,
-          disclosure: s.disclosure || null,
-        }));
-        const grouped = groupByBeat(sections);
-        const items = [];
-        for (const [key, group] of Object.entries(grouped)) {
-          for (const section of group.sections) {
-            items.push({ section, beat: beatMap[section.beatSlug] || beatMap[key] });
-          }
-        }
-        return items;
+        return sigs.map(s => {
+          const beatSlug = s.beatSlug || s.beat;
+          return {
+            section: {
+              id: s.id || null,
+              beat: s.beat,
+              beatSlug,
+              correspondent: s.btcAddress,
+              correspondentName: s.displayName || null,
+              correspondentShort: truncAddr(s.btcAddress),
+              timestamp: s.timestamp,
+              headline: s.headline || null,
+              content: s.content,
+              sources: s.sources || null,
+              tags: s.tags || null,
+              streak: 0,
+              correction: s.correction || null,
+              correctedAt: s.correctedAt || null,
+              disclosure: s.disclosure || null,
+            },
+            beat: beatMap[beatSlug],
+          };
+        });
       }
 
       // Helper: render mosaic HTML from items array


### PR DESCRIPTION
## Summary

- The `signalsToItems` helper in `public/index.html` was calling `groupByBeat()` before flattening signals into the mosaic, which bucketed all bitcoin-macro signals together, then all quantum, then all aibtc-network — regardless of when they were filed.
- Fix: remove the `groupByBeat` indirection and map sections directly, preserving the API's `created_at DESC` order that the DO already returns.
- The infinite-scroll path (`renderDaySection`) was already doing this correctly — the initial render now matches.

## Root cause

```js
// Before: groupByBeat destroys timestamp order
const grouped = groupByBeat(sections);
for (const [key, group] of Object.entries(grouped)) {
  for (const section of group.sections) {
    items.push({ section, beat: beatMap[section.beatSlug] || beatMap[key] });
  }
}

// After: preserve arrival order (already created_at DESC from the API)
return sigs.map(s => ({ section: { ...fields }, beat: beatMap[beatSlug] }));
```

## Test plan

- [ ] Load homepage with signals from multiple beats filed at different times — verify they appear interleaved by timestamp, not bucketed by beat
- [ ] Confirm infinite scroll still works (already used the correct approach, no change there)
- [ ] Confirm submitted-signals fallback still renders (uses a separate `groupByBeat` path, unchanged)

Closes #667

🤖 Generated with [Claude Code](https://claude.com/claude-code)