### PR TITLE
fix: chunk signal tag hydration

### DIFF
--- a/src/__tests__/signals.test.ts
+++ b/src/__tests__/signals.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { SELF } from "cloudflare:test";
 
 const PAGING_TAG = "paging-lower-bound-700";
+const LARGE_PAGE_TAG = "large-page-tag-hydration";
 
 async function seed(body: Record<string, unknown>) {
   const res = await SELF.fetch("http://example.com/api/test-seed", {
@@ -118,6 +119,43 @@ describe("GET /api/signals — bounded pagination metadata", () => {
     expect(beyondBody.signals).toHaveLength(0);
     expect(beyondBody.hasMore).toBe(false);
     expect(beyondBody.total).toBe(0);
+  }, 30_000);
+
+  it("hydrates tags for a 200-row page without exceeding DO SQLite variable limits", async () => {
+    const signals = Array.from({ length: 201 }, (_, index) => {
+      const n = String(index + 1).padStart(3, "0");
+      return {
+        id: `large-page-tag-${n}`,
+        beat_slug: "bitcoin-macro",
+        btc_address: "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
+        headline: `Large page tag hydration ${n}`,
+        sources: "[]",
+        created_at: `2026-04-30T13:${String(index % 60).padStart(2, "0")}:00.000Z`,
+        status: "brief_included",
+        reviewed_at: "2026-04-30T14:00:00.000Z",
+      };
+    });
+
+    await seed({
+      signals,
+      signal_tags: signals.map((signal) => ({
+        signal_id: signal.id,
+        tag: LARGE_PAGE_TAG,
+      })),
+    });
+
+    const res = await SELF.fetch(
+      `http://example.com/api/signals?beat=bitcoin-macro&status=brief_included&tag=${LARGE_PAGE_TAG}&limit=500`
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json<{
+      signals: Array<{ tags: string[] }>;
+      filtered: number;
+      hasMore: boolean;
+    }>();
+    expect(body.filtered).toBe(200);
+    expect(body.hasMore).toBe(true);
+    expect(body.signals.every((signal) => signal.tags.includes(LARGE_PAGE_TAG))).toBe(true);
   }, 30_000);
 });
 

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -61,6 +61,7 @@ type SqlParam = string | number | null;
 
 const REVIEWED_SIGNAL_STATUSES = ["approved", "brief_included", "rejected", "replaced"] as const;
 const COUNTED_SIGNAL_STATUSES = ["submitted", ...REVIEWED_SIGNAL_STATUSES] as const;
+const SIGNAL_TAG_HYDRATION_CHUNK_SIZE = 50;
 
 interface SignalListFilters {
   beat: string | null;
@@ -129,23 +130,27 @@ function fetchSignalTags(
   const tagsBySignal = new Map<string, string[]>();
   if (signalIds.length === 0) return tagsBySignal;
 
-  const placeholders = signalIds.map(() => "?").join(", ");
-  const rows = sql
-    .exec(
-      `SELECT signal_id, tag
-       FROM signal_tags
-       WHERE signal_id IN (${placeholders})
-       ORDER BY signal_id, tag`,
-      ...signalIds
-    )
-    .toArray();
+  for (let i = 0; i < signalIds.length; i += SIGNAL_TAG_HYDRATION_CHUNK_SIZE) {
+    const chunk = signalIds.slice(i, i + SIGNAL_TAG_HYDRATION_CHUNK_SIZE);
+    const placeholders = chunk.map(() => "?").join(", ");
+    const rows = sql
+      .exec(
+        `SELECT signal_id, tag
+         FROM signal_tags
+         WHERE signal_id IN (${placeholders})
+         ORDER BY signal_id, tag`,
+        ...chunk
+      )
+      .toArray();
 
-  for (const row of rows) {
-    const r = row as { signal_id: string; tag: string };
-    const tags = tagsBySignal.get(r.signal_id) ?? [];
-    tags.push(r.tag);
-    tagsBySignal.set(r.signal_id, tags);
+    for (const row of rows) {
+      const r = row as { signal_id: string; tag: string };
+      const tags = tagsBySignal.get(r.signal_id) ?? [];
+      tags.push(r.tag);
+      tagsBySignal.set(r.signal_id, tags);
+    }
   }
+
   return tagsBySignal;
 }
 


### PR DESCRIPTION
## Summary
- chunk `NewsDO` signal tag hydration into 50-ID batches instead of one large `WHERE signal_id IN (...)` bind list
- keep the public `/api/signals` 200-row page cap while avoiding the observed DO SQLite variable ceiling
- add a regression test for `limit=500` being clamped to a 200-row page with tag hydration

## Production evidence
Follow-up log triage in `worker-logs/.planning/2026-05-01T0428Z-agent-news-pr700-log-triage-followup.md` found a Cloudflare tail-only DO exception after PR #700 merged:

- public request: `/api/signals?beat=bitcoin-macro&status=brief_included&limit=500`
- DO request: `/do/signals?beat=bitcoin-macro&status=brief_included&limit=200&offset=0`
- DO error: `too many SQL variables ... SQLITE_ERROR`

This PR keeps the PR #700 query-shape gains and limits the follow-up tag lookup to at most 50 bind params per query, so a 200-row public page performs up to 4 small tag queries rather than one rejected 200-param query.

## Validation
- `npm run typecheck`
- `npm test -- src/__tests__/signals.test.ts`
- `npm test -- src/__tests__/signals.test.ts src/__tests__/do-client.test.ts src/__tests__/signal-counts-since.test.ts src/__tests__/schema-migration.test.ts src/__tests__/home-page.test.ts`
- `npm run lint` exits 0; repo still has unrelated pre-existing Biome warnings outside this change
- `npx biome lint src/objects/news-do.ts src/__tests__/signals.test.ts && git diff --check` exits 0; changed-file lint only reports pre-existing warnings in untouched parts of `news-do.ts`