### PR TITLE
fix(brief-compile): diagnostic logging for classifieds rotation (refs #515)

### DIFF
--- a/src/routes/brief-compile.ts
+++ b/src/routes/brief-compile.ts
@@ -225,10 +225,30 @@ async function handleBriefCompile(
     text += `${separator}\n`;
   }
 
-  // Classifieds rotation — best-effort, non-fatal if fetch fails
+  // Classifieds rotation — best-effort, non-fatal if fetch fails. Log all
+  // outcomes (empty/filled/errored) so silent omissions are diagnosable —
+  // see #515 for a case where rotation silently returned empty for 3 days
+  // and there was no way to tell whether it was a fetch error, an empty
+  // result, or a code-path skip.
   try {
     const classifiedsResult = await getClassifiedsRotation(c.env);
-    if (classifiedsResult.ok && classifiedsResult.data && classifiedsResult.data.length > 0) {
+    if (!classifiedsResult.ok) {
+      c.var.logger.warn("classifieds rotation returned !ok during brief compile", {
+        date,
+      });
+    } else if (!classifiedsResult.data || classifiedsResult.data.length === 0) {
+      c.var.logger.info("classifieds rotation returned empty during brief compile", {
+        date,
+        slots: classifiedsResult.slots,
+        filled: classifiedsResult.filled,
+      });
+    } else {
+      c.var.logger.info("classifieds rotation included in brief", {
+        date,
+        slots: classifiedsResult.slots,
+        filled: classifiedsResult.filled,
+        included_count: classifiedsResult.data.length,
+      });
       text += `\nCLASSIFIEDS\n\n`;
       text += `${separator}\n`;
       for (const ad of classifiedsResult.data) {
@@ -239,8 +259,11 @@ async function handleBriefCompile(
       }
       text += `${separator}\n`;
     }
-  } catch {
-    // Classifieds are supplementary — don't fail the brief on rotation errors
+  } catch (err) {
+    c.var.logger.error("classifieds rotation threw during brief compile", {
+      date,
+      error: err instanceof Error ? err.message : String(err),
+    });
   }
 
   text += `\nCompiled by AIBTC News Intelligence Network\n`;


### PR DESCRIPTION
## Summary

Refs #515 (classifieds rotation silently empty in 3 consecutive briefs).

The brief-compile path at \`src/routes/brief-compile.ts:228\` had a silent \`try/catch\` around the classifieds rotation block:

\`\`\`ts
try {
  const classifiedsResult = await getClassifiedsRotation(c.env);
  if (classifiedsResult.ok && classifiedsResult.data && classifiedsResult.data.length > 0) {
    // append CLASSIFIEDS section
  }
} catch {
  // Classifieds are supplementary — don't fail the brief on rotation errors
}
\`\`\`

The \"non-fatal\" intent is correct, but the silent swallow makes the bug in #515 undiagnosable: we can't tell from the saved brief or the logs whether the rotation:
- threw an error,
- returned \`!ok\`,
- returned ok-but-empty,
- or never ran at all.

## Change

Replace the silent catch with structured logging covering all three outcomes:
- **\`!ok\` response** → \`warn\` (something is wrong with the DO, but not throwing)
- **empty data array** → \`info\` (legitimate empty state — log slots/filled for diagnosis)
- **thrown exception** → \`error\` (with \`err.message\`)

The success path also logs at \`info\` with the included count.

Behavior is unchanged for the happy path — classifieds still appear in the brief text. This only adds visibility so the next failed compile leaves a diagnostic trail.

## What this PR does NOT do

This is a diagnostics-only change. It does not fix the underlying #515 root cause — that requires running with these logs enabled to see whether the rotation is throwing, returning \`!ok\`, or genuinely returning empty when it shouldn't.

Once this lands, the next 24h-cycle compile should reveal the real cause and a follow-up PR can target the actual bug.

## Test plan

- [x] \`npm run typecheck\` passes
- [ ] Once deployed: next daily brief compile produces one of the new log lines (info/warn/error)
- [ ] If the log shows \`empty\` despite active listings, the next investigation is the DO query (\`expires_at > NOW()\` semantics, possibly Hiro time vs CF time)
- [ ] If the log shows \`!ok\` or thrown, root cause is the DO/network call

🤖 Generated with [Claude Code](https://claude.com/claude-code)