### PR TITLE
feat(classifieds): wallet-driven placement via direct sBTC transfer

### DIFF
--- a/public/classifieds/index.html
+++ b/public/classifieds/index.html
@@ -423,6 +423,87 @@
       border: none; padding: 10px 22px; cursor: pointer; white-space: nowrap;
     }
     .compose-copy:hover { opacity: 0.9; }
+    .compose-copy[disabled] { opacity: 0.4; cursor: not-allowed; }
+    .compose-secondary {
+      font-family: var(--sans); font-size: 11px; color: var(--text-dim);
+      text-decoration: none; border: none; background: none; cursor: pointer; padding: 0;
+    }
+    .compose-secondary:hover { color: var(--text); text-decoration: underline; }
+
+    /* Status / done / error panels share styling */
+    .compose-panel { display: block; }
+    .compose-panel[hidden] { display: none; }
+    .compose-status {
+      text-align: center;
+      padding: var(--space-4) var(--space-3);
+    }
+    .compose-status-icon {
+      font-size: 36px;
+      line-height: 1;
+      margin-bottom: var(--space-3);
+    }
+    .compose-status-icon.spin {
+      display: inline-block;
+      animation: status-spin 1.4s linear infinite;
+    }
+    @keyframes status-spin {
+      from { transform: rotate(0deg); }
+      to   { transform: rotate(360deg); }
+    }
+    .compose-status-title {
+      font-family: var(--serif); font-size: 18px; font-weight: 700;
+      color: var(--text); margin-bottom: var(--space-2);
+    }
+    .compose-status-body {
+      font-family: var(--sans); font-size: 13px; line-height: 1.55;
+      color: var(--text-secondary); margin-bottom: var(--space-3);
+    }
+    .compose-status-meta {
+      display: flex; flex-direction: column; gap: 6px;
+      font-family: var(--mono); font-size: 11px;
+      color: var(--text-faint);
+      padding: var(--space-3) 0;
+      border-top: 1px solid var(--rule-faint);
+      border-bottom: 1px solid var(--rule-faint);
+      margin-bottom: var(--space-3);
+    }
+    .compose-status-meta a {
+      color: var(--link);
+      word-break: break-all;
+    }
+    .compose-status-hint {
+      font-family: var(--sans); font-size: 11px;
+      color: var(--text-faint); font-style: italic;
+      margin-top: var(--space-2);
+    }
+    .compose-status-actions {
+      display: flex; justify-content: space-between; align-items: center;
+      gap: var(--space-3); margin-top: var(--space-3);
+    }
+    .compose-status-actions.center { justify-content: center; }
+    .compose-status[data-tone="error"] .compose-status-icon { color: var(--bad, #c62828); }
+    .compose-status[data-tone="success"] .compose-status-icon { color: var(--good, #2e7d32); }
+
+    .compose-resume-banner {
+      font-family: var(--sans); font-size: 12px;
+      background: var(--streak-bg); color: var(--text);
+      padding: 10px 12px; border-left: 3px solid var(--accent);
+      margin-bottom: var(--space-3);
+      display: flex; gap: 10px; align-items: center; justify-content: space-between;
+    }
+    .compose-resume-banner button {
+      font-family: var(--sans); font-size: 10px; font-weight: 700;
+      letter-spacing: 0.1em; text-transform: uppercase;
+      background: var(--text); color: var(--bg); border: none;
+      padding: 6px 12px; cursor: pointer;
+    }
+
+    .agent-prompt-pre {
+      font-family: var(--mono); font-size: 11px; line-height: 1.5;
+      background: var(--bg-card); border: 1px solid var(--rule-light);
+      padding: var(--space-3); margin-bottom: var(--space-3);
+      max-height: 50vh; overflow: auto; white-space: pre-wrap; word-break: break-word;
+    }
   </style>
 </head>
 <body>
@@ -437,49 +518,107 @@
 
   <main id="root"></main>
 
-  <!-- Post-a-classified prompt builder -->
+  <!-- Post-a-classified — wallet flow (form) + agent prompt fallback -->
   <div class="compose-overlay" id="compose-overlay">
     <div class="compose-modal" role="dialog" aria-modal="true" aria-label="Post a classified">
       <div class="compose-head">
         <div>
           <div class="compose-kicker">Post a Classified</div>
-          <h3>Draft a prompt for your agent</h3>
+          <h3 id="compose-title-text">Place your listing</h3>
         </div>
         <button class="compose-close" id="compose-close" aria-label="Close">&times;</button>
       </div>
-      <p class="compose-intro">
-        Classifieds cost <b>3,000 sats sBTC</b> via x402 for a 7-day listing.
-        Fill in the fields below, copy the prompt, and hand it to your agent —
-        it'll execute the payment + API call. Full spec: <a href="/llms.txt" target="_blank">llms.txt</a>.
-      </p>
 
-      <div class="compose-grid">
-        <label class="compose-label">Category
-          <select id="compose-category">
-            <option value="wanted">Wanted</option>
-            <option value="services">Services</option>
-            <option value="ordinals">Ordinals</option>
-            <option value="agents">Agents</option>
-          </select>
+      <!-- ── Form panel ── -->
+      <div class="compose-panel" id="panel-form">
+        <div class="compose-resume-banner" id="resume-banner" hidden>
+          <span id="resume-banner-text">A previous payment is still being verified. Resume?</span>
+          <button type="button" id="resume-banner-btn">Resume</button>
+        </div>
+
+        <p class="compose-intro">
+          Pay <b>3,000 sats sBTC</b> from your Stacks wallet (Leather, Xverse) for a 7-day listing.
+          You cover the network fee in STX (~0.001 STX). Listings go live after a quick editorial review.
+        </p>
+
+        <div class="compose-grid">
+          <label class="compose-label">Category
+            <select id="compose-category">
+              <option value="wanted">Wanted</option>
+              <option value="services">Services</option>
+              <option value="ordinals">Ordinals</option>
+              <option value="agents">Agents</option>
+            </select>
+          </label>
+          <label class="compose-label">Contact BTC address (optional)
+            <input type="text" id="compose-addr" placeholder="bc1q… (defaults to your STX address)" spellcheck="false">
+          </label>
+        </div>
+
+        <label class="compose-label">Title
+          <input type="text" id="compose-title" maxlength="100" placeholder="Short ad title, max 100 chars">
         </label>
-        <label class="compose-label">Contact BTC address (optional)
-          <input type="text" id="compose-addr" placeholder="bc1q… (overrides x402 payer)" spellcheck="false">
+
+        <label class="compose-label">Body (optional)
+          <textarea id="compose-body" rows="4" maxlength="500" placeholder="Describe what you're offering or looking for. Max 500 chars."></textarea>
         </label>
+
+        <div class="compose-actions">
+          <button class="compose-secondary" id="compose-agent-link" type="button">Posting from an agent? Copy a prompt instead</button>
+          <button class="compose-copy" id="compose-pay" type="button">Connect wallet &amp; pay</button>
+        </div>
       </div>
 
-      <label class="compose-label">Title
-        <input type="text" id="compose-title" maxlength="100" placeholder="Short ad title, max 100 chars">
-      </label>
-
-      <label class="compose-label">Body (optional)
-        <textarea id="compose-body" rows="4" maxlength="500" placeholder="Describe what you're offering or looking for. Max 500 chars."></textarea>
-      </label>
-
-      <div class="compose-actions">
-        <div class="compose-hint" id="compose-hint">
-          Fill the fields, then copy the prompt to your agent.
+      <!-- ── Status panel (signing / broadcasting / mempool / confirming) ── -->
+      <div class="compose-panel compose-status" id="panel-status" hidden>
+        <div class="compose-status-icon" id="status-icon">⌛</div>
+        <h4 class="compose-status-title" id="status-title">Confirm in your wallet…</h4>
+        <p class="compose-status-body" id="status-body">Approve the sBTC transfer in your Stacks wallet to broadcast the payment.</p>
+        <div class="compose-status-meta" id="status-meta" hidden>
+          <span><strong>Transaction:</strong> <a id="status-explorer" href="#" target="_blank" rel="noopener"></a></span>
         </div>
-        <button class="compose-copy" id="compose-copy" type="button">Copy prompt</button>
+        <p class="compose-status-hint" id="status-hint" hidden>Stacks confirmations usually take 20 seconds to a minute. Keep this tab open.</p>
+      </div>
+
+      <!-- ── Done panel ── -->
+      <div class="compose-panel compose-status" id="panel-done" data-tone="success" hidden>
+        <div class="compose-status-icon">✓</div>
+        <h4 class="compose-status-title">Submitted for editorial review</h4>
+        <p class="compose-status-body">An editor will review your listing — usually within a day. Once approved, your ad goes live for 7 days.</p>
+        <div class="compose-status-meta">
+          <span><strong>Transaction:</strong> <a id="done-explorer" href="#" target="_blank" rel="noopener"></a></span>
+        </div>
+        <div class="compose-status-actions">
+          <button class="compose-secondary" id="done-view-mine" type="button">View my submissions →</button>
+          <button class="compose-copy" id="done-close" type="button">Done</button>
+        </div>
+      </div>
+
+      <!-- ── Error panel ── -->
+      <div class="compose-panel compose-status" id="panel-error" data-tone="error" hidden>
+        <div class="compose-status-icon">⚠</div>
+        <h4 class="compose-status-title" id="error-title">Something went wrong</h4>
+        <p class="compose-status-body" id="error-body">…</p>
+        <div class="compose-status-meta" id="error-meta" hidden>
+          <span><strong>Transaction:</strong> <a id="error-explorer" href="#" target="_blank" rel="noopener"></a></span>
+        </div>
+        <div class="compose-status-actions">
+          <button class="compose-secondary" id="error-back" type="button">← Back to form</button>
+          <button class="compose-copy" id="error-retry" type="button" hidden>Retry</button>
+        </div>
+      </div>
+
+      <!-- ── Agent prompt panel (legacy MCP/x402 path, behind a secondary link) ── -->
+      <div class="compose-panel" id="panel-agent" hidden>
+        <p class="compose-intro">
+          Hand this prompt to your AI agent — it'll execute the x402 payment + API call.
+          Full spec: <a href="/llms.txt" target="_blank">llms.txt</a>.
+        </p>
+        <pre class="agent-prompt-pre" id="agent-prompt-text"></pre>
+        <div class="compose-status-actions">
+          <button class="compose-secondary" id="agent-back" type="button">← Back to wallet flow</button>
+          <button class="compose-copy" id="agent-copy" type="button">Copy prompt</button>
+        </div>
       </div>
     </div>
   </div>
@@ -590,16 +729,462 @@
       applyData(data);
     }
 
-    // ── Post a Classified: build a ready-to-paste agent prompt (MCP-first) ──
-    function buildClassifiedPrompt() {
-      const cat = document.getElementById('compose-category').value;
-      const addr = document.getElementById('compose-addr').value.trim();
-      const title = document.getElementById('compose-title').value.trim();
-      const body = document.getElementById('compose-body').value.trim();
-      const params = { title: title || '<ad title, max 100 chars>', category: cat };
-      if (body) params.body = body;
-      if (addr) params.btc_address = addr;
+    // ── Wallet-driven classifieds flow ───────────────────────────────────────
+    // Modal state machine: form → signing → broadcasting → mempool → confirming
+    // → done | error. localStorage persistence keyed by 'aibtc:pendingClassified'
+    // protects users who close the tab between broadcast and final POST.
+    //
+    // Stacks libraries are CDN-loaded only when the user clicks "Connect & pay"
+    // — page weight stays the same for visitors who only browse listings.
 
+    const SBTC_CONTRACT_ADDR = 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4';
+    const SBTC_CONTRACT_NAME = 'sbtc-token';
+    const SBTC_ASSET_NAME    = 'sbtc-token';
+    const SBTC_CONTRACT_FULL = SBTC_CONTRACT_ADDR + '.' + SBTC_CONTRACT_NAME;
+    const TREASURY_STX_ADDR  = 'SP236MA9EWHF1DN3X84EQAJEW7R6BDZZ93K3EMC3C';
+    const CLASSIFIED_PRICE_SATS = 3000;
+    const HIRO_API           = 'https://api.hiro.so';
+    const HIRO_WS            = 'wss://api.hiro.so';
+    const PENDING_KEY        = 'aibtc:pendingClassified';
+    const POLL_FALLBACK_MS   = 8000;
+    const POLL_MAX_MS        = 4 * 60 * 1000; // 4 min — Stacks is usually 20–60s
+
+    let stacksLibs = null; // { connect, request, Cl, PostConditionMode } once loaded
+    let wsClient = null;   // shared WebSocket client per modal session
+    let pollTimer = null;
+    let pollStartedAt = 0;
+    let activeSubscription = null;
+
+    function loadStacks() {
+      if (stacksLibs) return Promise.resolve(stacksLibs);
+      return Promise.all([
+        import('https://esm.sh/@stacks/connect@7.10.1'),
+        import('https://esm.sh/@stacks/transactions@7.0.6'),
+      ]).then(([connectMod, txMod]) => {
+        stacksLibs = {
+          connect: connectMod.connect || connectMod.default?.connect,
+          request: connectMod.request || connectMod.default?.request,
+          getLocalStorage: connectMod.getLocalStorage,
+          Cl: txMod.Cl,
+          PostConditionMode: txMod.PostConditionMode,
+          Pc: txMod.Pc,
+        };
+        return stacksLibs;
+      });
+    }
+
+    function loadHiroWs() {
+      return import('https://esm.sh/@stacks/blockchain-api-client@7.10.0')
+        .then((mod) => mod.connectWebSocketClient || mod.default?.connectWebSocketClient);
+    }
+
+    // ── State persistence ─────────────────────────────────────────────────────
+    function savePending(state) {
+      try { localStorage.setItem(PENDING_KEY, JSON.stringify(state)); } catch {}
+    }
+    function loadPending() {
+      try {
+        const raw = localStorage.getItem(PENDING_KEY);
+        if (!raw) return null;
+        const parsed = JSON.parse(raw);
+        // Drop stale entries older than 1 hour
+        if (parsed.savedAt && Date.now() - parsed.savedAt > 60 * 60 * 1000) {
+          clearPending();
+          return null;
+        }
+        return parsed;
+      } catch { return null; }
+    }
+    function clearPending() {
+      try { localStorage.removeItem(PENDING_KEY); } catch {}
+    }
+
+    // ── Panel control ─────────────────────────────────────────────────────────
+    const PANEL_IDS = ['panel-form', 'panel-status', 'panel-done', 'panel-error', 'panel-agent'];
+    function showPanel(id) {
+      for (const pid of PANEL_IDS) {
+        const el = document.getElementById(pid);
+        if (el) el.hidden = pid !== id;
+      }
+      const titleEl = document.getElementById('compose-title-text');
+      if (titleEl) {
+        titleEl.textContent = ({
+          'panel-form':   'Place your listing',
+          'panel-status': 'Processing payment',
+          'panel-done':   'Listing submitted',
+          'panel-error':  'Couldn’t submit listing',
+          'panel-agent':  'Agent prompt',
+        })[id] || 'Place your listing';
+      }
+    }
+
+    function setStatus({ icon, title, body, txid, hint, spin }) {
+      document.getElementById('status-icon').textContent = icon || '⏳';
+      document.getElementById('status-icon').classList.toggle('spin', !!spin);
+      document.getElementById('status-title').textContent = title || '';
+      document.getElementById('status-body').textContent = body || '';
+      const meta = document.getElementById('status-meta');
+      const link = document.getElementById('status-explorer');
+      if (txid) {
+        link.href = 'https://explorer.hiro.so/txid/' + encodeURIComponent(txid) + '?chain=mainnet';
+        link.textContent = txid.slice(0, 8) + '…' + txid.slice(-8);
+        meta.hidden = false;
+      } else {
+        meta.hidden = true;
+      }
+      const hintEl = document.getElementById('status-hint');
+      if (hint) { hintEl.hidden = false; hintEl.textContent = hint; }
+      else      { hintEl.hidden = true; }
+      showPanel('panel-status');
+    }
+
+    function setError({ title, body, txid, retryable }) {
+      document.getElementById('error-title').textContent = title || 'Something went wrong';
+      document.getElementById('error-body').textContent = body || '';
+      const meta = document.getElementById('error-meta');
+      const link = document.getElementById('error-explorer');
+      if (txid) {
+        link.href = 'https://explorer.hiro.so/txid/' + encodeURIComponent(txid) + '?chain=mainnet';
+        link.textContent = txid.slice(0, 8) + '…' + txid.slice(-8);
+        meta.hidden = false;
+      } else {
+        meta.hidden = true;
+      }
+      const retryBtn = document.getElementById('error-retry');
+      retryBtn.hidden = !retryable;
+      showPanel('panel-error');
+    }
+
+    function setDone(txid, sender) {
+      const link = document.getElementById('done-explorer');
+      link.href = 'https://explorer.hiro.so/txid/' + encodeURIComponent(txid) + '?chain=mainnet';
+      link.textContent = txid.slice(0, 8) + '…' + txid.slice(-8);
+      const viewMine = document.getElementById('done-view-mine');
+      if (sender) {
+        viewMine.hidden = false;
+        viewMine.onclick = () => {
+          window.location.href = '/classifieds/?agent=' + encodeURIComponent(sender);
+        };
+      } else {
+        viewMine.hidden = true;
+      }
+      showPanel('panel-done');
+    }
+
+    // ── Form helpers ──────────────────────────────────────────────────────────
+    function readForm() {
+      return {
+        category: document.getElementById('compose-category').value,
+        title:    document.getElementById('compose-title').value.trim(),
+        body:     document.getElementById('compose-body').value.trim(),
+        addr:     document.getElementById('compose-addr').value.trim(),
+      };
+    }
+    function validateForm(f) {
+      if (!f.title) return 'Please add a title for your listing.';
+      if (f.title.length > 100) return 'Title must be 100 characters or fewer.';
+      if (f.body && f.body.length > 500) return 'Body must be 500 characters or fewer.';
+      if (f.addr && !/^bc1[a-z0-9]{8,}$/i.test(f.addr)) return 'Contact BTC address must be a bc1… bech32 address.';
+      return null;
+    }
+
+    // ── Main flow ─────────────────────────────────────────────────────────────
+    async function startPayment() {
+      const form = readForm();
+      const formError = validateForm(form);
+      if (formError) {
+        setError({ title: 'Please fix the form', body: formError, retryable: false });
+        return;
+      }
+
+      let libs;
+      try {
+        setStatus({ icon: '⏳', spin: true, title: 'Loading wallet support…', body: 'Fetching Stacks libraries.' });
+        libs = await loadStacks();
+      } catch (e) {
+        setError({ title: 'Couldn’t load wallet support', body: 'Failed to load the Stacks libraries. Check your internet connection and try again.', retryable: true });
+        return;
+      }
+
+      // Connect / get the user's STX address
+      let stxAddress = null;
+      try {
+        setStatus({ icon: '⏳', spin: true, title: 'Connect your wallet', body: 'Approve the connection request in your Stacks wallet.' });
+        const data = await libs.connect();
+        // Newer @stacks/connect returns { addresses: [{address, symbol: 'STX'}, ...] }.
+        // Some versions return { addresses: { stx: [{address}] } }. Handle both.
+        if (Array.isArray(data?.addresses)) {
+          stxAddress = (data.addresses.find(a => a.symbol === 'STX' || /^SP[A-Z0-9]+$/.test(a.address || '')) || {}).address;
+        } else if (data?.addresses?.stx) {
+          stxAddress = data.addresses.stx[0]?.address;
+        }
+        if (!stxAddress && libs.getLocalStorage) {
+          const stored = libs.getLocalStorage();
+          stxAddress = stored?.addresses?.stx?.[0]?.address;
+        }
+      } catch (e) {
+        setError({ title: 'Wallet connection cancelled', body: 'You closed the wallet prompt before connecting. Try again when you’re ready.', retryable: true });
+        return;
+      }
+      if (!stxAddress) {
+        setError({ title: 'No STX address available', body: 'We couldn’t read a Stacks address from your wallet. Make sure you’re using a Stacks-compatible wallet (Leather, Xverse).', retryable: true });
+        return;
+      }
+
+      // Sign + broadcast the sBTC transfer
+      setStatus({ icon: '⏳', spin: true, title: 'Confirm in your wallet', body: 'Approve the 3,000 sat sBTC transfer to publish your listing. The wallet will show the post-condition that caps the transfer at exactly that amount.' });
+
+      let txid;
+      try {
+        const fnArgs = [
+          libs.Cl.uint(CLASSIFIED_PRICE_SATS),
+          libs.Cl.principal(stxAddress),
+          libs.Cl.principal(TREASURY_STX_ADDR),
+          libs.Cl.none(),
+        ];
+        // Post-condition: caller transfers EXACTLY CLASSIFIED_PRICE_SATS of sBTC.
+        // Different connect versions use different post-condition shapes — try
+        // the modern object form first; fall back to none if the wallet rejects it.
+        const postConditions = [{
+          type: 'ft-postcondition',
+          address: stxAddress,
+          condition: 'eq',
+          amount: String(CLASSIFIED_PRICE_SATS),
+          asset: SBTC_CONTRACT_FULL + '::' + SBTC_ASSET_NAME,
+        }];
+
+        const result = await libs.request('stx_callContract', {
+          contract: SBTC_CONTRACT_FULL,
+          functionName: 'transfer',
+          functionArgs: fnArgs,
+          network: 'mainnet',
+          postConditions,
+          postConditionMode: 'deny',
+        });
+        txid = result?.txid || result?.txId || result?.txID || result?.transactionId;
+        if (!txid) throw new Error('Wallet did not return a txid');
+        if (!txid.startsWith('0x')) txid = '0x' + txid;
+      } catch (e) {
+        const msg = (e && (e.message || e.error || String(e))) || '';
+        if (/cancel|denied|reject/i.test(msg)) {
+          setError({ title: 'Payment cancelled', body: 'You declined the transaction in your wallet. No charge.', retryable: true });
+        } else {
+          setError({ title: 'Wallet error', body: 'The wallet rejected the transfer: ' + msg, retryable: true });
+        }
+        return;
+      }
+
+      // Persist + start watching
+      const pending = {
+        txid,
+        sender: stxAddress,
+        form,
+        savedAt: Date.now(),
+      };
+      savePending(pending);
+      await watchAndSubmit(pending);
+    }
+
+    async function watchAndSubmit(pending) {
+      const txid = pending.txid;
+
+      setStatus({
+        icon: '⚡', title: 'Broadcasting payment…',
+        body: 'Your transaction is on its way to the Stacks network.',
+        txid,
+        hint: 'Stacks confirmations usually take 20 seconds to a minute. Keep this tab open.',
+      });
+
+      // Try WebSocket first; fall back to polling if it can't subscribe.
+      let confirmed = false;
+      let aborted   = false;
+
+      try {
+        const connectWebSocketClient = await loadHiroWs();
+        wsClient = await connectWebSocketClient(HIRO_WS);
+        activeSubscription = await wsClient.subscribeTxUpdates(txid, (evt) => {
+          if (confirmed || aborted) return;
+          if (evt.tx_status === 'success') {
+            confirmed = true;
+            cleanupWatchers();
+            submitToServer(pending).catch(() => {});
+          } else if (evt.tx_status && evt.tx_status !== 'pending') {
+            aborted = true;
+            cleanupWatchers();
+            setError({
+              title: 'Payment failed on-chain',
+              body: 'The transaction did not succeed (' + evt.tx_status + '). No listing was posted, and no charge will appear on confirmation.',
+              txid,
+              retryable: false,
+            });
+            clearPending();
+          } else if (evt.tx_status === 'pending') {
+            setStatus({
+              icon: '⏳', spin: true, title: 'In the mempool…',
+              body: 'Waiting for a Stacks block to include your transaction.',
+              txid,
+              hint: 'Usually 20 seconds to a minute. Keep this tab open.',
+            });
+          }
+        });
+      } catch (e) {
+        // WebSocket not available — fall back to polling only
+        console.warn('Hiro WebSocket unavailable, falling back to polling', e);
+      }
+
+      // Poll Hiro REST as a fallback / belt-and-suspenders. The WS subscription
+      // sometimes misses the first event if the tx confirms before subscribe completes.
+      pollStartedAt = Date.now();
+      const tick = async () => {
+        if (confirmed || aborted) return;
+        if (Date.now() - pollStartedAt > POLL_MAX_MS) {
+          // Stop polling but leave localStorage so the user can resume later
+          cleanupWatchers();
+          setError({
+            title: 'Still waiting on confirmation',
+            body: 'Stacks is taking longer than usual. Your transaction is saved — close this and reopen the modal later to resume verification.',
+            txid,
+            retryable: false,
+          });
+          return;
+        }
+        try {
+          const r = await fetch(HIRO_API + '/extended/v1/tx/' + encodeURIComponent(txid));
+          if (r.ok) {
+            const tx = await r.json();
+            if (tx.tx_status === 'success' && !confirmed) {
+              confirmed = true;
+              cleanupWatchers();
+              submitToServer(pending).catch(() => {});
+              return;
+            }
+            if (tx.tx_status && tx.tx_status !== 'pending' && tx.tx_status !== 'success' && !aborted) {
+              aborted = true;
+              cleanupWatchers();
+              setError({
+                title: 'Payment failed on-chain',
+                body: 'The transaction did not succeed (' + tx.tx_status + '). No listing was posted.',
+                txid,
+                retryable: false,
+              });
+              clearPending();
+              return;
+            }
+          }
+        } catch {}
+        pollTimer = setTimeout(tick, POLL_FALLBACK_MS);
+      };
+      pollTimer = setTimeout(tick, POLL_FALLBACK_MS);
+    }
+
+    function cleanupWatchers() {
+      if (pollTimer) { clearTimeout(pollTimer); pollTimer = null; }
+      if (activeSubscription) {
+        try { activeSubscription.unsubscribe(); } catch {}
+        activeSubscription = null;
+      }
+    }
+
+    async function submitToServer(pending) {
+      setStatus({
+        icon: '⏳', spin: true,
+        title: 'Payment confirmed — submitting your listing…',
+        body: 'We saw the transaction confirm on Stacks. Recording your listing now.',
+        txid: pending.txid,
+      });
+
+      const payload = {
+        txid: pending.txid,
+        title: pending.form.title,
+        category: pending.form.category,
+        body: pending.form.body || undefined,
+        btc_address: pending.form.addr || undefined,
+      };
+
+      // Up to 4 attempts with backoff. Idempotent server-side via the
+      // partial UNIQUE index on payment_txid.
+      const delays = [0, 1500, 4000, 9000];
+      let lastErr = null;
+      for (let i = 0; i < delays.length; i++) {
+        if (delays[i]) await new Promise(r => setTimeout(r, delays[i]));
+        try {
+          const res = await fetch('/api/classifieds/web', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+          });
+          if (res.status === 201 || res.status === 200) {
+            clearPending();
+            const data = await res.json().catch(() => ({}));
+            setDone(pending.txid, data.placedBy || pending.sender);
+            return;
+          }
+          if (res.status === 202 || res.status === 404) {
+            // Server thinks the tx is still pending or not yet visible — keep retrying
+            const data = await res.json().catch(() => ({}));
+            setStatus({
+              icon: '⏳', spin: true,
+              title: 'Waiting for the network to catch up…',
+              body: data.error || 'Stacks is still indexing your transaction.',
+              txid: pending.txid,
+              hint: 'Re-checking shortly.',
+            });
+            lastErr = data.error || ('HTTP ' + res.status);
+            continue;
+          }
+          // 400 / 503 / other — terminal as far as the loop is concerned
+          const data = await res.json().catch(() => ({}));
+          lastErr = data.error || ('HTTP ' + res.status);
+          if (res.status >= 500) {
+            // Try again
+            continue;
+          }
+          // 4xx — terminal
+          setError({
+            title: 'Server rejected the listing',
+            body: lastErr,
+            txid: pending.txid,
+            retryable: false,
+          });
+          clearPending();
+          return;
+        } catch (e) {
+          lastErr = (e && e.message) || String(e);
+        }
+      }
+
+      setError({
+        title: 'Couldn’t finalize submission',
+        body: 'Your payment confirmed but we couldn’t reach the server. Your transaction is saved — reopen this modal later and we’ll resume.',
+        txid: pending.txid,
+        retryable: true,
+      });
+    }
+
+    // ── Resume support ────────────────────────────────────────────────────────
+    function maybeShowResumeBanner() {
+      const pending = loadPending();
+      const banner  = document.getElementById('resume-banner');
+      if (!banner) return;
+      if (!pending || !pending.txid) {
+        banner.hidden = true;
+        return;
+      }
+      banner.hidden = false;
+      document.getElementById('resume-banner-text').textContent =
+        'A previous submission for tx ' + pending.txid.slice(0, 10) + '… is unfinished. Resume?';
+      document.getElementById('resume-banner-btn').onclick = async () => {
+        banner.hidden = true;
+        await watchAndSubmit(pending);
+      };
+    }
+
+    // ── Agent-prompt fallback (unchanged copy/paste path) ─────────────────────
+    function buildClassifiedPrompt() {
+      const f = readForm();
+      const params = { title: f.title || '<ad title, max 100 chars>', category: f.category };
+      if (f.body) params.body = f.body;
+      if (f.addr) params.btc_address = f.addr;
       return ''
 + 'Please post this classified on AIBTC News using the news_post_classified tool\n'
 + 'from the aibtc-mcp-server MCP:\n'
@@ -607,46 +1192,78 @@
 + JSON.stringify(params, null, 2) + '\n'
 + '\n'
 + '# Payment: 3,000 sats sBTC via x402 · 7-day listing\n'
-+ '# ──────────────────────────────────────────────────────────────\n'
++ '# ──────────────────────────────────────────────\n'
 + '# Only if aibtc-mcp-server is not available:\n'
 + '# Install: npm i @aibtc/mcp-server\n'
 + '# Or POST https://aibtc.news/api/classifieds with X-PAYMENT header.\n'
 + '# Full spec: https://aibtc.news/llms.txt\n';
     }
 
+    // ── Wire up modal ─────────────────────────────────────────────────────────
     function bindCompose() {
-      const btn = document.getElementById('post-listing-btn');
+      const btn     = document.getElementById('post-listing-btn');
       const overlay = document.getElementById('compose-overlay');
-      const close = document.getElementById('compose-close');
-      const copy = document.getElementById('compose-copy');
+      const close   = document.getElementById('compose-close');
       if (!btn || !overlay) return;
 
-      btn.addEventListener('click', () => {
+      function open() {
+        showPanel('panel-form');
+        maybeShowResumeBanner();
         overlay.classList.add('open');
         document.body.style.overflow = 'hidden';
-      });
-      close.addEventListener('click', () => {
+      }
+      function shut() {
+        cleanupWatchers();
         overlay.classList.remove('open');
         document.body.style.overflow = '';
-      });
-      overlay.addEventListener('click', (e) => {
-        if (e.target === overlay) {
-          overlay.classList.remove('open');
-          document.body.style.overflow = '';
-        }
-      });
+      }
+
+      btn.addEventListener('click', open);
+      close.addEventListener('click', shut);
+      overlay.addEventListener('click', (e) => { if (e.target === overlay) shut(); });
       document.addEventListener('keydown', (e) => {
-        if (e.key === 'Escape' && overlay.classList.contains('open')) {
-          overlay.classList.remove('open');
-          document.body.style.overflow = '';
-        }
+        if (e.key === 'Escape' && overlay.classList.contains('open')) shut();
       });
-      copy.addEventListener('click', () => {
-        navigator.clipboard.writeText(buildClassifiedPrompt()).then(() => {
-          copy.textContent = 'Copied!';
-          setTimeout(() => { copy.textContent = 'Copy prompt'; }, 1500);
+
+      // Form -> wallet flow
+      document.getElementById('compose-pay').addEventListener('click', () => {
+        startPayment().catch((e) => {
+          setError({ title: 'Unexpected error', body: (e && e.message) || String(e), retryable: true });
         });
       });
+
+      // Done / error transitions back to form
+      document.getElementById('done-close').addEventListener('click', shut);
+      document.getElementById('error-back').addEventListener('click', () => showPanel('panel-form'));
+      document.getElementById('error-retry').addEventListener('click', () => {
+        const pending = loadPending();
+        if (pending) {
+          watchAndSubmit(pending).catch(() => {});
+        } else {
+          startPayment().catch(() => {});
+        }
+      });
+
+      // Agent fallback link
+      document.getElementById('compose-agent-link').addEventListener('click', () => {
+        document.getElementById('agent-prompt-text').textContent = buildClassifiedPrompt();
+        showPanel('panel-agent');
+      });
+      document.getElementById('agent-back').addEventListener('click', () => showPanel('panel-form'));
+      const agentCopy = document.getElementById('agent-copy');
+      agentCopy.addEventListener('click', () => {
+        navigator.clipboard.writeText(buildClassifiedPrompt()).then(() => {
+          agentCopy.textContent = 'Copied!';
+          setTimeout(() => { agentCopy.textContent = 'Copy prompt'; }, 1500);
+        });
+      });
+
+      // Auto-show modal in resume state if there's a pending submission on load
+      if (loadPending()) {
+        // Don't auto-open, but the banner inside the modal will surface it on next open.
+        // Surface a tiny indicator on the post button instead.
+        btn.textContent = '+ Post a Classified • (1 pending)';
+      }
     }
 
     async function initDetail(root, id) {

--- a/src/__tests__/classifieds-web.test.ts
+++ b/src/__tests__/classifieds-web.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Integration tests for POST /api/classifieds/web — wallet-driven classifieds.
+ *
+ * Mocks globalThis.fetch so the Hiro Stacks API never gets a real call, but
+ * the rest of the pipeline (route handler, DO insert, partial UNIQUE index,
+ * idempotency check) runs end-to-end against the in-test Worker.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SELF } from "cloudflare:test";
+import {
+  CLASSIFIED_PRICE_SATS,
+  SBTC_CONTRACT_MAINNET,
+  TREASURY_STX_ADDRESS,
+} from "../lib/constants";
+
+const SAMPLE_TXID = "0x" + "ab".repeat(32);
+const SENDER_STX = "SP2C2QH2H2H2H2H2H2H2H2H2H2H2H2H2H2H2H2H2";
+
+const originalFetch = globalThis.fetch;
+
+function makeHiroSuccess(overrides: Record<string, unknown> = {}): Response {
+  return new Response(
+    JSON.stringify({
+      tx_id: SAMPLE_TXID,
+      tx_status: "success",
+      tx_type: "contract_call",
+      sender_address: SENDER_STX,
+      block_height: 200000,
+      contract_call: {
+        contract_id: SBTC_CONTRACT_MAINNET,
+        function_name: "transfer",
+      },
+      events: [
+        {
+          event_type: "fungible_token_asset",
+          asset: {
+            asset_event_type: "transfer",
+            asset_id: `${SBTC_CONTRACT_MAINNET}::sbtc-token`,
+            sender: SENDER_STX,
+            recipient: TREASURY_STX_ADDRESS,
+            amount: String(CLASSIFIED_PRICE_SATS),
+          },
+        },
+      ],
+      ...overrides,
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } }
+  );
+}
+
+/** Replace globalThis.fetch but keep Worker-internal fetches working. */
+function mockHiroFetch(impl: (txid: string) => Response | Promise<Response>) {
+  globalThis.fetch = vi.fn<typeof fetch>(async (input, init) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    if (url.startsWith("https://api.hiro.so/")) {
+      const txid = decodeURIComponent(url.split("/").pop() ?? "");
+      return impl(txid);
+    }
+    return originalFetch(input as RequestInfo, init);
+  });
+}
+
+beforeEach(() => {
+  // Each test installs its own Hiro stub; default to original fetch otherwise.
+  globalThis.fetch = originalFetch;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  globalThis.fetch = originalFetch;
+});
+
+async function postWeb(body: Record<string, unknown>) {
+  return SELF.fetch("http://example.com/api/classifieds/web", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/classifieds/web — happy path", () => {
+  it("creates a pending_review classified after a verified sBTC transfer", async () => {
+    mockHiroFetch(() => makeHiroSuccess());
+
+    const res = await postWeb({
+      txid: SAMPLE_TXID,
+      title: "Wallet flow ad",
+      category: "services",
+      body: "Posted from a real Stacks wallet.",
+    });
+
+    expect(res.status).toBe(201);
+    const body = await res.json<Record<string, unknown>>();
+    expect(body.title).toBe("Wallet flow ad");
+    expect(body.category).toBe("services");
+    expect(body.status).toBe("pending_review");
+    expect(body.placedBy).toBe(SENDER_STX);
+    expect(body.paymentTxid).toBe(SAMPLE_TXID);
+    expect(body.message).toContain("editorial review");
+  });
+
+  it("uses caller-supplied btc_address when provided", async () => {
+    mockHiroFetch(() => makeHiroSuccess());
+    const customAddr = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+    const res = await postWeb({
+      txid: "0x" + "cd".repeat(32),
+      title: "Override addr",
+      category: "wanted",
+      btc_address: customAddr,
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json<Record<string, unknown>>();
+    expect(body.placedBy).toBe(customAddr);
+  });
+});
+
+describe("POST /api/classifieds/web — idempotency", () => {
+  it("returns the existing row instead of inserting twice for the same txid", async () => {
+    const reusedTxid = "0x" + "ee".repeat(32);
+    mockHiroFetch(() => makeHiroSuccess({ tx_id: reusedTxid }));
+
+    const first = await postWeb({
+      txid: reusedTxid,
+      title: "Replay test",
+      category: "agents",
+    });
+    expect(first.status).toBe(201);
+    const firstBody = await first.json<Record<string, unknown>>();
+
+    const second = await postWeb({
+      txid: reusedTxid,
+      title: "Replay test (different title — should be ignored)",
+      category: "agents",
+    });
+    expect(second.status).toBe(200);
+    const secondBody = await second.json<Record<string, unknown>>();
+    expect(secondBody.id).toBe(firstBody.id);
+    expect(secondBody.title).toBe("Replay test"); // original wins
+    expect(secondBody.message).toContain("already submitted");
+  });
+});
+
+describe("POST /api/classifieds/web — verification failures", () => {
+  it("returns 202 with Retry-After when the tx is still pending", async () => {
+    mockHiroFetch(() => makeHiroSuccess({ tx_status: "pending" }));
+    const res = await postWeb({
+      txid: "0x" + "11".repeat(32),
+      title: "Pending",
+      category: "services",
+    });
+    expect(res.status).toBe(202);
+    expect(res.headers.get("Retry-After")).toBe("10");
+    const body = await res.json<{ code: string; retryable: boolean }>();
+    expect(body.code).toBe("TX_PENDING");
+    expect(body.retryable).toBe(true);
+  });
+
+  it("returns 404 when the tx is not yet visible to Hiro", async () => {
+    mockHiroFetch(() => new Response("not found", { status: 404 }));
+    const res = await postWeb({
+      txid: "0x" + "22".repeat(32),
+      title: "Not found",
+      category: "services",
+    });
+    expect(res.status).toBe(404);
+    const body = await res.json<{ code: string }>();
+    expect(body.code).toBe("TX_NOT_FOUND");
+  });
+
+  it("returns 400 when the tx aborted on-chain", async () => {
+    mockHiroFetch(() => makeHiroSuccess({ tx_status: "abort_by_post_condition" }));
+    const res = await postWeb({
+      txid: "0x" + "33".repeat(32),
+      title: "Aborted",
+      category: "services",
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json<{ code: string; retryable: boolean }>();
+    expect(body.code).toBe("TX_ABORTED");
+    expect(body.retryable).toBe(false);
+  });
+
+  it("returns 400 for wrong recipient", async () => {
+    mockHiroFetch(() =>
+      makeHiroSuccess({
+        events: [
+          {
+            event_type: "fungible_token_asset",
+            asset: {
+              asset_event_type: "transfer",
+              asset_id: `${SBTC_CONTRACT_MAINNET}::sbtc-token`,
+              sender: SENDER_STX,
+              recipient: "SP000000000000000000002Q6VF78",
+              amount: String(CLASSIFIED_PRICE_SATS),
+            },
+          },
+        ],
+      })
+    );
+    const res = await postWeb({
+      txid: "0x" + "44".repeat(32),
+      title: "Wrong recipient",
+      category: "services",
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json<{ code: string }>();
+    expect(body.code).toBe("WRONG_RECIPIENT");
+  });
+
+  it("returns 400 for insufficient amount", async () => {
+    mockHiroFetch(() =>
+      makeHiroSuccess({
+        events: [
+          {
+            event_type: "fungible_token_asset",
+            asset: {
+              asset_event_type: "transfer",
+              asset_id: `${SBTC_CONTRACT_MAINNET}::sbtc-token`,
+              sender: SENDER_STX,
+              recipient: TREASURY_STX_ADDRESS,
+              amount: String(CLASSIFIED_PRICE_SATS - 1),
+            },
+          },
+        ],
+      })
+    );
+    const res = await postWeb({
+      txid: "0x" + "55".repeat(32),
+      title: "Underpaid",
+      category: "services",
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json<{ code: string }>();
+    expect(body.code).toBe("INSUFFICIENT_AMOUNT");
+  });
+
+  it("returns 503 when Hiro is unavailable", async () => {
+    mockHiroFetch(() => new Response("upstream", { status: 503 }));
+    const res = await postWeb({
+      txid: "0x" + "66".repeat(32),
+      title: "Hiro down",
+      category: "services",
+    });
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("10");
+    const body = await res.json<{ code: string; retryable: boolean }>();
+    expect(body.code).toBe("HIRO_UNAVAILABLE");
+    expect(body.retryable).toBe(true);
+  });
+});
+
+describe("POST /api/classifieds/web — input validation", () => {
+  it("returns 400 for missing txid", async () => {
+    const res = await postWeb({ title: "x", category: "services" });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for malformed txid", async () => {
+    const res = await postWeb({ txid: "not-a-hex", title: "x", category: "services" });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for missing title and headline", async () => {
+    const res = await postWeb({ txid: SAMPLE_TXID, category: "services" });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid category", async () => {
+    const res = await postWeb({
+      txid: SAMPLE_TXID,
+      title: "x",
+      category: "not-a-category",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for malformed btc_address override", async () => {
+    const res = await postWeb({
+      txid: SAMPLE_TXID,
+      title: "x",
+      category: "services",
+      btc_address: "not-a-bech32",
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/__tests__/stacks-tx-verify.test.ts
+++ b/src/__tests__/stacks-tx-verify.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it, vi } from "vitest";
+import { verifySbtcTransferTxid } from "../services/stacks-tx-verify";
+import {
+  CLASSIFIED_PRICE_SATS,
+  SBTC_CONTRACT_MAINNET,
+  TREASURY_STX_ADDRESS,
+} from "../lib/constants";
+
+const SAMPLE_TXID = "0x" + "ab".repeat(32);
+const SENDER = "SP2C2QH2H2H2H2H2H2H2H2H2H2H2H2H2H2H2H2H2";
+
+function makeOkResponse(overrides: Record<string, unknown> = {}): Response {
+  return new Response(
+    JSON.stringify({
+      tx_id: SAMPLE_TXID,
+      tx_status: "success",
+      tx_type: "contract_call",
+      sender_address: SENDER,
+      block_height: 123456,
+      contract_call: {
+        contract_id: SBTC_CONTRACT_MAINNET,
+        function_name: "transfer",
+      },
+      events: [
+        {
+          event_type: "fungible_token_asset",
+          asset: {
+            asset_event_type: "transfer",
+            asset_id: `${SBTC_CONTRACT_MAINNET}::sbtc-token`,
+            sender: SENDER,
+            recipient: TREASURY_STX_ADDRESS,
+            amount: String(CLASSIFIED_PRICE_SATS),
+          },
+        },
+      ],
+      ...overrides,
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } }
+  );
+}
+
+function fetchReturning(response: Response): typeof fetch {
+  return vi.fn<typeof fetch>().mockResolvedValue(response);
+}
+
+describe("verifySbtcTransferTxid", () => {
+  it("accepts a valid sBTC transfer to the treasury for the exact price", async () => {
+    const result = await verifySbtcTransferTxid(SAMPLE_TXID, CLASSIFIED_PRICE_SATS, {
+      fetchImpl: fetchReturning(makeOkResponse()),
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.sender).toBe(SENDER);
+      expect(result.amount).toBe(CLASSIFIED_PRICE_SATS);
+      expect(result.txid).toBe(SAMPLE_TXID);
+      expect(result.blockHeight).toBe(123456);
+    }
+  });
+
+  it("normalizes a txid without 0x prefix", async () => {
+    const without0x = SAMPLE_TXID.slice(2);
+    const result = await verifySbtcTransferTxid(without0x, CLASSIFIED_PRICE_SATS, {
+      fetchImpl: fetchReturning(makeOkResponse()),
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.txid).toBe(SAMPLE_TXID);
+  });
+
+  it("returns TX_NOT_FOUND on 404", async () => {
+    const result = await verifySbtcTransferTxid(SAMPLE_TXID, CLASSIFIED_PRICE_SATS, {
+      fetchImpl: fetchReturning(new Response("not found", { status: 404 })),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe("TX_NOT_FOUND");
+  });
+
+  it("returns TX_PENDING when tx_status is pending", async () => {
+    const result = await verifySbtcTransferTxid(SAMPLE_TXID, CLASSIFIED_PRICE_SATS, {
+      fetchImpl: fetchReturning(makeOkResponse({ tx_status: "pending" })),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe("TX_PENDING");
+  });
+
+  it("returns TX_ABORTED on abort_by_post_condition", async () => {
+    const result = await verifySbtcTransferTxid(SAMPLE_TXID, CLASSIFIED_PRICE_SATS, {
+      fetchImpl: fetchReturning(makeOkResponse({ tx_status: "abort_by_post_condition" })),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe("TX_ABORTED");
+  });
+
+  it("returns WRONG_CONTRACT when contract_id differs", async () => {
+    const result = await verifySbtcTransferTxid(SAMPLE_TXID, CLASSIFIED_PRICE_SATS, {
+      fetchImpl: fetchReturning(
+        makeOkResponse({
+          contract_call: { contract_id: "SP000.other-token", function_name: "transfer" },
+          events: [], // contract mismatch caught before event matching anyway
+        })
+      ),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe("WRONG_CONTRACT");
+  });
+
+  it("returns WRONG_FUNCTION when function_name is not transfer", async () => {
+    const result = await verifySbtcTransferTxid(SAMPLE_TXID, CLASSIFIED_PRICE_SATS, {
+      fetchImpl: fetchReturning(
+        makeOkResponse({
+          contract_call: { contract_id: SBTC_CONTRACT_MAINNET, function_name: "burn" },
+        })
+      ),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe("WRONG_FUNCTION");
+  });
+
+  it("returns WRONG_RECIPIENT when no transfer event went to the treasury", async () => {
+    const result = await verifySbtcTransferTxid(SAMPLE_TXID, CLASSIFIED_PRICE_SATS, {
+      fetchImpl: fetchReturning(
+        makeOkResponse({
+          events: [
+            {
+              event_type: "fungible_token_asset",
+              asset: {
+                asset_event_type: "transfer",
+                asset_id: `${SBTC_CONTRACT_MAINNET}::sbtc-token`,
+                sender: SENDER,
+                recipient: "SP000000000000000000002Q6VF78",
+                amount: String(CLASSIFIED_PRICE_SATS),
+              },
+            },
+          ],
+        })
+      ),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe("WRONG_RECIPIENT");
+  });
+
+  it("returns INSUFFICIENT_AMOUNT when transferred sats are below the price", async () => {
+    const result = await verifySbtcTransferTxid(SAMPLE_TXID, CLASSIFIED_PRICE_SATS, {
+      fetchImpl: fetchReturning(
+        makeOkResponse({
+          events: [
+            {
+              event_type: "fungible_token_asset",
+              asset: {
+                asset_event_type: "transfer",
+                asset_id: `${SBTC_CONTRACT_MAINNET}::sbtc-token`,
+                sender: SENDER,
+                recipient: TREASURY_STX_ADDRESS,
+                amount: String(CLASSIFIED_PRICE_SATS - 1),
+              },
+            },
+          ],
+        })
+      ),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe("INSUFFICIENT_AMOUNT");
+  });
+
+  it("returns HIRO_UNAVAILABLE on 503 from the API", async () => {
+    const result = await verifySbtcTransferTxid(SAMPLE_TXID, CLASSIFIED_PRICE_SATS, {
+      fetchImpl: fetchReturning(new Response("upstream error", { status: 503 })),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe("HIRO_UNAVAILABLE");
+  });
+
+  it("returns HIRO_UNAVAILABLE when fetch throws", async () => {
+    const result = await verifySbtcTransferTxid(SAMPLE_TXID, CLASSIFIED_PRICE_SATS, {
+      fetchImpl: vi.fn<typeof fetch>().mockRejectedValue(new Error("network gone")),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe("HIRO_UNAVAILABLE");
+  });
+
+  it("accepts an overpayment", async () => {
+    const result = await verifySbtcTransferTxid(SAMPLE_TXID, CLASSIFIED_PRICE_SATS, {
+      fetchImpl: fetchReturning(
+        makeOkResponse({
+          events: [
+            {
+              event_type: "fungible_token_asset",
+              asset: {
+                asset_event_type: "transfer",
+                asset_id: `${SBTC_CONTRACT_MAINNET}::sbtc-token`,
+                sender: SENDER,
+                recipient: TREASURY_STX_ADDRESS,
+                amount: String(CLASSIFIED_PRICE_SATS * 2),
+              },
+            },
+          ],
+        })
+      ),
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.amount).toBe(CLASSIFIED_PRICE_SATS * 2);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { briefCompileRouter } from "./routes/brief-compile";
 import { briefInscribeRouter } from "./routes/brief-inscribe";
 import { classifiedReviewRouter } from "./routes/classified-review";
 import { classifiedsRouter } from "./routes/classifieds";
+import { classifiedsWebRouter } from "./routes/classifieds-web";
 import { correspondentsRouter } from "./routes/correspondents";
 import { streaksRouter } from "./routes/streaks";
 import { statusRouter } from "./routes/status";
@@ -140,6 +141,10 @@ app.route("/", classifiedReviewRouter);
 
 // Mount classifieds routes
 app.route("/", classifiedsRouter);
+
+// Wallet-driven classifieds — independent of x402 relay path. Uses an
+// on-chain sBTC txid the user already broadcast from their wallet.
+app.route("/", classifiedsWebRouter);
 
 // Mount corrections and referrals before generic signals
 app.route("/", correctionsRouter);

--- a/src/lib/do-client.ts
+++ b/src/lib/do-client.ts
@@ -479,6 +479,15 @@ export async function getClassified(
   return result.ok ? (result.data ?? null) : null;
 }
 
+export async function getClassifiedByTxid(
+  env: Env,
+  txid: string
+): Promise<Classified | null> {
+  const stub = getStub(env);
+  const result = await doFetch<Classified>(stub, `/classifieds/by-txid/${encodeURIComponent(txid)}`);
+  return result.ok ? (result.data ?? null) : null;
+}
+
 export interface CreateClassifiedInput {
   btc_address: string;
   category: string;

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -5,7 +5,7 @@ import type { Env, Beat, Signal, SignalStatus, Streak, Brief, Classified, Classi
 import { validateSlug, validateHexColor, sanitizeString, validateDateFormat } from "../lib/validators";
 import { generateId, getUTCDate, getUTCYesterday, getUTCDayStart, getUTCDayEnd, getNextDate } from "../lib/helpers";
 import { CLASSIFIED_DURATION_DAYS, CLASSIFIED_BRIEF_SLOTS, CLASSIFIED_BRIEF_MAX_CHARS, CLASSIFIED_STATUSES, SIGNAL_COOLDOWN_HOURS, BEAT_EXPIRY_DAYS, MAX_SIGNALS_PER_DAY, MAX_INCLUDED_SIGNALS_PER_BRIEF, MAX_APPROVED_SIGNALS_PER_DAY, SIGNAL_STATUSES, REVIEWABLE_SIGNAL_STATUSES, CONFIG_PUBLISHER_ADDRESS, BRIEF_INCLUSION_PAYOUT_SATS, WEEKLY_PRIZE_1ST_SATS, WEEKLY_PRIZE_2ND_SATS, WEEKLY_PRIZE_3RD_SATS, SCORING_WEIGHTS, PAYMENT_STAGE_TTL_MS } from "../lib/constants";
-import { SCHEMA_SQL, MIGRATION_PHASE0_SQL, MIGRATION_PAYMENTS_SQL, MIGRATION_BEAT_RESTRUCTURE_SQL, MIGRATION_SBTC_TRACKING_SQL, MIGRATION_CLASSIFIEDS_CLEANUP_SQL, MIGRATION_CLASSIFIEDS_REVIEW_SQL, MIGRATION_SNAPSHOTS_SQL, MIGRATION_BEAT_CLAIMS_SQL, MIGRATION_RETRACTION_SQL, MIGRATION_BEAT_NETWORK_FOCUS_SQL, MIGRATION_BITCOIN_MACRO_SQL, MIGRATION_QUANTUM_BEAT_SQL, MIGRATION_PAYMENT_STAGING_SQL, MIGRATION_APPROVAL_CAP_INDEX_SQL, MIGRATION_BEAT_EDITORS_SQL, MIGRATION_EDITORIAL_REVIEWS_SQL, MIGRATION_EDITOR_REVIEW_RATE_SQL, MIGRATION_CURATION_CLEANUP_SQL, MIGRATION_LEADERBOARD_INDEXES_SQL, MIGRATION_BEAT_CONSOLIDATION_SQL, MIGRATION_SIGNAL_SCORING_SQL, MIGRATION_APR7_EARNINGS_SQL } from "./schema";
+import { SCHEMA_SQL, MIGRATION_PHASE0_SQL, MIGRATION_PAYMENTS_SQL, MIGRATION_BEAT_RESTRUCTURE_SQL, MIGRATION_SBTC_TRACKING_SQL, MIGRATION_CLASSIFIEDS_CLEANUP_SQL, MIGRATION_CLASSIFIEDS_REVIEW_SQL, MIGRATION_SNAPSHOTS_SQL, MIGRATION_BEAT_CLAIMS_SQL, MIGRATION_RETRACTION_SQL, MIGRATION_BEAT_NETWORK_FOCUS_SQL, MIGRATION_BITCOIN_MACRO_SQL, MIGRATION_QUANTUM_BEAT_SQL, MIGRATION_PAYMENT_STAGING_SQL, MIGRATION_APPROVAL_CAP_INDEX_SQL, MIGRATION_BEAT_EDITORS_SQL, MIGRATION_EDITORIAL_REVIEWS_SQL, MIGRATION_EDITOR_REVIEW_RATE_SQL, MIGRATION_CURATION_CLEANUP_SQL, MIGRATION_LEADERBOARD_INDEXES_SQL, MIGRATION_BEAT_CONSOLIDATION_SQL, MIGRATION_SIGNAL_SCORING_SQL, MIGRATION_APR7_EARNINGS_SQL, MIGRATION_CLASSIFIEDS_TXID_UNIQUE_SQL } from "./schema";
 import { scoreSignal } from "../lib/signal-scorer";
 
 // ── State machine transition maps ──
@@ -522,7 +522,8 @@ export class NewsDO extends DurableObject<Env> {
     // 23 = Streak UTC migration (backfill last_signal_date from actual signal timestamps)
     // 24 = Signal quality auto-scoring — quality_score INTEGER, score_breakdown TEXT (#343)
     // 25 = Publisher payout reconciliation — Apr 7 amendment + clear 8 RBF payout_txid + Mar 31 over-cap void (#502)
-    const CURRENT_MIGRATION_VERSION = 25;
+    // 26 = Partial UNIQUE index on classifieds.payment_txid for replay protection across both placement paths
+    const CURRENT_MIGRATION_VERSION = 26;
     const versionRows = this.ctx.storage.sql
       .exec("SELECT value FROM config WHERE key = 'migration_version'")
       .toArray();
@@ -887,6 +888,23 @@ export class NewsDO extends DurableObject<Env> {
             this.ctx.storage.sql.exec(stmt);
           } catch (e) {
             console.error("Apr 7 earnings amendment migration failed:", e);
+          }
+        }
+      }
+
+      // Replay protection: same on-chain payment_txid cannot back two listings.
+      // Partial UNIQUE so legacy NULL rows survive. If existing duplicates exist
+      // the CREATE will fail — log and continue so the rest of the cold start
+      // succeeds; operator can clean up by hand.
+      if (appliedVersion < 26) {
+        for (const stmt of MIGRATION_CLASSIFIEDS_TXID_UNIQUE_SQL) {
+          try {
+            this.ctx.storage.sql.exec(stmt);
+          } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            if (!msg.includes("already exists")) {
+              console.error("Classifieds payment_txid unique-index migration failed:", e);
+            }
           }
         }
       }
@@ -2972,6 +2990,25 @@ export class NewsDO extends DurableObject<Env> {
         ok: true,
         data: rows as unknown as Classified[],
       } satisfies DOResult<Classified[]>);
+    });
+
+    // GET /classifieds/by-txid/:txid — look up a classified by payment_txid.
+    // Used by the wallet flow to recover from POST retries: same on-chain txid
+    // hits the partial UNIQUE index, and the caller fetches the existing row
+    // instead of double-creating. Registered before /classifieds/:id so the
+    // wildcard doesn't capture "by-txid".
+    this.router.get("/classifieds/by-txid/:txid", (c) => {
+      const txid = c.req.param("txid");
+      const rows = this.ctx.storage.sql
+        .exec("SELECT * FROM classifieds WHERE payment_txid = ?", txid)
+        .toArray();
+      if (rows.length === 0) {
+        return c.json(
+          { ok: false, error: `No classified found for txid "${txid}"` } satisfies DOResult<Classified>,
+          404
+        );
+      }
+      return c.json({ ok: true, data: rows[0] as unknown as Classified } satisfies DOResult<Classified>);
     });
 
     // GET /classifieds/:id — get a single classified

--- a/src/objects/schema.ts
+++ b/src/objects/schema.ts
@@ -719,6 +719,17 @@ export const MIGRATION_SIGNAL_SCORING_SQL = [
  * audit trail reflects the migration's actual run time rather than the
  * author's wall clock at commit time.
  */
+/**
+ * MIGRATION_CLASSIFIEDS_TXID_UNIQUE_SQL — replay protection across both
+ * payment paths. Partial UNIQUE index ignores rows where payment_txid IS NULL,
+ * so legacy rows that predate payment tracking are unaffected. Both the x402
+ * relay path and the new wallet path will hit this constraint, preventing the
+ * same on-chain transfer from minting two listings.
+ */
+export const MIGRATION_CLASSIFIEDS_TXID_UNIQUE_SQL = [
+  "CREATE UNIQUE INDEX IF NOT EXISTS idx_classifieds_payment_txid_unique ON classifieds(payment_txid) WHERE payment_txid IS NOT NULL",
+] as const;
+
 export const MIGRATION_APR7_EARNINGS_SQL = [
   // Void earnings for the 14 re-curated signals NOT on-chain
   `UPDATE earnings SET voided_at = datetime('now')

--- a/src/routes/classifieds-web.ts
+++ b/src/routes/classifieds-web.ts
@@ -1,0 +1,195 @@
+/**
+ * Wallet-driven classifieds endpoint.
+ *
+ * Independent of the x402 relay flow at /api/classifieds. The browser uses
+ * @stacks/connect to sign an sBTC transfer to the treasury, broadcasts it,
+ * and once the txid confirms, POSTs here with the txid + ad fields. The
+ * server independently verifies the txid against the Hiro Stacks API before
+ * inserting the row. Replay protection lives at the DB layer (partial UNIQUE
+ * index on classifieds.payment_txid).
+ */
+
+import { Hono } from "hono";
+import type { Env, AppVariables } from "../lib/types";
+import {
+  CLASSIFIED_PRICE_SATS,
+  CLASSIFIED_CATEGORIES,
+  CLASSIFIED_RATE_LIMIT,
+  isClassifiedCategory,
+} from "../lib/constants";
+import { validateBtcAddress, sanitizeString } from "../lib/validators";
+import { createRateLimitMiddleware } from "../middleware/rate-limit";
+import {
+  createClassified,
+  getClassifiedByTxid,
+} from "../lib/do-client";
+import { verifySbtcTransferTxid } from "../services/stacks-tx-verify";
+import { transformClassified } from "./classifieds";
+
+const classifiedsWebRouter = new Hono<{
+  Bindings: Env;
+  Variables: AppVariables;
+}>();
+
+const webRateLimit = createRateLimitMiddleware({
+  key: "classifieds-web",
+  ...CLASSIFIED_RATE_LIMIT,
+});
+
+const TXID_REGEX = /^(0x)?[0-9a-fA-F]{64}$/;
+
+classifiedsWebRouter.post(
+  "/api/classifieds/web",
+  webRateLimit,
+  async (c) => {
+    const logger = c.get("logger");
+
+    let body: Record<string, unknown>;
+    try {
+      body = await c.req.json<Record<string, unknown>>();
+    } catch {
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
+
+    const txid = typeof body.txid === "string" ? body.txid.trim() : "";
+    const headline = (body.headline ?? body.title) as string | undefined;
+    const category = body.category as string | undefined;
+    const adBody = (body.body as string | undefined) ?? null;
+    const bodyAddress = (body.btc_address as string | undefined)
+      ?? (body.contact as string | undefined);
+
+    if (!txid || !TXID_REGEX.test(txid)) {
+      return c.json({ error: "Missing or malformed txid (expected 32-byte hex)." }, 400);
+    }
+
+    if (!category || !headline) {
+      return c.json(
+        { error: "Missing required fields: category, title (or headline)" },
+        400
+      );
+    }
+
+    if (!isClassifiedCategory(category)) {
+      return c.json(
+        { error: `Invalid category. Must be one of: ${CLASSIFIED_CATEGORIES.join(", ")}` },
+        400
+      );
+    }
+
+    if (bodyAddress && !validateBtcAddress(bodyAddress)) {
+      return c.json(
+        { error: "Invalid BTC address format (expected bech32 bc1...)" },
+        400
+      );
+    }
+
+    // Idempotency short-circuit: if this txid already produced a listing,
+    // return it instead of re-running verification. Handles client retries
+    // without surfacing the UNIQUE constraint conflict to the user.
+    const existing = await getClassifiedByTxid(c.env, txid);
+    if (existing) {
+      logger.info("classifieds-web: returning existing row for txid", {
+        txid,
+        classifiedId: existing.id,
+      });
+      return c.json(
+        { ...transformClassified(existing), message: "Classified already submitted for editorial review." },
+        200
+      );
+    }
+
+    const verification = await verifySbtcTransferTxid(txid, CLASSIFIED_PRICE_SATS, { logger });
+
+    if (!verification.ok) {
+      logger.warn("classifieds-web: tx verification failed", {
+        txid,
+        code: verification.code,
+        reason: verification.reason,
+      });
+
+      switch (verification.code) {
+        case "TX_PENDING":
+          c.header("Retry-After", "10");
+          return c.json(
+            { error: verification.reason, code: verification.code, retryable: true },
+            202
+          );
+        case "TX_NOT_FOUND":
+          c.header("Retry-After", "15");
+          return c.json(
+            { error: verification.reason, code: verification.code, retryable: true },
+            404
+          );
+        case "HIRO_UNAVAILABLE":
+          c.header("Retry-After", "10");
+          return c.json(
+            { error: verification.reason, code: verification.code, retryable: true },
+            503
+          );
+        case "TX_ABORTED":
+        case "WRONG_CONTRACT":
+        case "WRONG_FUNCTION":
+        case "WRONG_RECIPIENT":
+        case "WRONG_ASSET":
+        case "INSUFFICIENT_AMOUNT":
+        case "MALFORMED_TX":
+          return c.json(
+            { error: verification.reason, code: verification.code, retryable: false },
+            400
+          );
+      }
+    }
+
+    const btc_address = bodyAddress ?? verification.sender;
+
+    const createResult = await createClassified(c.env, {
+      btc_address,
+      category,
+      headline: sanitizeString(headline, 100),
+      body: adBody ? sanitizeString(adBody, 500) : null,
+      payment_txid: verification.txid,
+    });
+
+    if (!createResult.ok || !createResult.data) {
+      // Race: another POST for the same txid raced past the idempotency check
+      // and won the UNIQUE-index battle. Return the row that did win.
+      const recovered = await getClassifiedByTxid(c.env, verification.txid);
+      if (recovered) {
+        logger.info("classifieds-web: recovered after race on payment_txid", {
+          txid: verification.txid,
+          classifiedId: recovered.id,
+        });
+        return c.json(
+          { ...transformClassified(recovered), message: "Classified already submitted for editorial review." },
+          200
+        );
+      }
+
+      logger.error("classifieds-web: createClassified failed", {
+        txid: verification.txid,
+        error: createResult.error,
+      });
+      return c.json(
+        { error: createResult.error ?? "Failed to record classified submission" },
+        createResult.status ?? 500
+      );
+    }
+
+    logger.info("classifieds-web: classified created", {
+      txid: verification.txid,
+      sender: verification.sender,
+      amount: verification.amount,
+      classifiedId: createResult.data.id,
+    });
+
+    return c.json(
+      {
+        ...transformClassified(createResult.data),
+        message: "Classified submitted for editorial review. An editor will review and publish your listing.",
+      },
+      201
+    );
+  }
+);
+
+export { classifiedsWebRouter };

--- a/src/services/stacks-tx-verify.ts
+++ b/src/services/stacks-tx-verify.ts
@@ -1,0 +1,236 @@
+/**
+ * Stacks transaction verifier — used by the wallet-driven classifieds flow.
+ *
+ * Independent of the x402 relay path. Given a txid that the user's wallet
+ * broadcast, fetch the canonical record from the Hiro Stacks API and confirm
+ * it really is a successful sBTC transfer of the expected amount to the
+ * treasury principal. The caller is responsible for replay protection.
+ */
+
+import {
+  SBTC_CONTRACT_MAINNET,
+  TREASURY_STX_ADDRESS,
+} from "../lib/constants";
+import type { Logger } from "../lib/types";
+
+const HIRO_TX_URL = "https://api.hiro.so/extended/v1/tx";
+const HIRO_TIMEOUT_MS = 8_000;
+
+export type TxVerifyErrorCode =
+  | "TX_NOT_FOUND"
+  | "TX_PENDING"
+  | "TX_ABORTED"
+  | "WRONG_CONTRACT"
+  | "WRONG_FUNCTION"
+  | "WRONG_RECIPIENT"
+  | "WRONG_ASSET"
+  | "INSUFFICIENT_AMOUNT"
+  | "MALFORMED_TX"
+  | "HIRO_UNAVAILABLE";
+
+export type TxVerifyResult =
+  | {
+      ok: true;
+      sender: string;
+      amount: number;
+      txid: string;
+      blockHeight: number | null;
+    }
+  | {
+      ok: false;
+      code: TxVerifyErrorCode;
+      reason: string;
+    };
+
+export interface VerifyOptions {
+  logger?: Logger;
+  /** Override Hiro fetch for tests. */
+  fetchImpl?: typeof fetch;
+  /** Override the expected recipient (defaults to TREASURY_STX_ADDRESS). */
+  expectedRecipient?: string;
+  /** Override the expected sBTC contract id (defaults to mainnet). */
+  expectedContractId?: string;
+}
+
+interface HiroFtAssetEvent {
+  event_type?: string;
+  asset?: {
+    asset_event_type?: string;
+    asset_id?: string;
+    sender?: string;
+    recipient?: string;
+    amount?: string;
+  };
+}
+
+interface HiroTxResponse {
+  tx_id?: string;
+  tx_status?: string;
+  tx_type?: string;
+  sender_address?: string;
+  block_height?: number;
+  contract_call?: {
+    contract_id?: string;
+    function_name?: string;
+  };
+  events?: HiroFtAssetEvent[];
+}
+
+const TERMINAL_FAILURE_STATUSES = new Set([
+  "abort_by_response",
+  "abort_by_post_condition",
+  "dropped_replace_by_fee",
+  "dropped_replace_across_fork",
+  "dropped_too_expensive",
+  "dropped_stale_garbage_collect",
+  "dropped_problematic",
+]);
+
+function normalizeTxid(input: string): string {
+  const trimmed = input.trim().toLowerCase();
+  return trimmed.startsWith("0x") ? trimmed : `0x${trimmed}`;
+}
+
+/**
+ * Verify that a Stacks txid is a confirmed sBTC transfer to the treasury for
+ * at least `requiredAmount` sats. Returns sender + actual transferred amount.
+ */
+export async function verifySbtcTransferTxid(
+  rawTxid: string,
+  requiredAmount: number,
+  options: VerifyOptions = {}
+): Promise<TxVerifyResult> {
+  const txid = normalizeTxid(rawTxid);
+  const expectedRecipient = options.expectedRecipient ?? TREASURY_STX_ADDRESS;
+  const expectedContractId = options.expectedContractId ?? SBTC_CONTRACT_MAINNET;
+  const fetchFn = options.fetchImpl ?? fetch;
+  const logger = options.logger;
+
+  let response: Response;
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), HIRO_TIMEOUT_MS);
+    try {
+      response = await fetchFn(`${HIRO_TX_URL}/${encodeURIComponent(txid)}`, {
+        method: "GET",
+        headers: { Accept: "application/json" },
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  } catch (err) {
+    logger?.warn("hiro tx fetch failed", { txid, error: String(err) });
+    return { ok: false, code: "HIRO_UNAVAILABLE", reason: "Could not reach the Stacks API to verify your transaction." };
+  }
+
+  if (response.status === 404) {
+    return { ok: false, code: "TX_NOT_FOUND", reason: "Transaction not found on the Stacks network yet." };
+  }
+
+  if (response.status >= 500) {
+    return { ok: false, code: "HIRO_UNAVAILABLE", reason: `Stacks API returned ${response.status}.` };
+  }
+
+  if (!response.ok) {
+    return { ok: false, code: "MALFORMED_TX", reason: `Stacks API rejected lookup with status ${response.status}.` };
+  }
+
+  let body: HiroTxResponse;
+  try {
+    body = (await response.json()) as HiroTxResponse;
+  } catch {
+    return { ok: false, code: "HIRO_UNAVAILABLE", reason: "Stacks API returned an unparseable response." };
+  }
+
+  const status = body.tx_status;
+  if (status === "pending") {
+    return { ok: false, code: "TX_PENDING", reason: "Transaction is still in the mempool." };
+  }
+
+  if (!status || (status !== "success" && !TERMINAL_FAILURE_STATUSES.has(status))) {
+    return { ok: false, code: "TX_PENDING", reason: `Transaction status is "${status ?? "unknown"}".` };
+  }
+
+  if (TERMINAL_FAILURE_STATUSES.has(status)) {
+    return { ok: false, code: "TX_ABORTED", reason: `Transaction failed on-chain (${status}).` };
+  }
+
+  if (body.tx_type !== "contract_call") {
+    return { ok: false, code: "WRONG_FUNCTION", reason: "Transaction is not a contract call." };
+  }
+
+  const contractId = body.contract_call?.contract_id;
+  if (contractId !== expectedContractId) {
+    return {
+      ok: false,
+      code: "WRONG_CONTRACT",
+      reason: `Transaction calls ${contractId ?? "unknown"}, not the sBTC token contract.`,
+    };
+  }
+
+  if (body.contract_call?.function_name !== "transfer") {
+    return {
+      ok: false,
+      code: "WRONG_FUNCTION",
+      reason: `Transaction calls ${body.contract_call?.function_name ?? "unknown"}, not transfer.`,
+    };
+  }
+
+  // Use the actual ft_transfer event so we measure what really moved on-chain,
+  // not what the contract call args claimed. tx_status="success" already
+  // guarantees post-conditions passed, but events let us pick the matching
+  // recipient/asset directly.
+  const sbtcAssetId = `${expectedContractId}::sbtc-token`;
+  const matchingTransfer = (body.events ?? []).find((evt) => {
+    if (evt.event_type !== "fungible_token_asset") return false;
+    const a = evt.asset;
+    return (
+      a?.asset_event_type === "transfer" &&
+      a.asset_id === sbtcAssetId &&
+      a.recipient === expectedRecipient
+    );
+  });
+
+  if (!matchingTransfer) {
+    // No event to the treasury — could be wrong recipient or wrong asset.
+    const anyTransferToRecipient = (body.events ?? []).some(
+      (evt) => evt.asset?.asset_event_type === "transfer" && evt.asset?.recipient === expectedRecipient
+    );
+    if (!anyTransferToRecipient) {
+      return {
+        ok: false,
+        code: "WRONG_RECIPIENT",
+        reason: "Transaction did not transfer sBTC to the treasury.",
+      };
+    }
+    return { ok: false, code: "WRONG_ASSET", reason: "Transaction transferred a different asset." };
+  }
+
+  const amountStr = matchingTransfer.asset?.amount;
+  const amount = amountStr ? Number.parseInt(amountStr, 10) : Number.NaN;
+  if (!Number.isFinite(amount) || amount <= 0) {
+    return { ok: false, code: "MALFORMED_TX", reason: "Transfer event missing a valid amount." };
+  }
+
+  if (amount < requiredAmount) {
+    return {
+      ok: false,
+      code: "INSUFFICIENT_AMOUNT",
+      reason: `Transferred ${amount} sats, expected at least ${requiredAmount}.`,
+    };
+  }
+
+  const sender = matchingTransfer.asset?.sender ?? body.sender_address;
+  if (!sender) {
+    return { ok: false, code: "MALFORMED_TX", reason: "Could not determine sender address from transaction." };
+  }
+
+  return {
+    ok: true,
+    sender,
+    amount,
+    txid,
+    blockHeight: typeof body.block_height === "number" ? body.block_height : null,
+  };
+}


### PR DESCRIPTION
## Summary

Adds a **wallet-driven path** for placing classifieds, parallel to the existing x402 agent flow. Browser users sign an sBTC transfer with their Stacks wallet (Leather, Xverse, etc.), broadcast it themselves, and once confirmed the server independently verifies the on-chain payment via Hiro before inserting the listing. No relay involvement, no sponsorship.

End-to-end: schema migration, on-chain tx verifier, new `POST /api/classifieds/web` endpoint, full test coverage, and a real wallet-driven modal on `/classifieds/` (replacing the old prompt-builder).

## Backend

### Schema
- New migration (#26) adds a partial `UNIQUE` index on `classifieds(payment_txid) WHERE payment_txid IS NOT NULL`. Replay protection across both placement paths — the same on-chain transfer cannot back two listings. NULL rows are unaffected.

### New service — `src/services/stacks-tx-verify.ts`
- `verifySbtcTransferTxid(txid, requiredAmount)` — fetches the canonical tx record from `https://api.hiro.so/extended/v1/tx/:txid` and confirms it really is a successful sBTC transfer of at least `requiredAmount` sats to the treasury principal.
- Verification reads the `ft_transfer` event (not function args / post-conditions) so we measure what actually moved on-chain.
- Returns a discriminated union with stable error codes per failure mode: `TX_NOT_FOUND`, `TX_PENDING`, `TX_ABORTED`, `WRONG_CONTRACT`, `WRONG_FUNCTION`, `WRONG_RECIPIENT`, `WRONG_ASSET`, `INSUFFICIENT_AMOUNT`, `MALFORMED_TX`, `HIRO_UNAVAILABLE`.
- 8s timeout, injectable `fetch` impl for tests.

### New endpoint — `POST /api/classifieds/web`
- Accepts `{ txid, headline|title, category, body?, btc_address? }`.
- Verifies the txid via the new service, then inserts a `pending_review` row through the existing `createClassified()` path. The resulting listing is **identical** to one placed via x402 — same editorial pipeline, same shape on the wire, same `expires_at` semantics, same rate limiter.
- **Idempotency** — pre-insert lookup by `payment_txid` short-circuits client retries (returns 200 + existing row). A second post-insert lookup recovers from concurrent races against the partial UNIQUE index.
- HTTP status mapping: `TX_PENDING` → 202 + Retry-After 10; `TX_NOT_FOUND` → 404 + Retry-After 15; `HIRO_UNAVAILABLE` → 503 + Retry-After 10; everything terminal (aborts, wrong recipient, insufficient amount, malformed) → 400 with `retryable: false`.

### DO route — `GET /classifieds/by-txid/:txid`
- Backs `getClassifiedByTxid()`. Registered before `/classifieds/:id` so the wildcard does not capture the literal segment.

### Mounted router
- `src/index.ts` mounts `classifiedsWebRouter` alongside `classifiedsRouter`. Both serve traffic concurrently.

## Frontend (`public/classifieds/index.html`)

Real wallet-driven modal replaces the static "draft a prompt for your agent" copy-paste UI. The agent prompt is preserved behind a "Posting from an agent? Copy a prompt instead" secondary link.

**State machine:** form → signing → broadcasting → mempool → confirming → done | error.

- **CDN-loaded, lazy.** `@stacks/connect`, `@stacks/transactions`, and `@stacks/blockchain-api-client` are dynamic-`import()`ed via esm.sh **only when the user clicks "Connect wallet & pay"**. The classifieds page itself stays the same weight for visitors who only browse.
- **Payment.** SIP-010 `transfer` to `TREASURY_STX_ADDRESS`, with an `ft-postcondition` that caps the transfer at exactly `CLASSIFIED_PRICE_SATS` — the wallet shows the cap before signing, so worst case is a 3000-sat sBTC loss, never more. User pays their own STX gas.
- **Live tracking.** Hiro WebSocket (`subscribeTxUpdates`) for primary updates, REST polling on `https://api.hiro.so/extended/v1/tx/:txid` every 8s as a belt-and-suspenders fallback.
- **Stacks-correct copy.** Confirmation hint says "usually 20 seconds to a minute" (not the 10–30 minute BTC-style wait we initially drafted). Every status panel surfaces the txid as a `https://explorer.hiro.so/txid/...?chain=mainnet` link — no mempool.space (that is BTC).
- **localStorage recovery.** The moment the wallet returns a txid, `aibtc:pendingClassified` is persisted with the txid + form data. If the user closes the tab between broadcast and confirmation, the next modal open shows a "Resume" banner that picks up where they left off. Server is idempotent so resume cannot double-create. Stale entries (>1h) auto-purge.
- **Resilient submission.** POST to `/api/classifieds/web` retries up to 4 times with backoff. `202`/`404` responses (Hiro hasn't indexed yet) are treated as "keep waiting", not failure.
- **Distinct error copy** per failure category — wallet cancel ("Payment cancelled — no charge"), on-chain abort ("Transaction did not succeed — no listing was posted"), server validation rejection ("Server rejected the listing: <reason>"), Hiro unavailable ("Stacks API is down — your transaction is saved, reopen later to resume").
- **Done state** shows a "View my submissions →" link to `/classifieds/?agent=<sender>` so users can see their `pending_review` row immediately.

## What this deliberately does NOT change

- No changes to the existing `POST /api/classifieds` (x402) or to the relay.
- No sponsored gas — users pay their own STX fee.
- No new editorial-review state — wallet submissions enter the same `pending_review` queue.
- No changes to `llms.txt` or the `aibtc-mcp-server` MCP — agents continue using x402.

## Test plan

- [x] New unit tests (`stacks-tx-verify.test.ts`, 12 cases) — happy path + every error code branch.
- [x] New integration tests (`classifieds-web.test.ts`, 14 cases) — happy path, idempotent retry, every error category, full input validation.
- [x] Existing classifieds tests still pass (18 cases).
- [x] Inline JS in `classifieds/index.html` parses cleanly.
- [ ] Manual smoke test against staging from a real Stacks wallet.
- [ ] Manual smoke test of the resume-after-reload path.

## Commit-by-commit walkthrough

Each file is its own commit so review can read the diff one piece at a time:

1. `schema.ts` — adds the new migration constant.
2. `news-do.ts` — wires the migration into the cold-start path and adds the `/classifieds/by-txid/:txid` lookup endpoint.
3. `do-client.ts` — `getClassifiedByTxid()` wrapper.
4. `stacks-tx-verify.ts` — new verifier service.
5. `classifieds-web.ts` — new route handler.
6. `index.ts` — mounts the router.
7. `stacks-tx-verify.test.ts` — unit tests for the verifier.
8. `classifieds-web.test.ts` — integration tests for the endpoint.
9. `public/classifieds/index.html` — wallet-driven modal + state machine.