### PR TITLE
fix: scope agent-resolver NEWS_KV writes to requested addresses

### DIFF
--- a/src/services/agent-resolver.ts
+++ b/src/services/agent-resolver.ts
@@ -191,11 +191,9 @@ export async function resolveAgentNames(
   const { agents: bulkAgents, complete } = await fetchBulkAgents();
   const uncachedSet = new Set(uncached);
 
-  // Step 4: Populate KV cache only for addresses the caller asked about.
-  // We previously wrote every agent in the bulk page (~1000) on every miss
-  // as a "pre-warm"; that produced the bulk of remaining NEWS_KV writes
-  // (B1, cloudflare-bill-reduction-tracker-2026-05.md) without measurable
-  // hit-rate benefit, so the writes are now scoped to uncachedSet.
+  // The bulk fetch is a latency optimization, not a pre-warm: writing
+  // every fetched agent (up to 1000) on each miss inflated NEWS_KV writes
+  // without measurable hit-rate benefit, so writes are scoped to uncachedSet.
   const kvWrites: Promise<void>[] = [];
 
   for (const [btcAddr, info] of bulkAgents) {

--- a/src/services/agent-resolver.ts
+++ b/src/services/agent-resolver.ts
@@ -149,7 +149,8 @@ async function fetchBulkAgents(): Promise<BulkFetchResult> {
  * 1. Check KV cache for all requested addresses
  * 2. If there are cache misses, fetch the bulk agent list (~0.3s for 100 agents)
  *    instead of making N individual calls (~42s each)
- * 3. Populate KV cache for ALL fetched agents (pre-warms future requests)
+ * 3. Populate KV cache only for the originally-requested addresses
+ *    (the bulk fetch is a latency optimization, not a pre-warm)
  * 4. Return a Map<address, AgentInfo> for all requested addresses
  */
 export async function resolveAgentNames(
@@ -190,10 +191,19 @@ export async function resolveAgentNames(
   const { agents: bulkAgents, complete } = await fetchBulkAgents();
   const uncachedSet = new Set(uncached);
 
-  // Step 4: Populate KV cache for ALL fetched agents (pre-warm) and resolve our addresses
+  // Step 4: Populate KV cache only for addresses the caller asked about.
+  // We previously wrote every agent in the bulk page (~1000) on every miss
+  // as a "pre-warm"; that produced the bulk of remaining NEWS_KV writes
+  // (B1, cloudflare-bill-reduction-tracker-2026-05.md) without measurable
+  // hit-rate benefit, so the writes are now scoped to uncachedSet.
   const kvWrites: Promise<void>[] = [];
 
   for (const [btcAddr, info] of bulkAgents) {
+    if (!uncachedSet.has(btcAddr)) continue;
+
+    infoMap.set(btcAddr, info);
+    uncachedSet.delete(btcAddr);
+
     const cacheKey = `${CACHE_KEY_PREFIX}${btcAddr}`;
     const ttl = info.name ? CACHE_TTL_SECONDS : NEGATIVE_CACHE_TTL_SECONDS;
     kvWrites.push(
@@ -201,11 +211,6 @@ export async function resolveAgentNames(
         expirationTtl: ttl,
       }),
     );
-
-    if (uncachedSet.has(btcAddr)) {
-      infoMap.set(btcAddr, info);
-      uncachedSet.delete(btcAddr);
-    }
   }
 
   // Negative-cache addresses as "not found" when the bulk fetch completed fully.


### PR DESCRIPTION
## Summary

- `resolveAgentNames` previously wrote **every** agent in the bulk fetch (up to 1000 entries) to `NEWS_KV` on every cache miss, even when the caller only asked about 1–2 addresses.
- Scope the `kv.put` fan-out to the originally-requested addresses; keep the bulk fetch itself as the latency optimization.
- Targets B1 in `cloudflare-bill-reduction-tracker-2026-05.md` — remaining `NEWS_KV` writes (~12.3K/h, residual after PR #704/#705 removed rate-limit counters).

## Why this is the dominant remaining writer

Inventory: `worker-logs/.planning/2026-05-02T2050Z-news-kv-write-inventory.md`

`resolveAgentNames` is called from `routes/{signals,correspondents,init,leaderboard,classifieds,agents,brief-compile}.ts`. With ~1000 registered agents on staggered 24h TTLs, a single uncached address triggered up to 1000 KV puts. Other writers (single-address resolver, identity gate, SWR locks) are bounded to 1 put per relevant event.

## Expected metric movement

| Metric | Pre-PR (last 24h) | Target |
| --- | ---: | ---: |
| `NEWS_KV` writes/h | 12.3K | low single-digit K/h (driven by SWR locks + identity gate) |
| `NEWS_KV` reads/h | ~50K | unchanged |
| Name resolution correctness | 100% | 100% (smoke `/api/signals`, `/api/correspondents`, `/api/init`) |

Validation window: 24h post-deploy, Cloudflare GraphQL on the production NEWS_KV namespace.

## Rollback signal

If we see name-resolution regressions in `/api/signals`, `/api/correspondents`, or `/api/init` (rendered display names suddenly missing for non-requested-but-recently-seen addresses), revert this commit. The previous behavior pre-warmed the entire registry, so any caller relying on a sibling lookup populating its cache implicitly would break.

There are no such callers in the current code — every call site explicitly passes the addresses it cares about.

## Test plan

- [x] `npm run typecheck` passes
- [ ] post-deploy smoke: `/api/signals`, `/api/correspondents`, `/api/init` return populated `name` fields
- [ ] Cloudflare GraphQL: `NEWS_KV` writes/h drops materially in 24h post-deploy window
- [ ] Central logs (`logs.aibtc.com`) clean for `agent-news` post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)