### PR TITLE
feat(earnings): add POST /api/payouts/record idempotent payout endpoint

### DIFF
--- a/src/routes/earnings.ts
+++ b/src/routes/earnings.ts
@@ -65,7 +65,12 @@ earningsRouter.post("/api/payouts/record", async (c) => {
   }
 
   // Verify caller is the designated Publisher
-  const publisherConfig = await getConfig(c.env, CONFIG_PUBLISHER_ADDRESS);
+  let publisherConfig: Awaited<ReturnType<typeof getConfig>>;
+  try {
+    publisherConfig = await getConfig(c.env, CONFIG_PUBLISHER_ADDRESS);
+  } catch {
+    return c.json({ error: "Failed to fetch publisher config" }, 503);
+  }
   if (!publisherConfig || publisherConfig.value !== btc_address) {
     return c.json({ error: "Only the designated Publisher can record payouts" }, 403);
   }
@@ -87,7 +92,16 @@ earningsRouter.post("/api/payouts/record", async (c) => {
     .map((s) => (s as Record<string, unknown>).signal_id as string)
     .filter(Boolean);
 
-  const result = await recordBriefInclusionPayouts(c.env, brief_date, signalIds);
+  if (signalIds.length === 0) {
+    return c.json({ error: `No valid signal IDs found in brief for ${brief_date}` }, 404);
+  }
+
+  let result: Awaited<ReturnType<typeof recordBriefInclusionPayouts>>;
+  try {
+    result = await recordBriefInclusionPayouts(c.env, brief_date, signalIds);
+  } catch {
+    return c.json({ error: "Failed to record payouts" }, 503);
+  }
 
   if (!result.ok) {
     return c.json({ error: result.error ?? "Failed to record payouts" }, 500);

--- a/src/routes/earnings.ts
+++ b/src/routes/earnings.ts
@@ -1,6 +1,7 @@
 /**
- * Earnings route — correspondent earning history.
+ * Earnings route — correspondent earning history and payout recording.
  *
+ * POST  /api/payouts/record     — Publisher records brief inclusion earnings (idempotent)
  * GET   /api/earnings/unpaid    — aggregated unpaid earnings by correspondent (Publisher-only)
  * GET   /api/earnings/:address  — list earnings for a BTC address
  * PATCH /api/earnings/:id       — Publisher records sBTC txid after sending payout
@@ -9,10 +10,107 @@
 import { Hono } from "hono";
 import type { Env, AppVariables, Earning } from "../lib/types";
 import { validateBtcAddress } from "../lib/validators";
-import { listEarnings, listUnpaidEarnings, updateEarning } from "../lib/do-client";
+import {
+  listEarnings,
+  listUnpaidEarnings,
+  updateEarning,
+  getBriefSignals,
+  recordBriefInclusionPayouts,
+  getConfig,
+} from "../lib/do-client";
 import { verifyAuth } from "../services/auth";
+import { CONFIG_PUBLISHER_ADDRESS } from "../lib/constants";
 
 const earningsRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>();
+
+// POST /api/payouts/record — Publisher records brief inclusion earnings (Publisher-only, idempotent)
+// Calls POST /payouts/brief-inclusion in the DO, which uses INSERT OR IGNORE — safe to retry.
+earningsRouter.post("/api/payouts/record", async (c) => {
+  let body: Record<string, unknown>;
+  try {
+    body = await c.req.json<Record<string, unknown>>();
+  } catch {
+    return c.json({ error: "Invalid JSON body" }, 400);
+  }
+
+  const { btc_address, brief_date } = body;
+
+  if (!btc_address || typeof btc_address !== "string") {
+    return c.json({ error: "Missing required field: btc_address" }, 400);
+  }
+  if (
+    !brief_date ||
+    typeof brief_date !== "string" ||
+    !/^\d{4}-\d{2}-\d{2}$/.test(brief_date)
+  ) {
+    return c.json(
+      { error: "Missing or invalid field: brief_date (expected YYYY-MM-DD)" },
+      400
+    );
+  }
+
+  if (!validateBtcAddress(btc_address)) {
+    return c.json({ error: "Invalid BTC address format" }, 400);
+  }
+
+  // BIP-322 auth — Publisher must sign the request
+  const authResult = verifyAuth(
+    c.req.raw.headers,
+    btc_address,
+    "POST",
+    "/api/payouts/record"
+  );
+  if (!authResult.valid) {
+    return c.json({ error: authResult.error, code: authResult.code }, 401);
+  }
+
+  // Verify caller is the designated Publisher
+  const publisherConfig = await getConfig(c.env, CONFIG_PUBLISHER_ADDRESS);
+  if (!publisherConfig || publisherConfig.value !== btc_address) {
+    return c.json({ error: "Only the designated Publisher can record payouts" }, 403);
+  }
+
+  // Look up signals included in this brief
+  let briefSignals: unknown[];
+  try {
+    briefSignals = await getBriefSignals(c.env, brief_date);
+  } catch {
+    return c.json({ error: `Failed to fetch brief signals for ${brief_date}` }, 503);
+  }
+
+  if (briefSignals.length === 0) {
+    return c.json({ error: `No signals found in brief for ${brief_date}` }, 404);
+  }
+
+  // Extract signal IDs and call the idempotent DO payout endpoint
+  const signalIds = briefSignals
+    .map((s) => (s as Record<string, unknown>).signal_id as string)
+    .filter(Boolean);
+
+  const result = await recordBriefInclusionPayouts(c.env, brief_date, signalIds);
+
+  if (!result.ok) {
+    return c.json({ error: result.error ?? "Failed to record payouts" }, 500);
+  }
+
+  const logger = c.get("logger");
+  logger.info("brief payouts recorded", {
+    brief_date,
+    paid: result.data?.paid,
+    skipped: result.data?.skipped,
+    publisher: btc_address,
+  });
+
+  return c.json(
+    {
+      ok: true,
+      brief_date,
+      paid: result.data?.paid ?? 0,
+      skipped: result.data?.skipped ?? 0,
+    },
+    201
+  );
+});
 
 // GET /api/earnings/unpaid — aggregated unpaid earnings by correspondent (Publisher-only)
 earningsRouter.get("/api/earnings/unpaid", async (c) => {


### PR DESCRIPTION
## Summary

- Adds `POST /api/payouts/record` as a Publisher-only endpoint that calls the existing `recordBriefInclusionPayouts()` DO function, which uses `INSERT OR IGNORE` for idempotency
- The DO backing functions (`getBriefSignals`, `recordBriefInclusionPayouts`) have existed on main since before this branch; this PR wires them up via HTTP
- Safe to retry: calling the endpoint twice for the same `brief_date` returns `paid=0, skipped=N` on the second call without double-recording earnings

## Request shape

```
POST /api/payouts/record
X-BTC-Address: <publisher_btc_address>
X-BTC-Signature: <bip322-signature>
X-BTC-Timestamp: <unix-timestamp>

{
  "btc_address": "bc1q...",
  "brief_date": "2026-04-29"
}
```

## Response shape

```json
{ "ok": true, "brief_date": "2026-04-29", "paid": 12, "skipped": 0 }
```

**Error cases:**
- `400` — missing/invalid fields or invalid BTC address format
- `401` — BIP-322 auth failure
- `403` — caller is not the designated Publisher
- `404` — no signals found in brief for that date
- `503` — DO unavailable when fetching brief signals

## Branch origin

Cherry-picked and rebased from `fix/erc8004-clarity-idempotency` (original commit `6dd6a2b`), isolating only the payouts endpoint. The identity-gate middleware bundled in that branch is tracked in a separate issue — see #[identity-gate-issue].

## Test plan

- [ ] TypeScript: `npm run typecheck` passes (verified locally)
- [ ] Lint: `biome lint src/routes/earnings.ts` clean (verified locally)
- [ ] CI green on this PR
- [ ] Manual: `POST /api/payouts/record` with valid Publisher auth returns 201 on first call, 201 with `skipped > 0` on retry
- [ ] Manual: calling without Publisher auth returns 403
- [ ] Manual: calling with a date that has no brief signals returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)