### PR TITLE
test: tighten signal tag hydration regression

### DIFF
--- a/src/__tests__/signals.test.ts
+++ b/src/__tests__/signals.test.ts
@@ -155,6 +155,8 @@ describe("GET /api/signals — bounded pagination metadata", () => {
     }>();
     expect(body.filtered).toBe(200);
     expect(body.hasMore).toBe(true);
+    expect(body.signals).toHaveLength(200);
+    expect(body.signals.length).toBe(body.filtered);
     expect(body.signals.every((signal) => signal.tags.includes(LARGE_PAGE_TAG))).toBe(true);
   }, 30_000);
 });

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -61,6 +61,8 @@ type SqlParam = string | number | null;
 
 const REVIEWED_SIGNAL_STATUSES = ["approved", "brief_included", "rejected", "replaced"] as const;
 const COUNTED_SIGNAL_STATUSES = ["submitted", ...REVIEWED_SIGNAL_STATUSES] as const;
+// Keep tag hydration batches below the observed Durable Object SQLite variable cap.
+// A 200-row public page becomes at most four tag queries instead of one rejected IN list.
 const SIGNAL_TAG_HYDRATION_CHUNK_SIZE = 50;
 
 interface SignalListFilters {


### PR DESCRIPTION
## Summary
- document why signal tag hydration uses 50-ID batches
- assert the 200-row regression page length before checking tag hydration contents

## Context
Follow-up for Copilot review comments on merged PR #702.

## Validation
- `npm run typecheck`
- `npm test -- src/__tests__/signals.test.ts`