### PR TITLE
fix: move agent-news rate limits off KV

### DIFF
--- a/docs/cloudflare-cost-runbook.md
+++ b/docs/cloudflare-cost-runbook.md
@@ -57,3 +57,43 @@ Local validation run for this change:
 npm run typecheck
 npm test -- src/__tests__/signals.test.ts src/__tests__/do-client.test.ts src/__tests__/signal-counts-since.test.ts src/__tests__/schema-migration.test.ts src/__tests__/home-page.test.ts
 ```
+
+## F2: NEWS_KV rate-limit write removal
+
+PR scope:
+- Replace the KV-backed rate-limit middleware with first-party Cloudflare
+  `ratelimits` bindings.
+- Keep x402 probe behavior: routes with `skipIfMissingHeaders` still bypass the
+  limiter until a real payment header is present.
+- Check the `/api/signals` edge cache before read-rate limiting so public cache
+  hits do not perform any per-request KV read/write or rate-limit binding call.
+
+Expected Cloudflare movement:
+- `NEWS_KV` writes should drop sharply. April audit baseline: `NEWS_KV` wrote
+  32.2 M times/month, mostly from per-request rate-limit counters.
+- `NEWS_KV` reads should also drop, but not to zero: agent-name resolution,
+  identity/cache lookups, and the edge-cache stampede lock still use KV.
+
+Behavior change:
+- Old KV counters supported route-specific long windows such as 10/hour,
+  3/day, and 1/week.
+- Cloudflare `ratelimits.simple` supports only 10s or 60s windows. This repo now
+  uses short-window burst protection:
+  - `RATE_LIMIT_READ`: 300/minute.
+  - `RATE_LIMIT_MUTATING`: 20/minute.
+  - `RATE_LIMIT_AUTHENTICATED`: 200/minute.
+- Payment, BIP-322 auth, identity gates, publisher gates, and DO validation
+  remain the durable controls for expensive state changes.
+
+Before/after window:
+- Before: record `NEWS_KV` reads/writes for the previous 24h and the current
+  partial day before deploy.
+- Fast safety check: 15-30 minutes after deploy for 5xx, 429 spikes, and
+  WARN/ERROR log regression.
+- Cost signal: record `NEWS_KV` writes for the first same-day post-deploy window
+  and then compare a full 24h window.
+
+Rollback signal:
+- Sustained 5xx increase on public read or mutating routes.
+- Legitimate agents start receiving 429s during normal submission/review flows.
+- Cloudflare deploy rejects the `ratelimits` binding config.

--- a/src/__tests__/rate-limit-skip.test.ts
+++ b/src/__tests__/rate-limit-skip.test.ts
@@ -8,7 +8,7 @@ import { SELF } from "cloudflare:test";
  * so that x402 probes (requests without a payment header) bypass rate limiting,
  * while real payment attempts are counted against the quota.
  *
- * NOTE: All tests share a single KV-backed rate-limit bucket keyed by IP
+ * NOTE: All tests share a single Cloudflare Rate Limiting bucket keyed by IP
  * (CF-Connecting-IP is absent in tests, so the key is "unknown"). Tests are
  * ordered so that cumulative state is accounted for.
  */
@@ -18,7 +18,7 @@ const VALID_BODY = JSON.stringify({ category: "services", headline: "Test Ad" })
 
 describe("skipIfMissingHeaders — classifieds rate limiting", () => {
   it("requests WITHOUT payment headers bypass rate limiting (always get 402)", async () => {
-    // Send more requests than the rate limit (20 req / 10 min) — all should
+    // Send more requests than the mutating burst limit (20 req / min) — all should
     // return 402 because missing-header requests are never counted.
     const results: number[] = [];
     for (let i = 0; i < 25; i++) {
@@ -36,7 +36,7 @@ describe("skipIfMissingHeaders — classifieds rate limiting", () => {
   });
 
   it("requests WITH payment headers ARE rate limited (eventually 429)", async () => {
-    // The classified rate limit is 20 req / 10 min. Exhaust the quota with
+    // The classified rate limit is 20 req / min. Exhaust the quota with
     // X-PAYMENT, then confirm payment-signature also counts against the same bucket.
     const statuses: number[] = [];
     for (let i = 0; i < 22; i++) {

--- a/src/__tests__/signal-read-rate-limit.test.ts
+++ b/src/__tests__/signal-read-rate-limit.test.ts
@@ -9,9 +9,9 @@ import { SELF } from "cloudflare:test";
  * Cloudflare WAF fires first and returns an opaque 403 with no
  * Retry-After header.
  *
- * Fix: apply signalReadRateLimit (300 req/min per IP) to GET /api/signals
- * and GET /api/signals/:id. This ensures the app returns 429 + Retry-After
- * before Cloudflare's WAF can fire, giving clients actionable backoff info.
+ * Fix: apply the first-party RATE_LIMIT_READ binding (300 req/min per IP) to
+ * read traffic. GET /api/signals checks the edge cache before rate limiting so
+ * cache hits do not perform any per-request KV writes.
  *
  * NOTE: The read limit is 300 req/min - far above what these tests can hit
  * in a single test run. We verify the middleware is present and well-behaved,

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -112,6 +112,9 @@ export const REVIEWABLE_SIGNAL_STATUSES = [
 ] as const;
 
 // ── Rate limits ──
+// Route-level constants are retained as call-site labels/backoff hints. Actual
+// enforcement is now handled by Cloudflare `ratelimits` bindings in wrangler:
+// read = 300/min, mutating = 20/min, authenticated = 200/min.
 // Agent-facing routes (many callers, tighter windows)
 export const SIGNAL_RATE_LIMIT = {
   maxRequests: 10,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -106,6 +106,11 @@ export interface Env {
   LOGS?: unknown;
   // X402_RELAY is a service binding to x402-sponsor-relay RPC (RelayRPC WorkerEntrypoint)
   X402_RELAY?: unknown;
+  // First-party Cloudflare Rate Limiting bindings. These replace the old
+  // per-request NEWS_KV counters for burst protection.
+  RATE_LIMIT_READ?: RateLimit;
+  RATE_LIMIT_MUTATING?: RateLimit;
+  RATE_LIMIT_AUTHENTICATED?: RateLimit;
   ENVIRONMENT?: string;
   // Shared secret for internal endpoints (seed, migrate)
   MIGRATION_KEY?: string;

--- a/src/middleware/rate-limit.ts
+++ b/src/middleware/rate-limit.ts
@@ -2,22 +2,22 @@ import type { Context, Next } from "hono";
 import type { Env, AppVariables } from "../lib/types";
 import { resolveAgentName } from "../services/agent-resolver";
 
-interface RateLimitRecord {
-  count: number;
-  resetAt: number;
-}
+const RATE_LIMIT_BINDING_CONFIG = {
+  read: { maxRequests: 300, periodSeconds: 60 },
+  mutating: { maxRequests: 20, periodSeconds: 60 },
+  authenticated: { maxRequests: 200, periodSeconds: 60 },
+} as const;
 
 interface RateLimitOptions {
   key: string;
   maxRequests: number;
   windowSeconds: number;
+  binding?: "read" | "mutating" | "authenticated";
   /**
    * Optional header name used to refine the rate-limit bucket for
    * authenticated callers. When set and the header carries a non-empty
-   * value, the bucket is keyed by `{key}:{identity}` so that distinct
-   * identities behind the same IP get independent quotas. An IP-based
-   * bucket is **always** checked first to prevent unauthenticated callers
-   * from spoofing the header to bypass per-IP limits.
+   * value, the bucket is keyed by `{key}:id:{identity}` so that distinct
+   * identities behind the same IP get independent quotas.
    */
   identityHeader?: string;
   /**
@@ -46,13 +46,14 @@ interface RateLimitOptions {
 
 /**
  * Factory that creates a Hono rate-limit middleware scoped to a given key.
- * Reads CF-Connecting-IP and checks a sliding window counter in NEWS_KV.
- * Returns 429 when the limit is exceeded.
+ * Reads CF-Connecting-IP or an authenticated identity header and checks a
+ * first-party Cloudflare Rate Limiting binding. Returns 429 when limited.
  *
- * When `identityHeader` is provided, **two** buckets are checked:
- *   1. IP-based bucket (always enforced — prevents header-spoofing bypass)
- *   2. Identity-based bucket (only when header is present and non-empty)
- * The request must pass both buckets.
+ * Public/anonymous requests are keyed by IP. Authenticated requests should
+ * carry `X-BTC-Address` and are keyed by address to avoid shared-IP false
+ * positives. The old KV implementation used long-window counters; the
+ * Cloudflare binding intentionally enforces short-window burst limits, which
+ * removes per-request NEWS_KV writes from the request path.
  *
  * On rate-limit violations, the BTC address from X-BTC-Address is included in
  * warning logs (along with agent_name from the registry) so operators can
@@ -62,11 +63,10 @@ interface RateLimitOptions {
  * All 429 responses include a `Retry-After` header and `retry_after` field in
  * the JSON body so clients can implement proper exponential backoff.
  *
- * KNOWN LIMITATION — Worker (KV) level only:
- * Rate limiting is enforced at the Cloudflare Worker layer using KV storage.
- * A caller with direct access to the Durable Object (e.g. via internal DO-to-DO
- * RPC or a misconfigured binding) can bypass this middleware entirely. This is an
- * accepted trade-off for the current architecture; the DO itself does not enforce
+ * KNOWN LIMITATION — Worker level only:
+ * Rate limiting is enforced at the Cloudflare Worker layer using the
+ * account-level Rate Limiting API. A caller with direct access to the Durable
+ * Object can bypass this middleware entirely; the DO itself does not enforce
  * its own rate limits.
  */
 export function createRateLimitMiddleware(opts: RateLimitOptions) {
@@ -98,57 +98,43 @@ export function createRateLimitMiddleware(opts: RateLimitOptions) {
       if (!hasAny) return next();
     }
 
-    const ip = c.req.header("CF-Connecting-IP") ?? "unknown";
-    const identity = opts.identityHeader
-      ? (c.req.header(opts.identityHeader)?.trim() || null)
-      : null;
-
-    // Always check IP-based bucket first (prevents identity header spoofing)
-    const ipKey = `ratelimit:${opts.key}:${ip}`;
-    const blocked = await checkBucket(c, ipKey, opts, ip, identity);
+    const blocked = await checkRateLimit(c, opts);
     if (blocked) return blocked;
-
-    // If an identity header is present, also check the identity bucket.
-    // This gives each authenticated caller their own quota independent of IP.
-    if (identity) {
-      const idKey = `ratelimit:${opts.key}:id:${identity}`;
-      const idBlocked = await checkBucket(c, idKey, opts, ip, identity);
-      if (idBlocked) return idBlocked;
-    }
 
     return next();
   };
 }
 
-async function checkBucket(
+export async function checkRateLimit(
   c: Context<{ Bindings: Env; Variables: AppVariables }>,
-  rlKey: string,
-  opts: RateLimitOptions,
-  ip: string,
-  identity: string | null
+  opts: RateLimitOptions
 ) {
-  const record =
-    (await c.env.NEWS_KV.get<RateLimitRecord>(rlKey, "json")) ?? {
-      count: 0,
-      resetAt: 0,
-    };
-
-  const now = Date.now();
-
-  if (now > record.resetAt) {
-    record.count = 1;
-    record.resetAt = now + opts.windowSeconds * 1000;
-  } else {
-    record.count += 1;
+  const binding = opts.binding ?? "mutating";
+  const limiter = selectLimiter(c.env, binding);
+  if (!limiter) {
+    const logger = c.get("logger");
+    logger.warn("rate limit binding missing; request allowed", {
+      key: opts.key,
+      binding,
+    });
+    return null;
   }
 
-  if (record.count > opts.maxRequests) {
-    const retryAfter = Math.ceil((record.resetAt - now) / 1000);
+  const ip = c.req.header("CF-Connecting-IP") ?? "unknown";
+  const identityHeader = opts.identityHeader ?? "X-BTC-Address";
+  const identity = c.req.header(identityHeader)?.trim() || null;
+  const bucket = identity ? `id:${identity}` : `ip:${ip}`;
+  const rlKey = `${opts.key}:${bucket}`;
+  const { success } = await limiter.limit({ key: rlKey });
+
+  if (!success) {
+    const config = RATE_LIMIT_BINDING_CONFIG[binding];
+    const retryAfter = config.periodSeconds;
     const logger = c.get("logger");
 
     // Read BTC address for agent identification in logs.
-    // Always check X-BTC-Address header first (present on all authenticated routes).
-    // Fall back to the identity value when identityHeader is configured.
+    // Always check X-BTC-Address header first (present on authenticated routes).
+    // Fall back to the configured identity header when present.
     // Fire-and-forget: agent name resolution must never delay the 429 response.
     const btcAddress = c.req.header("X-BTC-Address")?.trim() || identity || null;
 
@@ -158,8 +144,7 @@ async function checkBucket(
       btc_address: btcAddress ?? undefined,
       auth: btcAddress ? undefined : "missing",
       bucket: rlKey,
-      count: record.count,
-      max: opts.maxRequests,
+      max: config.maxRequests,
       retry_after: retryAfter,
     });
 
@@ -194,9 +179,19 @@ async function checkBucket(
     );
   }
 
-  await c.env.NEWS_KV.put(rlKey, JSON.stringify(record), {
-    expirationTtl: opts.windowSeconds,
-  });
-
   return null;
+}
+
+function selectLimiter(
+  env: Env,
+  binding: NonNullable<RateLimitOptions["binding"]>
+): RateLimit | undefined {
+  switch (binding) {
+    case "read":
+      return env.RATE_LIMIT_READ;
+    case "authenticated":
+      return env.RATE_LIMIT_AUTHENTICATED;
+    case "mutating":
+      return env.RATE_LIMIT_MUTATING;
+  }
 }

--- a/src/routes/brief-compile.ts
+++ b/src/routes/brief-compile.ts
@@ -13,6 +13,7 @@ const briefCompileRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>(
 
 const compileRateLimit = createRateLimitMiddleware({
   key: "brief-compile",
+  binding: "authenticated",
   ...BRIEF_COMPILE_RATE_LIMIT,
 });
 

--- a/src/routes/brief-inscribe.ts
+++ b/src/routes/brief-inscribe.ts
@@ -11,6 +11,7 @@ const briefInscribeRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>
 
 const inscribeRateLimit = createRateLimitMiddleware({
   key: "brief-inscribe",
+  binding: "authenticated",
   ...BRIEF_INSCRIBE_RATE_LIMIT,
   identityHeader: "X-BTC-Address",
 });

--- a/src/routes/classified-review.ts
+++ b/src/routes/classified-review.ts
@@ -19,6 +19,7 @@ const classifiedReviewRouter = new Hono<{ Bindings: Env; Variables: AppVariables
 
 const reviewRateLimit = createRateLimitMiddleware({
   key: "classified-review",
+  binding: "authenticated",
   ...REVIEW_RATE_LIMIT,
 });
 

--- a/src/routes/signal-review.ts
+++ b/src/routes/signal-review.ts
@@ -19,6 +19,7 @@ const signalReviewRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>(
 
 const reviewRateLimit = createRateLimitMiddleware({
   key: "signal-review",
+  binding: "authenticated",
   ...REVIEW_RATE_LIMIT,
 });
 

--- a/src/routes/signals.ts
+++ b/src/routes/signals.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import type { Env, AppVariables } from "../lib/types";
-import { createRateLimitMiddleware } from "../middleware/rate-limit";
+import { checkRateLimit, createRateLimitMiddleware } from "../middleware/rate-limit";
 import { SIGNAL_RATE_LIMIT, SIGNAL_READ_RATE_LIMIT, SIGNAL_STATUSES, SIGNAL_PRICE_SATS, CONFIG_PUBLISHER_ADDRESS } from "../lib/constants";
 import {
   validateBtcAddress,
@@ -29,6 +29,7 @@ const signalsRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>();
 
 const signalRateLimit = createRateLimitMiddleware({
   key: "signals",
+  binding: "mutating",
   ...SIGNAL_RATE_LIMIT,
 });
 
@@ -41,11 +42,12 @@ const signalRateLimit = createRateLimitMiddleware({
  */
 const signalReadRateLimit = createRateLimitMiddleware({
   key: "signals-read",
+  binding: "read",
   ...SIGNAL_READ_RATE_LIMIT,
 });
 
 // GET /api/signals — list signals with optional filters
-signalsRouter.get("/api/signals", signalReadRateLimit, async (c) => {
+signalsRouter.get("/api/signals", async (c) => {
   // Edge-cache short-circuit. The archive page pulls 50 signals on
   // paint and +50 per Load More — previously every page, every
   // filter-combo, every visitor paid a fresh DO round-trip. Cache key
@@ -53,6 +55,13 @@ signalsRouter.get("/api/signals", signalReadRateLimit, async (c) => {
   // ?agent=Y&limit=50 live as separate entries.
   const cached = await edgeCacheMatch(c);
   if (cached) return cached;
+
+  const blocked = await checkRateLimit(c, {
+    key: "signals-read",
+    binding: "read",
+    ...SIGNAL_READ_RATE_LIMIT,
+  });
+  if (blocked) return blocked;
 
   const beat = c.req.query("beat");
   const agent = c.req.query("agent");

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -21,6 +21,15 @@
     { "binding": "NEWS_KV", "id": "3b2ccbdc1fd5426ba72ed323e3407bdc" }
   ],
 
+  // First-party rate limit bindings. Top-level IDs are isolated from the
+  // named production/staging envs so branch preview traffic cannot consume
+  // production counters.
+  "ratelimits": [
+    { "name": "RATE_LIMIT_READ", "namespace_id": "2026050101", "simple": { "limit": 300, "period": 60 } },
+    { "name": "RATE_LIMIT_MUTATING", "namespace_id": "2026050102", "simple": { "limit": 20, "period": 60 } },
+    { "name": "RATE_LIMIT_AUTHENTICATED", "namespace_id": "2026050103", "simple": { "limit": 200, "period": 60 } }
+  ],
+
   // Durable Object binding — primary storage engine (SQLite)
   "durable_objects": {
     "bindings": [
@@ -93,6 +102,12 @@
         { "binding": "NEWS_KV", "id": "341f4de6834c4a908eb52f6cb556bbce" }
       ],
 
+      "ratelimits": [
+        { "name": "RATE_LIMIT_READ", "namespace_id": "2026050111", "simple": { "limit": 300, "period": 60 } },
+        { "name": "RATE_LIMIT_MUTATING", "namespace_id": "2026050112", "simple": { "limit": 20, "period": 60 } },
+        { "name": "RATE_LIMIT_AUTHENTICATED", "namespace_id": "2026050113", "simple": { "limit": 200, "period": 60 } }
+      ],
+
       "durable_objects": {
         "bindings": [
           { "name": "NEWS_DO", "class_name": "NewsDO" }
@@ -133,6 +148,12 @@
 
       "kv_namespaces": [
         { "binding": "NEWS_KV", "id": "3b2ccbdc1fd5426ba72ed323e3407bdc" }
+      ],
+
+      "ratelimits": [
+        { "name": "RATE_LIMIT_READ", "namespace_id": "2026050121", "simple": { "limit": 300, "period": 60 } },
+        { "name": "RATE_LIMIT_MUTATING", "namespace_id": "2026050122", "simple": { "limit": 20, "period": 60 } },
+        { "name": "RATE_LIMIT_AUTHENTICATED", "namespace_id": "2026050123", "simple": { "limit": 200, "period": 60 } }
       ],
 
       "durable_objects": {


### PR DESCRIPTION
## Summary
- replace the KV-backed rate-limit middleware with first-party Cloudflare `ratelimits` bindings
- add `RATE_LIMIT_READ`, `RATE_LIMIT_MUTATING`, and `RATE_LIMIT_AUTHENTICATED` bindings for top-level, staging, and production Wrangler envs
- check `/api/signals` edge cache before read-rate limiting so public cache hits do not perform per-request KV writes or rate-limit binding calls
- document the F2 validation plan and the intentional move from long-window KV counters to short-window burst protection

## Production baseline before this PR
Fresh log window from `2026-05-01T04:15:00Z`:

- `agent-news`: 0 ERRORs; 13 WARNs, with `/api/correspondents` SWR warnings stopping at `04:25Z` and only rate-limit WARNs newer than that
- `x402-relay`: 0 ERRORs / 3 WARNs
- `x402-api-host`: 0 ERRORs / 0 WARNs
- `aibtc-landing`: 1 mempool fetch ERROR on `/api/achievements/verify`, unrelated to this PR

## Expected billing movement
April audit baseline: `NEWS_KV` had 32.2M writes/month, mostly from per-request rate-limit counters. This PR removes `NEWS_KV.get`/`NEWS_KV.put` from `src/middleware/rate-limit.ts`, so `NEWS_KV` writes should drop sharply after deploy. Remaining KV usage is non-rate-limit cache/identity work such as agent names and edge-cache locks.

Legacy `ratelimit:*` KV keys were written with TTLs, so they should age out naturally once this lands.

## Behavior note
Cloudflare `ratelimits.simple` only supports 10s or 60s windows. This changes route limiting from long-window KV counters to short-window burst limits:

- `RATE_LIMIT_READ`: 300/minute
- `RATE_LIMIT_MUTATING`: 20/minute
- `RATE_LIMIT_AUTHENTICATED`: 200/minute

Payment, BIP-322 auth, identity gates, publisher gates, and DO validation remain the durable controls for expensive state changes.

## Validation
- `npm run typecheck`
- `npm test -- src/__tests__/rate-limit-skip.test.ts src/__tests__/signal-read-rate-limit.test.ts src/__tests__/signals.test.ts`
- `npx biome lint src/middleware/rate-limit.ts src/routes/signals.ts src/routes/signal-review.ts src/routes/classified-review.ts src/routes/brief-compile.ts src/routes/brief-inscribe.ts src/lib/types.ts src/lib/constants.ts src/__tests__/rate-limit-skip.test.ts src/__tests__/signal-read-rate-limit.test.ts && git diff --check`
- `npm run deploy:dry-run:staging`
- `npm run wrangler -- deploy --dry-run --env production`

Both Wrangler dry-runs list the expected Rate Limit bindings.