### PR TITLE
fix(classifieds): exclude same-day expired ads from listing

### DIFF
--- a/src/__tests__/classifieds.test.ts
+++ b/src/__tests__/classifieds.test.ts
@@ -191,3 +191,55 @@ describe("POST /api/classifieds — field aliasing (pre-payment validation)", ()
     expect(res.status).not.toBe(400);
   });
 });
+
+// ── Regression: GET /api/classifieds must exclude same-day expired rows ──────
+//
+// expires_at is stored as ISO 8601 ('2026-04-29T10:00:00.000Z') but the SQL
+// filter previously compared against datetime('now') ('YYYY-MM-DD HH:MM:SS').
+// With the same date prefix, lex comparison treats 'T' (0x54) as greater than
+// ' ' (0x20), so already-expired rows would slip through and the classifieds
+// page (which client-filters expiry) appeared empty even when home page rows
+// were present. Lock the correct behavior in.
+describe("GET /api/classifieds — same-day expiry filter", () => {
+  it("excludes approved rows whose expires_at has already passed today", async () => {
+    const expiredId = `expired-same-day-${Date.now()}`;
+    const activeId = `active-same-day-${Date.now()}`;
+    const oneSecondAgo = new Date(Date.now() - 1000).toISOString();
+    const oneHourAhead = new Date(Date.now() + 3600 * 1000).toISOString();
+
+    const seedRes = await SELF.fetch("http://example.com/api/test-seed", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        classifieds: [
+          {
+            id: expiredId,
+            btc_address: "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
+            category: "services",
+            headline: "Expired same-day ad",
+            created_at: new Date(Date.now() - 7 * 86400 * 1000).toISOString(),
+            expires_at: oneSecondAgo,
+            status: "approved",
+          },
+          {
+            id: activeId,
+            btc_address: "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
+            category: "services",
+            headline: "Active same-day ad",
+            created_at: new Date().toISOString(),
+            expires_at: oneHourAhead,
+            status: "approved",
+          },
+        ],
+      }),
+    });
+    expect(seedRes.status).toBe(200);
+
+    const res = await SELF.fetch("http://example.com/api/classifieds?limit=200");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ classifieds: Array<{ id: string }> }>();
+    const ids = body.classifieds.map((c) => c.id);
+    expect(ids).toContain(activeId);
+    expect(ids).not.toContain(expiredId);
+  });
+});

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -2884,8 +2884,15 @@ export class NewsDO extends DurableObject<Env> {
             .toArray()
         : this.ctx.storage.sql
             .exec(
+              // expires_at is stored as ISO 8601 with 'T' and trailing 'Z'
+              // (e.g. '2026-04-29T10:00:00.000Z'); SQLite's datetime('now')
+              // returns 'YYYY-MM-DD HH:MM:SS' without T or Z, so a same-day
+              // string comparison incorrectly treats every ISO row as "greater"
+              // (because 'T' (0x54) > ' ' (0x20)) and lets already-expired rows
+              // pass the filter. Build the comparator in the same ISO format
+              // so the comparison is correct for intra-day expiries too.
               `SELECT * FROM classifieds
-               WHERE expires_at > datetime('now')
+               WHERE expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
                  AND status = 'approved'
                  AND (?1 IS NULL OR category = ?1)
                ORDER BY created_at DESC
@@ -2913,8 +2920,9 @@ export class NewsDO extends DurableObject<Env> {
       // become common and rejection rate rises, consider bumping to 10x.
       const rows = this.ctx.storage.sql
         .exec(
+          // ISO/datetime('now') format mismatch — see /classifieds list query above.
           `SELECT * FROM classifieds
-           WHERE expires_at > datetime('now')
+           WHERE expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
              AND status = 'approved'
            ORDER BY RANDOM()
            LIMIT ?`,
@@ -4755,10 +4763,11 @@ export class NewsDO extends DurableObject<Env> {
       });
 
       // Classifieds (active approved only)
+      // ISO/datetime('now') format mismatch — see /classifieds list query above.
       const classifiedRows = this.ctx.storage.sql
         .exec(
           `SELECT * FROM classifieds
-           WHERE expires_at > datetime('now')
+           WHERE expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
              AND status = 'approved'
            ORDER BY created_at DESC
            LIMIT 50`

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -96,6 +96,14 @@ function rowToSignal(row: Record<string, unknown>): Signal {
 const FRONT_PAGE_WINDOW_SQL = "-2 days";
 const FRONT_PAGE_MAX_ROWS = 200;
 
+// ISO 8601 'now' for SQLite comparators against ISO-stored timestamp columns
+// (e.g. classifieds.expires_at). Default datetime('now') returns
+// 'YYYY-MM-DD HH:MM:SS' (no T, no Z), and a same-day lex compare puts 'T'
+// (0x54) above ' ' (0x20) — every same-day ISO row falsely passes
+// `expires_at > datetime('now')`. strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+// produces an identically-shaped string so the comparison is correct.
+const ISO_NOW_SQL = "strftime('%Y-%m-%dT%H:%M:%fZ', 'now')";
+
 const FRONT_PAGE_SIGNALS_QUERY = `
   SELECT s.*, b.name as beat_name, GROUP_CONCAT(st.tag) as tags_csv
   FROM signals s
@@ -2884,15 +2892,8 @@ export class NewsDO extends DurableObject<Env> {
             .toArray()
         : this.ctx.storage.sql
             .exec(
-              // expires_at is stored as ISO 8601 with 'T' and trailing 'Z'
-              // (e.g. '2026-04-29T10:00:00.000Z'); SQLite's datetime('now')
-              // returns 'YYYY-MM-DD HH:MM:SS' without T or Z, so a same-day
-              // string comparison incorrectly treats every ISO row as "greater"
-              // (because 'T' (0x54) > ' ' (0x20)) and lets already-expired rows
-              // pass the filter. Build the comparator in the same ISO format
-              // so the comparison is correct for intra-day expiries too.
               `SELECT * FROM classifieds
-               WHERE expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+               WHERE expires_at > ${ISO_NOW_SQL}
                  AND status = 'approved'
                  AND (?1 IS NULL OR category = ?1)
                ORDER BY created_at DESC
@@ -2920,9 +2921,8 @@ export class NewsDO extends DurableObject<Env> {
       // become common and rejection rate rises, consider bumping to 10x.
       const rows = this.ctx.storage.sql
         .exec(
-          // ISO/datetime('now') format mismatch — see /classifieds list query above.
           `SELECT * FROM classifieds
-           WHERE expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+           WHERE expires_at > ${ISO_NOW_SQL}
              AND status = 'approved'
            ORDER BY RANDOM()
            LIMIT ?`,
@@ -4763,11 +4763,10 @@ export class NewsDO extends DurableObject<Env> {
       });
 
       // Classifieds (active approved only)
-      // ISO/datetime('now') format mismatch — see /classifieds list query above.
       const classifiedRows = this.ctx.storage.sql
         .exec(
           `SELECT * FROM classifieds
-           WHERE expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+           WHERE expires_at > ${ISO_NOW_SQL}
              AND status = 'approved'
            ORDER BY created_at DESC
            LIMIT 50`


### PR DESCRIPTION
## Summary

Closing the home / classifieds-page parity gap noticed during an aibtc.news review: classifieds appeared on the home rail but the `/classifieds` page rendered empty.

## Root cause

`GET /api/classifieds`, the brief rotation, and the bundled-init query all filter expired rows with:

```sql
WHERE expires_at > datetime('now')
```

`expires_at` is written via `new Date().toISOString()` → `'2026-04-29T10:00:00.000Z'`. SQLite's `datetime('now')` returns `'YYYY-MM-DD HH:MM:SS'` (no `T`, no `Z`). With matching date prefixes, the lexicographic compare hits position 10 first: `'T'` (0x54) vs `' '` (0x20). `T > space`, so **same-day** ISO rows are always treated as "greater than now", regardless of whether the actual expiry hour has already passed.

That meant approved ads whose 7-day TTL ended earlier today still slipped through the filter. The home page renders top 3 unconditionally, so it looked fine. The `/classifieds` page applies a client-side `expiresAt >= Date.now()` check and correctly drops them — leaving the page empty whenever the only "active" rows the API returned were actually stale same-day expirees.

## Fix

Replace `datetime('now')` with `strftime('%Y-%m-%dT%H:%M:%fZ', 'now')` in the three affected queries (`/classifieds` listing, `/classifieds/rotation`, bundled init) so both sides of the comparator share the ISO 8601 shape that the column stores.

Added a regression test that seeds one same-day expired and one same-day active row, then asserts only the active one appears in the listing.

## Test plan
- [x] `npx vitest run src/__tests__/classifieds.test.ts` — 14/14 pass, including the new regression case.
- [ ] Deploy + sanity check `/classifieds` on aibtc.news shows the same active rows the home rail does.
- [ ] Confirm tomorrow's brief rotation no longer includes a stale same-day expired ad.

## Related
Part of the broader aibtc.news punch list (archive inscriptions = #669, home interleaving = #668). This is the "classifieds parity (home vs classifieds page)" item.