### PR TITLE
fix(homepage): round-robin beats in mosaic so every active beat shows

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3937,7 +3937,7 @@
 
       // Helper: convert signals array to section items for mosaic rendering
       function signalsToItems(sigs) {
-        return sigs.map(s => {
+        const items = sigs.map(s => {
           const beatSlug = s.beatSlug || s.beat;
           return {
             section: {
@@ -3960,6 +3960,37 @@
             beat: beatMap[beatSlug],
           };
         });
+
+        // Pure timestamp DESC (the previous fix) interleaves beats only if
+        // every beat has filed recently. When one beat's freshest signal is
+        // hours older than the others — e.g. aibtc-network when macro and
+        // quantum dominate the latest hour — it falls off the visible mosaic
+        // entirely. Round-robin by beat keeps every active beat present in
+        // the first N cards, while still leading with the beat that filed
+        // most recently (so the lead remains the freshest story overall).
+        const groups = new Map();
+        for (const it of items) {
+          const slug = it.section.beatSlug;
+          if (!groups.has(slug)) groups.set(slug, []);
+          groups.get(slug).push(it);
+        }
+        const ts = (it) => it.section.timestamp ? new Date(it.section.timestamp).getTime() : 0;
+        const beatLists = [...groups.values()];
+        for (const list of beatLists) list.sort((a, b) => ts(b) - ts(a));
+        beatLists.sort((a, b) => ts(b[0]) - ts(a[0]));
+
+        const interleaved = [];
+        for (let i = 0; ; i++) {
+          let pushedThisRound = false;
+          for (const list of beatLists) {
+            if (i < list.length) {
+              interleaved.push(list[i]);
+              pushedThisRound = true;
+            }
+          }
+          if (!pushedThisRound) break;
+        }
+        return interleaved;
       }
 
       // Helper: render mosaic HTML from items array


### PR DESCRIPTION
## Summary

Continuing the front-page mosaic fix from #668.

## Problem

Pure timestamp DESC interleaves beats only when each beat has filed recently. On aibtc.news right now \`/api/front-page\` returns 48 signals across 3 beats — bitcoin-macro: 20, quantum: 17, aibtc-network: 11 — but today (UTC) has 0 approved signals, so the mosaic falls back to the global "most recent" path. The freshest macro and quantum signals were filed at ~10:00 UTC; aibtc-network's freshest is ~02:00 UTC, ~8 hours earlier. After timestamp-DESC sort, aibtc-network slides past the visible mosaic and the user only sees macro / quantum even though network is active.

## Fix

\`signalsToItems\` now round-robins by beat:
1. Group signals by beat slug.
2. Sort each beat's list by timestamp DESC.
3. Order beats by their own freshest signal — the overall lead is still the newest story.
4. Interleave: pick the freshest from each beat in turn, then the second-freshest from each, etc.

With 3 active beats this guarantees the first 3 cards cover all 3 beats. The lead remains the globally-freshest signal because the beat that owns it sorts first.

## Test plan
- [ ] On \`/\`, mosaic shows aibtc-network within the first three cards alongside macro and quantum.
- [ ] Lead card is still the most-recent signal overall (whichever beat filed it).
- [ ] Beats with no signals in the loaded window don't break rendering — they just don't appear.

## Related
Part of the broader aibtc.news punch list. #669 (archive inscriptions), #668 (initial mosaic mix), #670 (classifieds expiry SQL), #671 (archive inscription link clickability).