### PR TITLE
Reduce correspondents cache rebuild pressure

### DIFF
--- a/src/__tests__/agent-classifieds.test.ts
+++ b/src/__tests__/agent-classifieds.test.ts
@@ -65,9 +65,9 @@ describe("agent classifieds injection", () => {
     expect(res.headers.get("cache-control")).toBe("private, no-store");
     const body = await res.json<{ classifieds?: unknown[] }>();
     expect(Array.isArray(body.classifieds)).toBe(true);
-    expect(body.classifieds!.length).toBeGreaterThan(0);
-    expect(body.classifieds!.length).toBeLessThanOrEqual(3);
-  });
+    expect(body.classifieds?.length).toBeGreaterThan(0);
+    expect(body.classifieds?.length).toBeLessThanOrEqual(3);
+  }, 30_000);
 
   it("does not attach classifieds when Sec-Fetch-Site is present (browser)", async () => {
     const res = await SELF.fetch("http://example.com/api/correspondents", {
@@ -77,7 +77,7 @@ describe("agent classifieds injection", () => {
     expect(res.headers.get("x-classifieds-injected")).toBeNull();
     const body = await res.json<{ classifieds?: unknown[] }>();
     expect(body.classifieds).toBeUndefined();
-  });
+  }, 30_000);
 
   it("skips array-rooted endpoints to avoid breaking shape compatibility", async () => {
     // /api/beats returns a JSON array — middleware must not inject onto it.

--- a/src/lib/edge-cache.ts
+++ b/src/lib/edge-cache.ts
@@ -49,8 +49,21 @@ import type { AppContext } from "./types";
 
 const CACHED_AT_HEADER = "X-Edge-Cached-At";
 
-function buildCacheKey(c: AppContext): Request {
-  return new Request(new URL(c.req.url).toString(), { method: "GET" });
+export interface EdgeCacheKeyOptions {
+  /**
+   * Optional canonical path for routes whose query string does not change the
+   * response. Use sparingly; most cached routes intentionally key by full URL.
+   */
+  cacheKeyPath?: string;
+}
+
+function buildCacheKey(c: AppContext, options: EdgeCacheKeyOptions = {}): Request {
+  const url = new URL(c.req.url);
+  if (options.cacheKeyPath) {
+    url.pathname = options.cacheKeyPath;
+    url.search = "";
+  }
+  return new Request(url.toString(), { method: "GET" });
 }
 
 /**
@@ -69,9 +82,12 @@ function isTestEnv(c: AppContext): boolean {
  * (with an `X-Edge-Cache: HIT` header attached for observability) or `null`
  * on miss. Safe to call from any GET handler.
  */
-export async function edgeCacheMatch(c: AppContext): Promise<Response | null> {
+export async function edgeCacheMatch(
+  c: AppContext,
+  options: EdgeCacheKeyOptions = {}
+): Promise<Response | null> {
   if (isTestEnv(c)) return null;
-  const cached = await caches.default.match(buildCacheKey(c));
+  const cached = await caches.default.match(buildCacheKey(c, options));
   if (!cached) return null;
   // Clone-via-Response constructor so we can mutate the headers without
   // touching the body stream (which would break subsequent reads).
@@ -93,6 +109,7 @@ export interface SWRMatchOptions {
    * rebuild. Should be well below the outer s-maxage edge TTL.
    */
   freshSeconds: number;
+  cacheKeyPath?: string;
 }
 
 /**
@@ -114,7 +131,7 @@ export async function edgeCacheMatchSWR(
   options: SWRMatchOptions
 ): Promise<SWRHit | null> {
   if (isTestEnv(c)) return null;
-  const cached = await caches.default.match(buildCacheKey(c));
+  const cached = await caches.default.match(buildCacheKey(c, options));
   if (!cached) return null;
   const cachedAt = Number(cached.headers.get(CACHED_AT_HEADER) ?? "0");
   const ageSeconds = cachedAt > 0 ? (Date.now() - cachedAt) / 1000 : Number.POSITIVE_INFINITY;
@@ -136,12 +153,16 @@ export async function edgeCacheMatchSWR(
  * requests. The live response returned to the current caller also carries
  * the stamp (harmless; helps debugging).
  */
-export function edgeCachePut(c: AppContext, response: Response): void {
+export function edgeCachePut(
+  c: AppContext,
+  response: Response,
+  options: EdgeCacheKeyOptions = {}
+): void {
   if (isTestEnv(c)) return;
   response.headers.set(CACHED_AT_HEADER, String(Date.now()));
   const cacheCopy = response.clone();
   response.headers.set("X-Edge-Cache", "MISS");
-  c.executionCtx.waitUntil(caches.default.put(buildCacheKey(c), cacheCopy));
+  c.executionCtx.waitUntil(caches.default.put(buildCacheKey(c, options), cacheCopy));
 }
 
 /**
@@ -162,10 +183,14 @@ export function edgeCachePut(c: AppContext, response: Response): void {
 export function triggerSWRRefresh(
   c: AppContext,
   bucket: string,
-  rebuild: () => Promise<unknown>
+  rebuild: () => Promise<unknown>,
+  options: EdgeCacheKeyOptions = {}
 ): void {
   if (isTestEnv(c)) return;
-  const lockKey = `swr-lock:${bucket}:${new URL(c.req.url).pathname}${new URL(c.req.url).search}`;
+  const requestUrl = new URL(c.req.url);
+  const lockPath = options.cacheKeyPath ?? requestUrl.pathname;
+  const lockSearch = options.cacheKeyPath ? "" : requestUrl.search;
+  const lockKey = `swr-lock:${bucket}:${lockPath}${lockSearch}`;
   c.executionCtx.waitUntil(
     (async () => {
       try {

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -5,7 +5,7 @@ import type { Env, Beat, Signal, SignalStatus, Streak, Brief, Classified, Classi
 import { validateSlug, validateHexColor, sanitizeString, validateDateFormat } from "../lib/validators";
 import { generateId, getUTCDate, getUTCYesterday, getUTCDayStart, getUTCDayEnd, getNextDate } from "../lib/helpers";
 import { CLASSIFIED_DURATION_DAYS, CLASSIFIED_BRIEF_SLOTS, CLASSIFIED_BRIEF_MAX_CHARS, CLASSIFIED_STATUSES, SIGNAL_COOLDOWN_HOURS, BEAT_EXPIRY_DAYS, MAX_SIGNALS_PER_DAY, MAX_INCLUDED_SIGNALS_PER_BRIEF, MAX_APPROVED_SIGNALS_PER_DAY, SIGNAL_STATUSES, REVIEWABLE_SIGNAL_STATUSES, CONFIG_PUBLISHER_ADDRESS, BRIEF_INCLUSION_PAYOUT_SATS, WEEKLY_PRIZE_1ST_SATS, WEEKLY_PRIZE_2ND_SATS, WEEKLY_PRIZE_3RD_SATS, SCORING_WEIGHTS, PAYMENT_STAGE_TTL_MS } from "../lib/constants";
-import { SCHEMA_SQL, MIGRATION_PHASE0_SQL, MIGRATION_PAYMENTS_SQL, MIGRATION_BEAT_RESTRUCTURE_SQL, MIGRATION_SBTC_TRACKING_SQL, MIGRATION_CLASSIFIEDS_CLEANUP_SQL, MIGRATION_CLASSIFIEDS_REVIEW_SQL, MIGRATION_SNAPSHOTS_SQL, MIGRATION_BEAT_CLAIMS_SQL, MIGRATION_RETRACTION_SQL, MIGRATION_BEAT_NETWORK_FOCUS_SQL, MIGRATION_BITCOIN_MACRO_SQL, MIGRATION_QUANTUM_BEAT_SQL, MIGRATION_PAYMENT_STAGING_SQL, MIGRATION_APPROVAL_CAP_INDEX_SQL, MIGRATION_BEAT_EDITORS_SQL, MIGRATION_EDITORIAL_REVIEWS_SQL, MIGRATION_EDITOR_REVIEW_RATE_SQL, MIGRATION_CURATION_CLEANUP_SQL, MIGRATION_LEADERBOARD_INDEXES_SQL, MIGRATION_BEAT_CONSOLIDATION_SQL, MIGRATION_SIGNAL_SCORING_SQL, MIGRATION_APR7_EARNINGS_SQL, MIGRATION_CLASSIFIEDS_TXID_UNIQUE_SQL, MIGRATION_SIGNAL_HOT_PATH_INDEXES_SQL } from "./schema";
+import { SCHEMA_SQL, MIGRATION_PHASE0_SQL, MIGRATION_PAYMENTS_SQL, MIGRATION_BEAT_RESTRUCTURE_SQL, MIGRATION_SBTC_TRACKING_SQL, MIGRATION_CLASSIFIEDS_CLEANUP_SQL, MIGRATION_CLASSIFIEDS_REVIEW_SQL, MIGRATION_SNAPSHOTS_SQL, MIGRATION_BEAT_CLAIMS_SQL, MIGRATION_RETRACTION_SQL, MIGRATION_BEAT_NETWORK_FOCUS_SQL, MIGRATION_BITCOIN_MACRO_SQL, MIGRATION_QUANTUM_BEAT_SQL, MIGRATION_PAYMENT_STAGING_SQL, MIGRATION_APPROVAL_CAP_INDEX_SQL, MIGRATION_BEAT_EDITORS_SQL, MIGRATION_EDITORIAL_REVIEWS_SQL, MIGRATION_EDITOR_REVIEW_RATE_SQL, MIGRATION_CURATION_CLEANUP_SQL, MIGRATION_LEADERBOARD_INDEXES_SQL, MIGRATION_BEAT_CONSOLIDATION_SQL, MIGRATION_SIGNAL_SCORING_SQL, MIGRATION_APR7_EARNINGS_SQL, MIGRATION_CLASSIFIEDS_TXID_UNIQUE_SQL, MIGRATION_SIGNAL_HOT_PATH_INDEXES_SQL, MIGRATION_CORRESPONDENTS_BUNDLE_INDEXES_SQL } from "./schema";
 import { scoreSignal } from "../lib/signal-scorer";
 
 // ── State machine transition maps ──
@@ -712,7 +712,8 @@ export class NewsDO extends DurableObject<Env> {
     // 25 = Publisher payout reconciliation — Apr 7 amendment + clear 8 RBF payout_txid + Mar 31 over-cap void (#502)
     // 26 = Partial UNIQUE index on classifieds.payment_txid for replay protection across both placement paths
     // 27 = Signal hot-path composite indexes for Cloudflare bill reduction
-    const CURRENT_MIGRATION_VERSION = 27;
+    // 28 = Correspondents bundle composite indexes for DO timeout reduction
+    const CURRENT_MIGRATION_VERSION = 28;
     const versionRows = this.ctx.storage.sql
       .exec("SELECT value FROM config WHERE key = 'migration_version'")
       .toArray();
@@ -1108,6 +1109,21 @@ export class NewsDO extends DurableObject<Env> {
             const msg = e instanceof Error ? e.message : String(e);
             if (!msg.includes("already exists")) {
               console.error("Signal hot-path index migration failed:", e);
+            }
+          }
+        }
+      }
+
+      // Correspondents bundle indexes — supports /api/correspondents and the
+      // corresponding /api/init bundle section under cache miss/rebuild bursts.
+      if (appliedVersion < 28) {
+        for (const stmt of MIGRATION_CORRESPONDENTS_BUNDLE_INDEXES_SQL) {
+          try {
+            this.ctx.storage.sql.exec(stmt);
+          } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            if (!msg.includes("already exists")) {
+              console.error("Correspondents bundle index migration failed:", e);
             }
           }
         }

--- a/src/objects/schema.ts
+++ b/src/objects/schema.ts
@@ -750,6 +750,22 @@ export const MIGRATION_SIGNAL_HOT_PATH_INDEXES_SQL = [
   "CREATE INDEX IF NOT EXISTS idx_signals_btc_created ON signals(btc_address, created_at DESC)",
 ] as const;
 
+/**
+ * MIGRATION_CORRESPONDENTS_BUNDLE_INDEXES_SQL — reduce DO pressure from
+ * /api/correspondents and /api/init bundle queries.
+ *
+ * The correspondents bundle groups non-correction signals by btc_address,
+ * joins active beat claims by beat/address, and computes leaderboard earnings.
+ * These composite indexes keep those hot scans ordered by the grouping/join
+ * keys instead of walking broad single-column indexes under cache-miss bursts.
+ */
+export const MIGRATION_CORRESPONDENTS_BUNDLE_INDEXES_SQL = [
+  "CREATE INDEX IF NOT EXISTS idx_signals_correction_btc_created ON signals(correction_of, btc_address, created_at DESC)",
+  "CREATE INDEX IF NOT EXISTS idx_signals_beat_btc_correction_created ON signals(beat_slug, btc_address, correction_of, created_at DESC)",
+  "CREATE INDEX IF NOT EXISTS idx_beat_claims_status_beat_address ON beat_claims(status, beat_slug, btc_address)",
+  "CREATE INDEX IF NOT EXISTS idx_earnings_unpaid_leaderboard ON earnings(voided_at, payout_txid, btc_address)",
+] as const;
+
 export const MIGRATION_APR7_EARNINGS_SQL = [
   // Void earnings for the 14 re-curated signals NOT on-chain
   `UPDATE earnings SET voided_at = datetime('now')

--- a/src/routes/correspondents.ts
+++ b/src/routes/correspondents.ts
@@ -7,8 +7,8 @@
  *
  * Cache layout:
  *   - s-maxage=1800 — Cloudflare holds the entry at the edge for 30 minutes.
- *   - freshSeconds=300 — within 5 minutes of writing, served as a plain HIT.
- *   - 300s < age ≤ 1800s — served immediately as a STALE hit, AND a
+ *   - freshSeconds=1500 — within 25 minutes of writing, served as a plain HIT.
+ *   - 1500s < age ≤ 1800s — served immediately as a STALE hit, AND a
  *     background rebuild fires (guarded by a KV lock so concurrent stale
  *     hits don't all hammer the DO). User never waits for the cold boot.
  *   - age > 1800s — CF evicts the entry; next request pays the MISS cost.
@@ -29,7 +29,8 @@ const correspondentsRouter = new Hono<{
   Variables: AppVariables;
 }>();
 
-const FRESH_SECONDS = 300;
+const CACHE_KEY_PATH = "/api/correspondents";
+const FRESH_SECONDS = 1_500;
 
 async function buildCorrespondentsResponse(c: AppContext): Promise<Response> {
   const bundle = await getCorrespondentsBundle(c.env);
@@ -104,16 +105,24 @@ async function buildCorrespondentsResponse(c: AppContext): Promise<Response> {
       "Cache-Control": "public, max-age=60, s-maxage=1800",
     },
   });
-  edgeCachePut(c, response);
+  edgeCachePut(c, response, { cacheKeyPath: CACHE_KEY_PATH });
   return response;
 }
 
 // GET /api/correspondents — ranked correspondents with signal counts, streaks, and names.
 correspondentsRouter.get("/api/correspondents", async (c) => {
-  const hit = await edgeCacheMatchSWR(c, { freshSeconds: FRESH_SECONDS });
+  const hit = await edgeCacheMatchSWR(c, {
+    cacheKeyPath: CACHE_KEY_PATH,
+    freshSeconds: FRESH_SECONDS,
+  });
   if (hit && !hit.stale) return hit.response;
-  if (hit && hit.stale) {
-    triggerSWRRefresh(c, "correspondents", () => buildCorrespondentsResponse(c));
+  if (hit?.stale) {
+    triggerSWRRefresh(
+      c,
+      "correspondents",
+      () => buildCorrespondentsResponse(c),
+      { cacheKeyPath: CACHE_KEY_PATH }
+    );
     return hit.response;
   }
   return buildCorrespondentsResponse(c);


### PR DESCRIPTION
## Summary
- Canonicalize `/api/correspondents` edge-cache/SWR keys to the naked path so query-string probes or variants do not bypass the expensive cached payload.
- Extend the correspondents SWR fresh window from 5 minutes to 25 minutes while keeping the 30 minute edge TTL, reducing background rebuild frequency against the singleton NewsDO.
- Add migration 28 composite indexes for the correspondents/init bundle query shape and leaderboard earnings scans.
- Give the existing agent-classifieds correspondents middleware test a realistic timeout for the known heavy endpoint.

## Production context
Post-#705 smoke was functionally green except `/api/correspondents` remained slow, and central logs since `2026-05-01T05:00:00Z` showed four new `SWR rebuild failed` WARNs for `/api/correspondents` with NewsDO overload/10s timeout messages. Repeated cache-bypassing smoke requests with a query string reproduced 10s 500s.

## Validation
- `npm run typecheck`
- `npm test -- src/__tests__/agent-classifieds.test.ts src/__tests__/home-page.test.ts src/__tests__/schema-migration.test.ts`
- `npx biome lint src/lib/edge-cache.ts src/routes/correspondents.ts src/objects/schema.ts src/__tests__/agent-classifieds.test.ts && git diff --check`
- `npm run wrangler -- deploy --dry-run --env production`