### PR TITLE
fix: reduce NewsDO hot query scans

### DIFF
--- a/docs/cloudflare-cost-runbook.md
+++ b/docs/cloudflare-cost-runbook.md
@@ -1,0 +1,59 @@
+# Cloudflare Cost Runbook
+
+This repo is part of the April 2026 bill-reduction sprint. Every cost PR must
+record the Cloudflare metric it is expected to move, the before/after window,
+and the rollback signal.
+
+## F1: NewsDO hot query rewrite
+
+PR scope:
+- `/signals`: dynamic SQL filters, no `(? IS NULL OR col = ?)` clauses, deferred
+  `signal_tags` fetch after pagination, and no unbounded list `COUNT(*)`.
+- `/signals/counts`: per-status indexed counts instead of one full-table
+  `OR`/`COALESCE` grouped scan.
+- `/init`: same per-status indexed count path for beat rail and 1-hour ticker.
+- migration 27: composite indexes for the hot status/date, beat/date,
+  address/date, and tag lookup paths.
+
+Expected Cloudflare movement:
+- Durable Objects SQLite `rows_read` for the `agent-news` script and the NewsDO
+  namespace (`1bb5fade...` in the April audit) should drop by orders of
+  magnitude.
+- Baseline from the April audit: 427.8 B rows read / 5.1 M DO invocations, about
+  84,000 rows read per invocation.
+- Target after deployment: 50-500 rows read per hot listing/count invocation.
+
+Before/after window:
+- Before: capture the 24h production window immediately before deploy.
+- Fast safety check: 15-30 minutes after deploy for 5xx, availability, and
+  WARN/ERROR log regression.
+- Cost signal: capture the same 24h window after deploy, then confirm again at
+  48h.
+
+Cloudflare metric to record:
+- Account Analytics / GraphQL Analytics API.
+- Filter to script `agent-news` and the NewsDO Durable Object SQLite namespace.
+- Record:
+  - DO invocations for `agent-news`.
+  - DO SQLite rows read for the NewsDO namespace.
+  - rows_read / invocations.
+  - deploy commit SHA and deploy timestamp.
+
+Dashboard fallback:
+- Workers & Pages -> `agent-news` -> Metrics.
+- Durable Objects / SQLite metrics: record rows read for the NewsDO namespace.
+- Worker metrics: record Durable Object invocations for the same time window.
+
+Rollback signal:
+- Any sustained 5xx increase on `/api/signals`, `/api/signals/counts`, or
+  `/api/init`.
+- Missing tags in `/api/signals` responses.
+- Incorrect `since` bucketing for `/api/signals/counts`.
+- Rows-read-per-invocation does not materially improve after 24-48h of traffic.
+
+Local validation run for this change:
+
+```sh
+npm run typecheck
+npm test -- src/__tests__/signals.test.ts src/__tests__/do-client.test.ts src/__tests__/signal-counts-since.test.ts src/__tests__/schema-migration.test.ts src/__tests__/home-page.test.ts
+```

--- a/src/__tests__/signals.test.ts
+++ b/src/__tests__/signals.test.ts
@@ -1,6 +1,17 @@
 import { describe, it, expect } from "vitest";
 import { SELF } from "cloudflare:test";
 
+const PAGING_TAG = "paging-lower-bound-700";
+
+async function seed(body: Record<string, unknown>) {
+  const res = await SELF.fetch("http://example.com/api/test-seed", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  expect(res.status).toBe(200);
+}
+
 /**
  * Integration tests for /api/signals endpoints.
  * Tests validation layer and error responses (happy-path CRUD requires BIP-322 auth).
@@ -25,6 +36,89 @@ describe("GET /api/signals", () => {
     );
     expect(res.status).toBe(200);
   });
+});
+
+describe("GET /api/signals — bounded pagination metadata", () => {
+  it("returns hasMore and a bounded total without over-reporting empty pages", async () => {
+    await seed({
+      signals: [
+        {
+          id: "paging-700-001",
+          beat_slug: "agent-social",
+          btc_address: "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
+          headline: "Paging test first",
+          sources: "[]",
+          created_at: "2026-04-30T12:03:00.000Z",
+          status: "approved",
+          reviewed_at: "2026-04-30T12:04:00.000Z",
+        },
+        {
+          id: "paging-700-002",
+          beat_slug: "agent-social",
+          btc_address: "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
+          headline: "Paging test second",
+          sources: "[]",
+          created_at: "2026-04-30T12:02:00.000Z",
+          status: "approved",
+          reviewed_at: "2026-04-30T12:04:00.000Z",
+        },
+        {
+          id: "paging-700-003",
+          beat_slug: "agent-social",
+          btc_address: "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
+          headline: "Paging test third",
+          sources: "[]",
+          created_at: "2026-04-30T12:01:00.000Z",
+          status: "approved",
+          reviewed_at: "2026-04-30T12:04:00.000Z",
+        },
+      ],
+      signal_tags: [
+        { signal_id: "paging-700-001", tag: PAGING_TAG },
+        { signal_id: "paging-700-002", tag: PAGING_TAG },
+        { signal_id: "paging-700-003", tag: PAGING_TAG },
+      ],
+    });
+
+    const firstRes = await SELF.fetch(
+      `http://example.com/api/signals?tag=${PAGING_TAG}&limit=2`
+    );
+    expect(firstRes.status).toBe(200);
+    const firstBody = await firstRes.json<{
+      signals: unknown[];
+      total: number;
+      hasMore: boolean;
+    }>();
+    expect(firstBody.signals).toHaveLength(2);
+    expect(firstBody.hasMore).toBe(true);
+    expect(firstBody.total).toBe(3);
+
+    const secondRes = await SELF.fetch(
+      `http://example.com/api/signals?tag=${PAGING_TAG}&limit=2&offset=2`
+    );
+    expect(secondRes.status).toBe(200);
+    const secondBody = await secondRes.json<{
+      signals: unknown[];
+      total: number;
+      hasMore: boolean;
+    }>();
+    expect(secondBody.signals).toHaveLength(1);
+    expect(secondBody.hasMore).toBe(false);
+    expect(secondBody.total).toBe(3);
+
+    const beyondRes = await SELF.fetch(
+      `http://example.com/api/signals?tag=${PAGING_TAG}&limit=2&offset=100`
+    );
+    expect(beyondRes.status).toBe(200);
+    const beyondBody = await beyondRes.json<{
+      signals: unknown[];
+      total: number;
+      hasMore: boolean;
+    }>();
+    expect(beyondBody.signals).toHaveLength(0);
+    expect(beyondBody.hasMore).toBe(false);
+    expect(beyondBody.total).toBe(0);
+  }, 30_000);
 });
 
 describe("GET /api/signals/:id — not found", () => {

--- a/src/lib/do-client.ts
+++ b/src/lib/do-client.ts
@@ -183,14 +183,14 @@ export async function listSignals(
 }
 
 /**
- * Same query as `listSignals` but also returns the total count of matching
- * rows (ignoring limit/offset) so the caller can paginate. Used by the
- * public /api/signals route — clients render "Page X of N" off the total.
+ * Same query as `listSignals` but also returns bounded pagination metadata.
+ * `total` is now a lower bound that preserves the legacy numeric field without
+ * forcing NewsDO to run an unbounded COUNT(*) on every list request.
  */
 export async function listSignalsPage(
   env: Env,
   filters: SignalFilters = {}
-): Promise<{ signals: Signal[]; total: number }> {
+): Promise<{ signals: Signal[]; total: number; hasMore: boolean }> {
   const stub = getStub(env);
   const params = new URLSearchParams();
   if (filters.beat) params.set("beat", filters.beat);
@@ -205,7 +205,11 @@ export async function listSignalsPage(
   const result = await doFetch<Signal[]>(stub, `/signals${qs ? `?${qs}` : ""}`);
   if (!result.ok) throw new Error(result.error ?? "Failed to list signals");
   if (result.data === undefined) throw new Error("Missing data in response");
-  return { signals: result.data, total: result.total ?? result.data.length };
+  return {
+    signals: result.data,
+    total: result.total ?? result.data.length,
+    hasMore: result.hasMore ?? false,
+  };
 }
 
 /** All data needed for the initial page load, fetched in a single DO call. */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -418,7 +418,11 @@ export interface DOResult<T> {
   status?: DOErrorStatus;
   /** Present on approval responses — current daily cap status */
   approval_cap?: ApprovalCapInfo;
-  /** Present on paginated list responses — count of matching rows ignoring limit/offset */
+  /**
+   * Present on paginated list responses. Some hot paths return a bounded
+   * lower-bound count instead of an exact count; check hasMore for next-page
+   * availability before treating this as authoritative.
+   */
   total?: number;
   /** Present on bounded paginated list responses when one more page is known to exist */
   hasMore?: boolean;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -420,6 +420,8 @@ export interface DOResult<T> {
   approval_cap?: ApprovalCapInfo;
   /** Present on paginated list responses — count of matching rows ignoring limit/offset */
   total?: number;
+  /** Present on bounded paginated list responses when one more page is known to exist */
+  hasMore?: boolean;
 }
 
 export type PaymentStageKind = "brief_access" | "classified_submission";

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -2336,7 +2336,7 @@ export class NewsDO extends DurableObject<Env> {
       // Avoid the unbounded COUNT(*) that made every paginated list scan the
       // whole table. `total` remains numeric for old callers, but is now a
       // bounded lower bound that reveals only whether another page exists.
-      const total = offset + signals.length + (hasMore ? 1 : 0);
+      const total = signals.length === 0 ? 0 : offset + signals.length + (hasMore ? 1 : 0);
 
       return c.json({ ok: true, data: signals, total, hasMore } satisfies DOResult<Signal[]>);
     });

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -5,7 +5,7 @@ import type { Env, Beat, Signal, SignalStatus, Streak, Brief, Classified, Classi
 import { validateSlug, validateHexColor, sanitizeString, validateDateFormat } from "../lib/validators";
 import { generateId, getUTCDate, getUTCYesterday, getUTCDayStart, getUTCDayEnd, getNextDate } from "../lib/helpers";
 import { CLASSIFIED_DURATION_DAYS, CLASSIFIED_BRIEF_SLOTS, CLASSIFIED_BRIEF_MAX_CHARS, CLASSIFIED_STATUSES, SIGNAL_COOLDOWN_HOURS, BEAT_EXPIRY_DAYS, MAX_SIGNALS_PER_DAY, MAX_INCLUDED_SIGNALS_PER_BRIEF, MAX_APPROVED_SIGNALS_PER_DAY, SIGNAL_STATUSES, REVIEWABLE_SIGNAL_STATUSES, CONFIG_PUBLISHER_ADDRESS, BRIEF_INCLUSION_PAYOUT_SATS, WEEKLY_PRIZE_1ST_SATS, WEEKLY_PRIZE_2ND_SATS, WEEKLY_PRIZE_3RD_SATS, SCORING_WEIGHTS, PAYMENT_STAGE_TTL_MS } from "../lib/constants";
-import { SCHEMA_SQL, MIGRATION_PHASE0_SQL, MIGRATION_PAYMENTS_SQL, MIGRATION_BEAT_RESTRUCTURE_SQL, MIGRATION_SBTC_TRACKING_SQL, MIGRATION_CLASSIFIEDS_CLEANUP_SQL, MIGRATION_CLASSIFIEDS_REVIEW_SQL, MIGRATION_SNAPSHOTS_SQL, MIGRATION_BEAT_CLAIMS_SQL, MIGRATION_RETRACTION_SQL, MIGRATION_BEAT_NETWORK_FOCUS_SQL, MIGRATION_BITCOIN_MACRO_SQL, MIGRATION_QUANTUM_BEAT_SQL, MIGRATION_PAYMENT_STAGING_SQL, MIGRATION_APPROVAL_CAP_INDEX_SQL, MIGRATION_BEAT_EDITORS_SQL, MIGRATION_EDITORIAL_REVIEWS_SQL, MIGRATION_EDITOR_REVIEW_RATE_SQL, MIGRATION_CURATION_CLEANUP_SQL, MIGRATION_LEADERBOARD_INDEXES_SQL, MIGRATION_BEAT_CONSOLIDATION_SQL, MIGRATION_SIGNAL_SCORING_SQL, MIGRATION_APR7_EARNINGS_SQL, MIGRATION_CLASSIFIEDS_TXID_UNIQUE_SQL } from "./schema";
+import { SCHEMA_SQL, MIGRATION_PHASE0_SQL, MIGRATION_PAYMENTS_SQL, MIGRATION_BEAT_RESTRUCTURE_SQL, MIGRATION_SBTC_TRACKING_SQL, MIGRATION_CLASSIFIEDS_CLEANUP_SQL, MIGRATION_CLASSIFIEDS_REVIEW_SQL, MIGRATION_SNAPSHOTS_SQL, MIGRATION_BEAT_CLAIMS_SQL, MIGRATION_RETRACTION_SQL, MIGRATION_BEAT_NETWORK_FOCUS_SQL, MIGRATION_BITCOIN_MACRO_SQL, MIGRATION_QUANTUM_BEAT_SQL, MIGRATION_PAYMENT_STAGING_SQL, MIGRATION_APPROVAL_CAP_INDEX_SQL, MIGRATION_BEAT_EDITORS_SQL, MIGRATION_EDITORIAL_REVIEWS_SQL, MIGRATION_EDITOR_REVIEW_RATE_SQL, MIGRATION_CURATION_CLEANUP_SQL, MIGRATION_LEADERBOARD_INDEXES_SQL, MIGRATION_BEAT_CONSOLIDATION_SQL, MIGRATION_SIGNAL_SCORING_SQL, MIGRATION_APR7_EARNINGS_SQL, MIGRATION_CLASSIFIEDS_TXID_UNIQUE_SQL, MIGRATION_SIGNAL_HOT_PATH_INDEXES_SQL } from "./schema";
 import { scoreSignal } from "../lib/signal-scorer";
 
 // ── State machine transition maps ──
@@ -55,6 +55,187 @@ interface RawSignalRow {
 interface RawCompiledSignalRow extends CompiledSignalRow {
   reviewed_at: string | null;
   position?: number | null;
+}
+
+type SqlParam = string | number | null;
+
+const REVIEWED_SIGNAL_STATUSES = ["approved", "brief_included", "rejected", "replaced"] as const;
+const COUNTED_SIGNAL_STATUSES = ["submitted", ...REVIEWED_SIGNAL_STATUSES] as const;
+
+interface SignalListFilters {
+  beat: string | null;
+  agent: string | null;
+  since: string | null;
+  tag: string | null;
+  status: string | null;
+  dateStart: string | null;
+  dateEnd: string | null;
+}
+
+interface SignalCountFilters {
+  beat: string | null;
+  agent: string | null;
+  since: string | null;
+}
+
+function appendSignalScopeFilters(
+  clauses: string[],
+  params: SqlParam[],
+  filters: Pick<SignalListFilters, "beat" | "agent">,
+  alias = "s"
+) {
+  const prefix = alias ? `${alias}.` : "";
+  if (filters.beat) {
+    clauses.push(`${prefix}beat_slug = ?`);
+    params.push(filters.beat);
+  }
+  if (filters.agent) {
+    clauses.push(`${prefix}btc_address = ?`);
+    params.push(filters.agent);
+  }
+}
+
+function buildSignalListWhere(filters: SignalListFilters): { whereSql: string; params: SqlParam[] } {
+  const clauses: string[] = [];
+  const params: SqlParam[] = [];
+  appendSignalScopeFilters(clauses, params, filters);
+  if (filters.since) {
+    clauses.push("s.created_at > ?");
+    params.push(filters.since);
+  }
+  if (filters.tag) {
+    clauses.push("s.id IN (SELECT signal_id FROM signal_tags WHERE tag = ?)");
+    params.push(filters.tag);
+  }
+  if (filters.status) {
+    clauses.push("s.status = ?");
+    params.push(filters.status);
+  }
+  if (filters.dateStart) {
+    clauses.push("s.created_at >= ?");
+    params.push(filters.dateStart);
+  }
+  if (filters.dateEnd) {
+    clauses.push("s.created_at < ?");
+    params.push(filters.dateEnd);
+  }
+  return { whereSql: clauses.length ? clauses.join(" AND ") : "1 = 1", params };
+}
+
+function fetchSignalTags(
+  sql: DurableObjectState["storage"]["sql"],
+  signalIds: string[]
+): Map<string, string[]> {
+  const tagsBySignal = new Map<string, string[]>();
+  if (signalIds.length === 0) return tagsBySignal;
+
+  const placeholders = signalIds.map(() => "?").join(", ");
+  const rows = sql
+    .exec(
+      `SELECT signal_id, tag
+       FROM signal_tags
+       WHERE signal_id IN (${placeholders})
+       ORDER BY signal_id, tag`,
+      ...signalIds
+    )
+    .toArray();
+
+  for (const row of rows) {
+    const r = row as { signal_id: string; tag: string };
+    const tags = tagsBySignal.get(r.signal_id) ?? [];
+    tags.push(r.tag);
+    tagsBySignal.set(r.signal_id, tags);
+  }
+  return tagsBySignal;
+}
+
+function rowsToSignalsWithTags(
+  sql: DurableObjectState["storage"]["sql"],
+  rows: Record<string, unknown>[]
+): Signal[] {
+  const ids = rows.map((row) => row.id as string).filter(Boolean);
+  const tagsBySignal = fetchSignalTags(sql, ids);
+  return rows.map((row) =>
+    rowToSignal({
+      ...row,
+      tags_csv: tagsBySignal.get(row.id as string)?.join(",") ?? null,
+    })
+  );
+}
+
+function querySignalCountRows(
+  sql: DurableObjectState["storage"]["sql"],
+  filters: SignalCountFilters
+): Array<{ status: string; count: number }> {
+  const rows: Array<{ status: string; count: number }> = [];
+  const countWhere = (clauses: string[], params: SqlParam[]) => {
+    const countRows = sql
+      .exec(`SELECT COUNT(*) as count FROM signals s WHERE ${clauses.join(" AND ")}`, ...params)
+      .toArray();
+    return Number((countRows[0] as { count: number } | undefined)?.count) || 0;
+  };
+
+  for (const status of COUNTED_SIGNAL_STATUSES) {
+    const reviewedStatus = (REVIEWED_SIGNAL_STATUSES as readonly string[]).includes(status);
+    const baseClauses = ["s.status = ?"];
+    const baseParams: SqlParam[] = [status];
+    appendSignalScopeFilters(baseClauses, baseParams, filters);
+
+    if (!filters.since) {
+      rows.push({ status, count: countWhere(baseClauses, baseParams) });
+      continue;
+    }
+
+    if (reviewedStatus) {
+      const reviewedClauses = [...baseClauses, "s.reviewed_at >= ?"];
+      const fallbackClauses = [...baseClauses, "s.reviewed_at IS NULL", "s.created_at >= ?"];
+      rows.push({
+        status,
+        count:
+          countWhere(reviewedClauses, [...baseParams, filters.since]) +
+          countWhere(fallbackClauses, [...baseParams, filters.since]),
+      });
+    } else {
+      const createdClauses = [...baseClauses, "s.created_at >= ?"];
+      rows.push({ status, count: countWhere(createdClauses, [...baseParams, filters.since]) });
+    }
+  }
+
+  return rows;
+}
+
+function queryBeatStatusCountRowsSince(
+  sql: DurableObjectState["storage"]["sql"],
+  since: string
+): Array<{ beat_slug: string; status: string; count: number }> {
+  const rows: Array<{ beat_slug: string; status: string; count: number }> = [];
+  const appendGroupedRows = (status: string, whereSql: string, ...params: SqlParam[]) => {
+    const queryRows = sql
+      .exec(
+        `SELECT beat_slug, COUNT(*) as count
+         FROM signals
+         WHERE ${whereSql}
+         GROUP BY beat_slug`,
+        ...params
+      )
+      .toArray();
+    for (const row of queryRows) {
+      const r = row as { beat_slug: string; count: number };
+      rows.push({ beat_slug: r.beat_slug, status, count: Number(r.count) || 0 });
+    }
+  };
+
+  for (const status of COUNTED_SIGNAL_STATUSES) {
+    const reviewedStatus = (REVIEWED_SIGNAL_STATUSES as readonly string[]).includes(status);
+    if (reviewedStatus) {
+      appendGroupedRows(status, "status = ? AND reviewed_at >= ?", status, since);
+      appendGroupedRows(status, "status = ? AND reviewed_at IS NULL AND created_at >= ?", status, since);
+    } else {
+      appendGroupedRows(status, "status = ? AND created_at >= ?", status, since);
+    }
+  }
+
+  return rows;
 }
 
 /**
@@ -523,7 +704,8 @@ export class NewsDO extends DurableObject<Env> {
     // 24 = Signal quality auto-scoring — quality_score INTEGER, score_breakdown TEXT (#343)
     // 25 = Publisher payout reconciliation — Apr 7 amendment + clear 8 RBF payout_txid + Mar 31 over-cap void (#502)
     // 26 = Partial UNIQUE index on classifieds.payment_txid for replay protection across both placement paths
-    const CURRENT_MIGRATION_VERSION = 26;
+    // 27 = Signal hot-path composite indexes for Cloudflare bill reduction
+    const CURRENT_MIGRATION_VERSION = 27;
     const versionRows = this.ctx.storage.sql
       .exec("SELECT value FROM config WHERE key = 'migration_version'")
       .toArray();
@@ -904,6 +1086,21 @@ export class NewsDO extends DurableObject<Env> {
             const msg = e instanceof Error ? e.message : String(e);
             if (!msg.includes("already exists")) {
               console.error("Classifieds payment_txid unique-index migration failed:", e);
+            }
+          }
+        }
+      }
+
+      // Hot listing/count indexes — supports /signals, /signals/counts, and
+      // /init query rewrites that avoid OR/COALESCE full scans.
+      if (appliedVersion < 27) {
+        for (const stmt of MIGRATION_SIGNAL_HOT_PATH_INDEXES_SQL) {
+          try {
+            this.ctx.storage.sql.exec(stmt);
+          } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            if (!msg.includes("already exists")) {
+              console.error("Signal hot-path index migration failed:", e);
             }
           }
         }
@@ -2106,63 +2303,42 @@ export class NewsDO extends DurableObject<Env> {
         dateEnd = getUTCDayEnd(dateParam);
       }
 
+      const { whereSql, params } = buildSignalListWhere({
+        beat,
+        agent,
+        since: dateParam ? null : since,
+        tag,
+        status,
+        dateStart,
+        dateEnd,
+      });
+      const pageLimit = limit + 1;
+
       const rows = this.ctx.storage.sql
         .exec(
-          `SELECT s.*, b.name as beat_name, GROUP_CONCAT(st.tag) as tags_csv
+          `SELECT s.*, b.name as beat_name, NULL as tags_csv
            FROM signals s
            LEFT JOIN beats b ON s.beat_slug = b.slug
-           LEFT JOIN signal_tags st ON s.id = st.signal_id
-           WHERE (?1 IS NULL OR s.beat_slug = ?1)
-             AND (?2 IS NULL OR s.btc_address = ?2)
-             AND (?3 IS NULL OR s.created_at > ?3)
-             AND (?4 IS NULL OR s.id IN (SELECT signal_id FROM signal_tags WHERE tag = ?4))
-             AND (?5 IS NULL OR s.status = ?5)
-             AND (?7 IS NULL OR s.created_at >= ?7)
-             AND (?8 IS NULL OR s.created_at < ?8)
-           GROUP BY s.id
+           WHERE ${whereSql}
            ORDER BY s.created_at DESC
-           LIMIT ?6
-           OFFSET ?9`,
-          beat,
-          agent,
-          dateParam ? null : since,
-          tag,
-          status,
-          limit,
-          dateStart,
-          dateEnd,
+           LIMIT ?
+           OFFSET ?`,
+          ...params,
+          pageLimit,
           offset
         )
-        .toArray();
+        .toArray() as Record<string, unknown>[];
 
-      const signals = rows.map((r) => rowToSignal(r as Record<string, unknown>));
+      const hasMore = rows.length > limit;
+      const pageRows = hasMore ? rows.slice(0, limit) : rows;
+      const signals = rowsToSignalsWithTags(this.ctx.storage.sql, pageRows);
 
-      // Total count of all matching rows (for pagination on the client).
-      // The data query slices to LIMIT/OFFSET so its row count alone can't
-      // tell the UI how many pages exist.
-      const totalRows = this.ctx.storage.sql
-        .exec(
-          `SELECT COUNT(*) as total
-           FROM signals s
-           WHERE (?1 IS NULL OR s.beat_slug = ?1)
-             AND (?2 IS NULL OR s.btc_address = ?2)
-             AND (?3 IS NULL OR s.created_at > ?3)
-             AND (?4 IS NULL OR s.id IN (SELECT signal_id FROM signal_tags WHERE tag = ?4))
-             AND (?5 IS NULL OR s.status = ?5)
-             AND (?6 IS NULL OR s.created_at >= ?6)
-             AND (?7 IS NULL OR s.created_at < ?7)`,
-          beat,
-          agent,
-          dateParam ? null : since,
-          tag,
-          status,
-          dateStart,
-          dateEnd
-        )
-        .toArray();
-      const total = (totalRows[0] as { total: number } | undefined)?.total ?? signals.length;
+      // Avoid the unbounded COUNT(*) that made every paginated list scan the
+      // whole table. `total` remains numeric for old callers, but is now a
+      // bounded lower bound that reveals only whether another page exists.
+      const total = offset + signals.length + (hasMore ? 1 : 0);
 
-      return c.json({ ok: true, data: signals, total } satisfies DOResult<Signal[]>);
+      return c.json({ ok: true, data: signals, total, hasMore } satisfies DOResult<Signal[]>);
     });
 
     // GET /signals/front-page — curated signals (approved + brief_included)
@@ -2266,40 +2442,7 @@ export class NewsDO extends DurableObject<Env> {
       const sinceRaw = c.req.query("since") ?? null;
       const since = sinceRaw && sinceRaw.trim() !== "" ? sinceRaw : null;
 
-      const rows = this.ctx.storage.sql
-        .exec(
-          `SELECT status, COUNT(*) as count
-           FROM signals
-           WHERE (?1 IS NULL OR beat_slug = ?1)
-             AND (?2 IS NULL OR btc_address = ?2)
-             AND (
-               ?3 IS NULL
-               OR (
-                 status = 'submitted' AND created_at >= ?3
-               )
-               OR (
-                 status IN ('approved', 'brief_included', 'rejected', 'replaced')
-                 AND COALESCE(reviewed_at, created_at) >= ?3
-               )
-               OR (
-                 -- Defensive fall-through for any future status added to
-                 -- SIGNAL_STATUSES. TypeScript's as-const enum forces call
-                 -- sites to update, but the SQL string can silently miss a
-                 -- new value and drop rows from the windowed count. Default
-                 -- to created_at-based bucketing (same as 'submitted') so a
-                 -- new status degrades gracefully instead of disappearing.
-                 -- Per review feedback on #522.
-                 status NOT IN (
-                   'submitted', 'approved', 'brief_included', 'rejected', 'replaced'
-                 ) AND created_at >= ?3
-               )
-             )
-           GROUP BY status`,
-          beat,
-          agent,
-          since
-        )
-        .toArray();
+      const rows = querySignalCountRows(this.ctx.storage.sql, { beat, agent, since });
 
       const counts: Record<string, number> = {
         submitted: 0,
@@ -2311,7 +2454,7 @@ export class NewsDO extends DurableObject<Env> {
       for (const row of rows) {
         const r = row as { status: string; count: number };
         if (r.status in counts) {
-          counts[r.status] = r.count;
+          counts[r.status] += Number(r.count) || 0;
         }
       }
       const total = Object.values(counts).reduce((a, b) => a + b, 0);
@@ -4910,69 +5053,26 @@ export class NewsDO extends DurableObject<Env> {
       // scrolls.
       const signals = queryFrontPageSignals(this.ctx.storage.sql);
 
-      // Homepage beat-rail counts — replaces 3 × /api/signals/counts?beat=X
-      // fan-out + the ticker's /api/signals/counts?since=1h call. Uses the
-      // same windowing rule as /signals/counts (submitted → by created_at,
-      // terminal statuses → by reviewed_at ?? created_at) so numbers match.
-      //
-      // IMPORTANT: the three-branch WHERE clause below is duplicated in
-      // the `signalsCount1h` query that follows AND mirrors the logic in
-      // the /signals/counts handler (~line 2220 in this file). Any change
-      // to status bucketing (e.g. a new SignalStatus value) must update
-      // all three sites together — the fall-through `NOT IN (...)` branch
-      // is a safety net for new statuses but won't catch a semantic
-      // re-grouping (e.g. moving `replaced` from terminal to creation-time
-      // bucketing). A CTE could unify these in a future refactor.
+      // Homepage beat-rail counts — same bucketing as /signals/counts, but
+      // expressed as per-status UNION queries so SQLite can use composite
+      // status/date indexes instead of scanning the full signals table.
       const todayUtcMidnight = `${getUTCDate(new Date(now))}T00:00:00.000Z`;
       const oneHourAgo = new Date(now - 3600 * 1000).toISOString();
 
-      const beatStatsRows = this.ctx.storage.sql
-        .exec(
-          `SELECT beat_slug, status, COUNT(*) as count
-           FROM signals
-           WHERE (
-             (status = 'submitted' AND created_at >= ?1)
-             OR (
-               status IN ('approved', 'brief_included', 'rejected', 'replaced')
-               AND COALESCE(reviewed_at, created_at) >= ?1
-             )
-             OR (
-               status NOT IN ('submitted', 'approved', 'brief_included', 'rejected', 'replaced')
-               AND created_at >= ?1
-             )
-           )
-           GROUP BY beat_slug, status`,
-          todayUtcMidnight
-        )
-        .toArray();
+      const beatStatsRows = queryBeatStatusCountRowsSince(this.ctx.storage.sql, todayUtcMidnight);
 
       const beatStats: Record<string, Record<string, number>> = {};
       for (const row of beatStatsRows) {
         const r = row as { beat_slug: string; status: string; count: number };
         if (!beatStats[r.beat_slug]) beatStats[r.beat_slug] = {};
-        beatStats[r.beat_slug][r.status] = Number(r.count) || 0;
+        beatStats[r.beat_slug][r.status] = (beatStats[r.beat_slug][r.status] ?? 0) + (Number(r.count) || 0);
       }
 
-      const hourlyCountRows = this.ctx.storage.sql
-        .exec(
-          `SELECT COUNT(*) as count
-           FROM signals
-           WHERE (
-             (status = 'submitted' AND created_at >= ?1)
-             OR (
-               status IN ('approved', 'brief_included', 'rejected', 'replaced')
-               AND COALESCE(reviewed_at, created_at) >= ?1
-             )
-             OR (
-               status NOT IN ('submitted', 'approved', 'brief_included', 'rejected', 'replaced')
-               AND created_at >= ?1
-             )
-           )`,
-          oneHourAgo
-        )
-        .toArray();
-      const signalsCount1h =
-        Number((hourlyCountRows[0] as { count: number } | undefined)?.count) || 0;
+      const signalsCount1h = querySignalCountRows(this.ctx.storage.sql, {
+        beat: null,
+        agent: null,
+        since: oneHourAgo,
+      }).reduce((total, row) => total + row.count, 0);
 
       return c.json({
         ok: true,

--- a/src/objects/schema.ts
+++ b/src/objects/schema.ts
@@ -126,9 +126,14 @@ CREATE TABLE IF NOT EXISTS payment_staging (
 );
 
 CREATE INDEX IF NOT EXISTS idx_signal_tags_tag          ON signal_tags(tag);
+CREATE INDEX IF NOT EXISTS idx_signal_tags_tag_signal   ON signal_tags(tag, signal_id);
 CREATE INDEX IF NOT EXISTS idx_signals_beat_slug        ON signals(beat_slug);
+CREATE INDEX IF NOT EXISTS idx_signals_beat_created     ON signals(beat_slug, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_signals_btc_address      ON signals(btc_address);
+CREATE INDEX IF NOT EXISTS idx_signals_btc_created      ON signals(btc_address, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_signals_created_at       ON signals(created_at);
+CREATE INDEX IF NOT EXISTS idx_signals_status_created   ON signals(status, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_signals_status_reviewed_created ON signals(status, reviewed_at DESC, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_signals_correction_of    ON signals(correction_of);
 CREATE INDEX IF NOT EXISTS idx_earnings_btc_address     ON earnings(btc_address);
 CREATE INDEX IF NOT EXISTS idx_classifieds_btc_address  ON classifieds(btc_address);
@@ -728,6 +733,21 @@ export const MIGRATION_SIGNAL_SCORING_SQL = [
  */
 export const MIGRATION_CLASSIFIEDS_TXID_UNIQUE_SQL = [
   "CREATE UNIQUE INDEX IF NOT EXISTS idx_classifieds_payment_txid_unique ON classifieds(payment_txid) WHERE payment_txid IS NOT NULL",
+] as const;
+
+/**
+ * MIGRATION_SIGNAL_HOT_PATH_INDEXES_SQL — Cloudflare bill-reduction indexes.
+ *
+ * Supports the April 2026 cost fix for /signals, /signals/counts, and /init:
+ * dynamic WHERE clauses, no unbounded list COUNT(*), deferred tag loading, and
+ * per-status count queries that avoid OR/COALESCE full scans.
+ */
+export const MIGRATION_SIGNAL_HOT_PATH_INDEXES_SQL = [
+  "CREATE INDEX IF NOT EXISTS idx_signal_tags_tag_signal ON signal_tags(tag, signal_id)",
+  "CREATE INDEX IF NOT EXISTS idx_signals_status_created ON signals(status, created_at DESC)",
+  "CREATE INDEX IF NOT EXISTS idx_signals_status_reviewed_created ON signals(status, reviewed_at DESC, created_at DESC)",
+  "CREATE INDEX IF NOT EXISTS idx_signals_beat_created ON signals(beat_slug, created_at DESC)",
+  "CREATE INDEX IF NOT EXISTS idx_signals_btc_created ON signals(btc_address, created_at DESC)",
 ] as const;
 
 export const MIGRATION_APR7_EARNINGS_SQL = [

--- a/src/routes/signals.ts
+++ b/src/routes/signals.ts
@@ -97,7 +97,7 @@ signalsRouter.get("/api/signals", signalReadRateLimit, async (c) => {
   }
 
   // date takes precedence over since — pass since only when date is absent
-  const { signals, total } = await listSignalsPage(c.env, { beat, agent, tag, since: date ? undefined : since, date, status, limit: resolvedLimit, offset: resolvedOffset });
+  const { signals, total, hasMore } = await listSignalsPage(c.env, { beat, agent, tag, since: date ? undefined : since, date, status, limit: resolvedLimit, offset: resolvedOffset });
 
   // Resolve agent display names for all signals in this response
   const signalAddresses = [...new Set(signals.map((s) => s.btc_address).filter(Boolean))];
@@ -136,9 +136,10 @@ signalsRouter.get("/api/signals", signalReadRateLimit, async (c) => {
   c.header("X-Timezone", "UTC");
   const response = c.json({
     signals: transformed,
-    // Count of all rows matching the filter set, across all pages.
-    // The signals list page renders "Page X of N" off this number.
+    // Bounded lower-bound count. Avoids making every list request run an
+    // unbounded COUNT(*) in NewsDO while preserving the legacy numeric field.
     total,
+    hasMore,
     // Count of rows actually returned in this response (after limit/offset).
     filtered: transformed.length,
     limit: resolvedLimit,


### PR DESCRIPTION
## Summary

Reduces the highest-dollar `agent-news` NewsDO row-read path from the April Cloudflare bill audit.

Changes:
- rewrites `/signals` to build dynamic SQL predicates instead of `(? IS NULL OR ...)` clauses
- removes the unbounded list `COUNT(*)`; returns bounded pagination metadata with `hasMore` while preserving numeric `total`
- defers `signal_tags` loading until after the page of signal IDs is selected
- rewrites `/signals/counts` and `/init` count queries to small per-status indexed queries instead of `OR` / `COALESCE` grouped scans
- adds migration 27 with hot-path composite indexes
- adds `docs/cloudflare-cost-runbook.md` with the rows-read verification plan

## Expected Cloudflare metric movement

Target metric: Durable Objects SQLite `rows_read` for the `agent-news` script / NewsDO namespace.

Baseline from `cloudflare-bill-audit-2026-04.md`:
- NewsDO rows read in April: 427.8B
- `agent-news` DO invocations in April: 5.1M
- average: about 84,000 rows read per invocation

Expected after deploy:
- hot listing/count invocations should drop to roughly 50-500 rows read per request class
- 24h and 48h production windows should show orders-of-magnitude lower rows_read / invocation

Verification window:
- before deploy: capture prior 24h rows_read and DO invocations
- 15-30 min after deploy: check `/api/signals`, `/api/signals/counts`, `/api/init` health and WARN/ERROR logs
- 24h and 48h after deploy: recapture rows_read / invocation and record it in the audit/runbook thread

## Tests

Passed:
- `npm run typecheck`
- `npm test -- src/__tests__/signals.test.ts src/__tests__/do-client.test.ts src/__tests__/signal-counts-since.test.ts src/__tests__/schema-migration.test.ts src/__tests__/home-page.test.ts`

Not clean / caveats:
- `npm run lint` currently reports pre-existing style warnings in unrelated files and existing warnings in `news-do.ts`.
- Full `npm test` hit repeated Cloudflare `workerd` RPC-handler internal errors and 30s timeouts in unrelated payment/classified tests; the focused signal/init suite above passed.
