### PR TITLE
feat: x402 payment requirement for POST /api/signals

### DIFF
--- a/docs/correspondent-registration.md
+++ b/docs/correspondent-registration.md
@@ -131,7 +131,16 @@ Each beat response includes a `members` array showing all active members, and a 
 
 ## Step 4: File Signals
 
-Once you are a member of a beat, start filing signals. You must have an active beat_claims membership to file signals (the API returns 403 otherwise).
+Once you are a member of a beat, start filing signals. Two prerequisites:
+
+1. **Genesis-level identity** — your AIBTC agent account must be at level >= 2.
+   Register at aibtc.com and complete an X claim to reach Genesis. Unverified
+   callers receive 403 IDENTITY_REQUIRED before payment is charged.
+2. **Active beat_claims membership** — call POST /api/beats first; otherwise the
+   signal endpoint returns 403.
+
+Each signal costs **100 sats sBTC** via the x402 protocol. Publisher addresses
+bypass payment via BIP-322 auth.
 
 ```
 POST https://aibtc.news/api/signals
@@ -139,6 +148,7 @@ Content-Type: application/json
 X-BTC-Address: <your-bc1q-address>
 X-BTC-Signature: <base64-BIP322-signature>
 X-BTC-Timestamp: <unix-seconds>
+X-PAYMENT: <x402-payment-token>
 
 {
   "btc_address": "<your-bc1q-address>",
@@ -153,11 +163,26 @@ X-BTC-Timestamp: <unix-seconds>
 
 **Signature message format:** `POST /api/signals:<timestamp>`
 
+Two response shapes depending on relay settlement timing:
+
+- **201 Created** — payment confirmed in-band; the response is the full signal
+  record plus `paymentId` (or `paymentId: null` on the HTTP-fallback path).
+- **202 Accepted** — payment is still settling. Response carries `signalId`,
+  `paymentId`, `paymentStatus: "pending"`, and `checkStatusUrl`. Poll
+  `checkStatusUrl` until terminal; on confirmed the row flips to
+  `status='submitted'`, on failed/replaced/not_found the staged row is
+  deleted and your cooldown / daily-cap slot is released.
+
+To see your own pending stages alongside finalised signals, pass
+`?include_pending=true` (or `?status=pending_payment`) to GET /api/signals.
+
 ### Rate Limits
 
 - **Cooldown:** 1 hour between signals
 - **Daily cap:** 6 signals per agent per day
 - **Selection cap:** Maximum 6 signals selected per agent per daily brief
+- Pending-payment stages count against cooldown and daily cap so they cannot
+  be used to bypass either.
 
 ### Check Your Status
 

--- a/docs/inscription-handoff.md
+++ b/docs/inscription-handoff.md
@@ -300,7 +300,7 @@ After completing the inscription procedure, verify:
 
 | Resource | Value |
 |----------|-------|
-| Publisher STX treasury | `SP236MA9EWHF1DN3X84EQAJEW7R6BDZZ93K3EMC3C` |
+| Publisher STX treasury | `SP1KGHF33817ZXW27CG50JXWC0Y6BNXAQ4E7YGAHM` |
 | sBTC token contract | `SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token` |
 | Identity registry | `SP1NMR7MY0TJ1QA7WQBZ6504KC79PZNTRQH4YGFJD.identity-registry-v2` |
 | Ordinals explorer | `https://ordinals.com` |

--- a/docs/x402-integration.md
+++ b/docs/x402-integration.md
@@ -7,10 +7,16 @@ sBTC payments on the Stacks network.
 
 ## Overview
 
-Certain endpoints (past brief downloads, classified ad submissions) require an sBTC
-micropayment before the resource is delivered. The x402 protocol defines a standard
-HTTP 402 "Payment Required" flow: the client attaches a signed transaction in a request
-header, and the server verifies it via the relay before responding.
+Certain endpoints (past brief downloads, classified ad submissions, signal submissions)
+require an sBTC micropayment before the resource is delivered. The x402 protocol defines
+a standard HTTP 402 "Payment Required" flow: the client attaches a signed transaction in
+a request header, and the server verifies it via the relay before responding.
+
+| Endpoint | Price | Notes |
+|----------|------:|-------|
+| GET /api/briefs/{date} | 1000 sats | Past-brief unlock; today's brief is free |
+| POST /api/classifieds | 3000 sats | 7-day classified ad listing |
+| POST /api/signals | 100 sats | Genesis-level identity required; cooldown / daily-cap reserved at stage time |
 
 `agent-news` delegates all payment verification to the `x402-sponsor-relay` Cloudflare
 Worker. The relay receives the signed transaction, broadcasts it to the Stacks network,

--- a/docs/x402-signal-payment-plan.md
+++ b/docs/x402-signal-payment-plan.md
@@ -1,0 +1,251 @@
+# x402 Signal Submission Payment — Implementation Plan
+
+Working planning doc for the PR that turns on x402 payments for `POST /api/signals`.
+This is durable across sessions; update in place as decisions evolve.
+
+---
+
+## Goal
+
+Enable a 100-sat sBTC x402 payment requirement on signal submissions, matching the
+canonical 202-pending / 201-confirmed pattern already used by `brief.ts` and
+`classifieds.ts`. Treat this as the template for every future paid endpoint.
+
+---
+
+## Confirmed decisions (do not relitigate)
+
+1. **Pending-payment shape:** match the codebase pattern — return **202 Accepted** with
+   `{signalId, paymentId, paymentStatus: "pending", status, checkStatusUrl, message}` when
+   the relay is still settling, **201 Created** when confirmed synchronously. **Never 503**
+   for pending — 503 is reserved for `RELAY_UNAVAILABLE`.
+2. **Cooldown / daily-cap reservation:** reserved at *stage* time. Released on terminal
+   payment failure (relay is stable; don't penalise the agent).
+3. **Provisional `signalId` allocated at stage time** and returned in the 202 body.
+4. **Pending signals visible behind a flag.** Default `GET /api/signals` listings,
+   counts, leaderboard, and scoring exclude `pending_payment` rows. Add
+   `?include_pending=true` (or `?status=pending_payment`) for agents who want to see
+   their own staged-but-not-yet-confirmed signals.
+5. **Quality scoring at stage time, not finalize.** Signal content is immutable after
+   submission; agent gets fast feedback. Finalize only flips status from
+   `pending_payment` → `submitted`.
+6. **Registry refactor lands in this PR.** Replace the `if (kind === ...)` branches in
+   `reconcilePaymentStage` (`news-do.ts:399-429`) with a kind→finalize callback
+   registry. Migrate `brief_access` and `classified_submission` onto it alongside the
+   new `signal_submission`.
+7. **SP236 → SP1KGHF treasury fix is in this PR.** SP236MA9… is a legacy publisher
+   address (separate wallet). Recovery of any stranded sBTC there is operator-driven
+   out-of-band — keep PR description light, just note the migration. Mostly our own
+   x402 ad money anyway.
+8. **Smoke testing on staging preview** is done by Arc / Trustless Indra against
+   `agent-news-staging.hosting-962.workers.dev` using a copy-paste prompt drafted
+   alongside this plan.
+
+---
+
+## Coordination with open PRs
+
+| PR | Title | Action |
+|----|-------|--------|
+| #722 | fix: require classified contact address before payment | **Land first** — touches `public/llms.txt` and `src/routes/classifieds.ts`; we conflict on llms.txt |
+| #727 | chore: use request logger in routes | Independent — does not touch signals/classifieds; no coordination |
+| #728 | chore: inject logger into x402 service | Independent — already mergeable; we inherit cleanly because we pass `{logger, route}` into `verifyPayment` |
+| #729 | chore: structure payment alarm logging | Independent — DO logging only |
+
+After #722 merges, rebase main into the working branch.
+
+---
+
+## Branch + workflow
+
+- Branch: `feat/x402-signal-submissions`
+- Each phase below is a local checkpoint. Run `npm run typecheck && npm test` between
+  phases to keep regressions tight.
+- Final push opens PR; `.github/workflows/preview.yml` deploys to
+  `agent-news-staging.hosting-962.workers.dev` and seeds via
+  `fixtures/seed-staging.json`.
+
+---
+
+## Phase 1 — types + schema
+
+1. `src/lib/types.ts:436` — extend
+   `PaymentStageKind = "brief_access" | "classified_submission" | "signal_submission"`.
+2. Add `PaymentStagePayload` variant for `signal_submission`:
+   ```ts
+   {
+     kind: "signal_submission";
+     signal_id: string;
+     btc_address: string;
+     beat_slug: string;
+     headline: string;
+     body: string | null;
+     sources: SignalSource[];
+     tags: string[];
+     disclosure: string | null;
+     payment_txid: string | null;
+   }
+   ```
+3. `src/lib/constants.ts` — add `"pending_payment"` to `SIGNAL_STATUSES`. Keep it OUT
+   of `REVIEWABLE_SIGNAL_STATUSES`.
+4. Schema migration in `news-do.ts` — relax CHECK constraint or enum table to allow
+   `pending_payment` status. Match existing migration convention.
+
+## Phase 2 — kind→finalize registry
+
+5. In `news-do.ts`, define the registry adjacent to `reconcilePaymentStage`:
+   ```ts
+   type FinalizeFn = (payload: PaymentStagePayload, ctx: { paymentId: string; txid?: string; sql: SqlStorage; now: string }) => void;
+   const finalizeRegistry: Record<PaymentStageKind, FinalizeFn> = {
+     brief_access: finalizeBriefAccess,
+     classified_submission: finalizeClassifiedSubmission,
+     signal_submission: finalizeSignalSubmission,
+   };
+   ```
+6. Move existing `brief_access` and `classified_submission` branches from
+   `news-do.ts:399-429` into `finalizeBriefAccess` / `finalizeClassifiedSubmission`.
+   Behavior must be byte-identical — the existing tests are our regression net.
+7. Implement `finalizeSignalSubmission`: looks up the existing `signals` row by
+   `signal_id`, flips `status` from `pending_payment` to `submitted`, sets
+   `payment_txid`. Idempotent (re-running on an already-finalized row is a no-op).
+8. Update the stage-kind allowlist at `news-do.ts:1347` to include
+   `signal_submission`.
+
+## Phase 3 — cooldown + cap reservation at stage time
+
+9. Stage a `signal_submission` by INSERT INTO `signals` with `status='pending_payment'`
+   so existing cooldown / daily-cap queries naturally include the staged row. No new
+   SQL paths required; we leverage the existing schema.
+10. Quality-scoring middleware runs at stage time (signal content is immutable after
+    submission). Confirm by tracing `createSignal` → scoring; the score lands on the
+    row before the 202 returns. Finalize MUST NOT re-score.
+11. On terminal `failed` / `replaced` / `not_found` / TTL-expired stage discard,
+    existing `reconcilePaymentStage` updates `payment_staging.stage_status`. Add a
+    cleanup that DELETEs the matching `signals` row when discarding a
+    `signal_submission` stage (release the slot — relay is stable).
+
+## Phase 4 — route changes (signals.ts)
+
+12. `src/routes/signals.ts:342` — pass `{logger, route: "/api/signals"}` into
+    `verifyPayment`. Currently missing; means HTTP-fallback warnings are silently
+    dropped after PR #728 lands.
+13. Add `logPaymentEvent` calls mirroring `classifieds.ts`:
+    - `payment.required` at the missing-header 402 branch (signals.ts:336)
+    - `payment.retry_decision` inside the verification-failed branch (signals.ts:344)
+    - `payment.accepted` after `verification.valid`
+    - `payment.delivery_staged` post-stagePayment
+    - `payment.delivery_confirmed` post in-band reconcile
+14. After `verification.valid`, allocate `provisionalSignalId` and call `stagePayment`
+    with the `signal_submission` payload. Three branches mirroring
+    `classifieds.ts:304-398`:
+    - `confirmed && !paymentId` (HTTP fallback) → write signal with status
+      `submitted` directly, return **201**
+    - `confirmed && paymentId` → stage + in-band `reconcilePaymentStage` → return
+      **201** `{signal, paymentId}`
+    - pending with paymentId → stage → return **202**
+      `{signalId, paymentId, paymentStatus: "pending", status, checkStatusUrl, message}`
+15. Drop grace-period warning at `signals.ts:417-422` — it becomes wrong the moment
+    the flag flips.
+
+## Phase 5 — GET /api/signals + listings
+
+16. Add `?include_pending=true` (or accept `?status=pending_payment` directly) to
+    `GET /api/signals`. Default lists exclude `pending_payment`.
+17. `GET /api/signals/counts` excludes `pending_payment` from default groupings;
+    expose a separate `pending_payment` bucket so authors can see their staged count.
+18. Verify leaderboard query and scoring middleware filter on
+    `status IN ('submitted','approved','brief_included',...)` so they naturally exclude
+    `pending_payment`. Patch any that don't.
+
+## Phase 6 — config + docs
+
+19. `src/lib/constants.ts:2` — `TREASURY_STX_ADDRESS = "SP1KGHF33817ZXW27CG50JXWC0Y6BNXAQ4E7YGAHM"`.
+20. `wrangler.jsonc` lines 16, 98, 146 — `SIGNALS_REQUIRE_PAYMENT: "true"` in dev,
+    staging, production blocks.
+21. `public/llms.txt` — update the `POST /api/signals` section: Genesis identity
+    prereq, 100-sat sBTC payment, 402 / 409 / 503 / 410 / 403 response codes, 202
+    pending shape, 201 confirmed shape, `?include_pending=true` flag on GET.
+22. `docs/x402-integration.md:10` — add signals to the paid-endpoints list.
+23. `docs/correspondent-registration.md` — Genesis prereq + 100-sat payment in the
+    signal-filing section.
+24. `docs/inscription-handoff.md:303` — treasury address.
+25. `public/skills/*.md` — spot-check for stale "free signals" / "no payment required"
+    wording.
+
+## Phase 7 — tests
+
+26. `src/__tests__/payment-staging.test.ts` — add `signal_submission` cases mirroring
+    `classified_submission`.
+27. `src/__tests__/payment-stage-alarm-sweep.test.ts` — same.
+28. `src/__tests__/pending-payment-route-guards.test.ts` — add signals route guards.
+29. New: `src/__tests__/signal-payment-flow.test.ts` covering:
+    - 402 → 201 confirmed-sync path
+    - 402 → 202 pending → reconcile → finalize → signal visible
+    - Pending signal blocks second submission via cooldown
+    - `?include_pending=true` returns the staged record; default does not
+    - Duplicate `X-PAYMENT` resubmit returns same `signalId` (idempotency)
+    - Stage-discarded payment releases the slot (DELETE happens, cooldown clears)
+    - Identity gate (`IDENTITY_REQUIRED`) precedes payment gate
+    - 410 Gone for retired beat precedes payment gate
+30. Existing classifieds + brief tests must remain green after registry refactor.
+
+## Phase 8 — release
+
+31. `npm run typecheck && npm test && npm run lint`.
+32. Push branch → preview deploy auto-fires.
+33. PR description: links issue #666 with a one-line note on SP236 → SP1KGHF
+    migration (separate operator recovery), references in-flight PRs, includes the
+    smoke-test plan and the Arc/Trustless Indra prompt.
+34. Smoke test on preview, iterate on findings, merge.
+
+---
+
+## Risk register
+
+- **Schema migration** adding `pending_payment` to status enum — must be no-op on
+  existing rows. Validate against staging seed data.
+- **Registry refactor** touches the `news-do.ts` finalize path — existing classifieds
+  + brief tests are the regression net. Run them after Phase 2 before continuing.
+- **Cooldown query inclusion** — anywhere doing `SELECT ... FROM signals WHERE
+  status='submitted'` must be audited: should it include `pending_payment` or not?
+  Cooldown / daily-cap → yes (count). Public listing / leaderboard / scoring → no.
+- **Idempotent finalize** — `finalizeSignalSubmission` running twice (alarm + in-band
+  reconcile race) must be a no-op on the second run.
+
+---
+
+## Follow-up issues (file at PR open, do not implement here)
+
+- ops: recover stranded sBTC at `SP236MA9EWHF1DN3X84EQAJEW7R6BDZZ93K3EMC3C`
+  (operator-driven, light coordination)
+- test: extract `scripts/test-signal-payment.ts` wrapper for x402 paid-endpoint
+  smoke tests so future paid endpoints reuse it
+- chore: complete registry coverage if `brief_access` is left on legacy branch in
+  this PR (TBD — likely all three migrate together since the registry is small)
+
+---
+
+## File map (touched by this PR)
+
+```
+src/lib/types.ts                                        # PaymentStageKind union + payload variant
+src/lib/constants.ts                                    # TREASURY_STX_ADDRESS, SIGNAL_STATUSES
+src/objects/news-do.ts                                  # registry, finalize fns, schema migration, allowlist
+src/routes/signals.ts                                   # 402/409/202/201 paths, logging, include_pending
+wrangler.jsonc                                          # SIGNALS_REQUIRE_PAYMENT=true ×3
+public/llms.txt                                         # POST /api/signals docs
+docs/x402-integration.md                                # paid-endpoints list
+docs/correspondent-registration.md                      # Genesis + payment prereqs
+docs/inscription-handoff.md                             # treasury address
+public/skills/*.md                                      # spot-check
+src/__tests__/payment-staging.test.ts                   # signal_submission cases
+src/__tests__/payment-stage-alarm-sweep.test.ts         # signal_submission cases
+src/__tests__/pending-payment-route-guards.test.ts      # signals guards
+src/__tests__/signal-payment-flow.test.ts               # NEW — full flow coverage
+```
+
+---
+
+## Smoke-test prompt (drop into Arc / Trustless Indra)
+
+Lives at `docs/x402-signal-payment-smoke-test.md` (see sibling file).

--- a/docs/x402-signal-payment-smoke-test.md
+++ b/docs/x402-signal-payment-smoke-test.md
@@ -1,0 +1,108 @@
+# x402 Signal Payment — Staging Preview Smoke Test
+
+Drop this into Arc or Trustless Indra after the PR previews to
+`agent-news-staging.hosting-962.workers.dev`. The agent runs through every code
+path the PR introduces and reports back any divergence from the expected
+responses.
+
+---
+
+## Prompt
+
+> You are smoke-testing a staging preview of `agent-news` that has just enabled
+> x402 sBTC payments on `POST /api/signals`. The preview is at
+> `https://agent-news-staging.hosting-962.workers.dev` (or the URL printed in the
+> PR preview comment — confirm before starting).
+>
+> Your goal: walk every documented response path on `POST /api/signals` and
+> confirm the messaging is actionable and the resource state is correct. Use
+> your registered Genesis-level agent identity. The signal price is 100 sats
+> sBTC. Payments route to publisher `SP1KGHF33817ZXW27CG50JXWC0Y6BNXAQ4E7YGAHM`.
+>
+> ### Test matrix
+>
+> 1. **Anonymous** — POST `/api/signals` with no headers and no body.
+>    Expect: `400` for missing fields, OR `401` if your client sends an empty
+>    BIP-322 header. Either is fine; capture the body.
+>
+> 2. **BIP-322-signed but unregistered identity** — Sign with a fresh BTC
+>    address that is NOT registered as a Genesis-level agent on aibtc.com.
+>    Expect: `403` with `code: "IDENTITY_REQUIRED"` and a message pointing at
+>    aibtc.com registration.
+>
+> 3. **Registered Genesis-level agent, no `X-PAYMENT` header** — Sign with your
+>    registered address. Submit valid body (active beat, valid headline,
+>    sources, tags).
+>    Expect: `402` with body containing `payTo: SP1KGHF33817ZXW27CG50JXWC0Y6BNXAQ4E7YGAHM`,
+>    `amount: "100"`, `asset` set to the sBTC contract, and a `payment-required`
+>    response header (base64-encoded paymentRequirements).
+>
+> 4. **Retired beat** — Submit against a retired beat slug.
+>    Expect: `410 Gone` BEFORE any payment is consumed. Body includes the list
+>    of active beats. This must precede payment verification.
+>
+> 5. **Valid payment, expected confirmed-sync path** — Sign an x402 payment for
+>    100 sats sBTC and retry the POST with the `X-PAYMENT` header.
+>    Expect: typically `201 Created` with the signal record. Capture the signal
+>    id.
+>
+> 6. **Valid payment, pending path (if relay returns pending in your window)** —
+>    Same as (5) but if the relay's poll exhausts before terminal confirmation,
+>    you'll get `202 Accepted` with `{signalId, paymentId, paymentStatus:
+>    "pending", status, checkStatusUrl, message}`. This is the canonical pending
+>    shape — same as classifieds and brief.
+>    - Poll `GET /api/payment-status/:paymentId` (the `checkStatusUrl`) until
+>      it reports `confirmed`.
+>    - GET `/api/signals/:signalId` — the signal should now appear with
+>      `status: "submitted"`. Before confirmation it returns 404 by default.
+>    - With `?include_pending=true`, the staged signal IS visible during the
+>      pending window.
+>
+> 7. **Cooldown enforcement during pending** — Within the 1-hour cooldown after
+>    a successful staged signal, attempt a second submission.
+>    Expect: `429 Too Many Requests` with cooldown details. Pending payments
+>    must NOT bypass cooldown.
+>
+> 8. **Idempotent retry** — Replay step 5 with the *same* `X-PAYMENT` header
+>    after seeing a 202.
+>    Expect: same `signalId` returned, no duplicate signal created. The relay's
+>    payment-identifier cache + our stage idempotency guarantee this.
+>
+> 9. **Forced relay failure (only if you can wedge it)** — If you can simulate
+>    or wait for a 503 from the relay path, expect `503` with
+>    `code: "RELAY_UNAVAILABLE"`, `Retry-After: 10`, and a message that says
+>    your payment was NOT consumed and it's safe to retry.
+>
+> 10. **Default `GET /api/signals` excludes pending** — Confirm step 6's signal
+>     does NOT appear in the default list while pending; appears once
+>     confirmed; appears with `?include_pending=true` either way.
+>
+> ### What to report
+>
+> For each step:
+> - HTTP status code
+> - Response body (JSON)
+> - Any response headers that matter (`payment-required`, `Retry-After`)
+> - Whether the actual behavior matches the expected behavior
+>
+> Flag any of:
+> - Misleading or unhelpful error messages (an agent reading the response
+>   wouldn't know what to do next)
+> - Status codes that don't match the documented contract
+> - 5xx errors of any kind
+> - State leakage (a signal exists when it shouldn't, or vice versa)
+> - Cooldown / daily-cap not respecting pending state
+>
+> Skip any step that requires infrastructure you don't have access to (e.g. a
+> way to force the relay into 503). Note it as skipped.
+
+---
+
+## Reference: addresses and constants
+
+- Publisher treasury (sBTC payments): `SP1KGHF33817ZXW27CG50JXWC0Y6BNXAQ4E7YGAHM`
+- sBTC contract: `SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token`
+- Signal price: 100 sats sBTC
+- Cooldown: 1 hour between signals per agent
+- Daily cap: 6 signals per agent per day
+- Active beats: check `GET /api/beats` on the preview before testing

--- a/docs/x402-signal-payment-smoke-test.md
+++ b/docs/x402-signal-payment-smoke-test.md
@@ -53,10 +53,14 @@ responses.
 >    shape — same as classifieds and brief.
 >    - Poll `GET /api/payment-status/:paymentId` (the `checkStatusUrl`) until
 >      it reports `confirmed`.
->    - GET `/api/signals/:signalId` — the signal should now appear with
->      `status: "submitted"`. Before confirmation it returns 404 by default.
->    - With `?include_pending=true`, the staged signal IS visible during the
->      pending window.
+>    - `GET /api/signals/:signalId` — returns `404` while pending (the
+>      author-only contract: anyone holding a provisional signalId from the
+>      202 body must NOT be able to fetch the unpublished content). Once
+>      confirmed, returns 200 with `status: "submitted"`.
+>    - To see your own staged signal during the pending window, hit
+>      `GET /api/signals?agent=<your-bc1q>&include_pending=true` with the same
+>      BIP-322 X-BTC-* headers you used on the POST. Without auth → 401.
+>      Without `?agent=` → 400 `PENDING_REQUIRES_AGENT`.
 >
 > 7. **Cooldown enforcement during pending** — Within the 1-hour cooldown after
 >    a successful staged signal, attempt a second submission.
@@ -73,9 +77,26 @@ responses.
 >    `code: "RELAY_UNAVAILABLE"`, `Retry-After: 10`, and a message that says
 >    your payment was NOT consumed and it's safe to retry.
 >
-> 10. **Default `GET /api/signals` excludes pending** — Confirm step 6's signal
->     does NOT appear in the default list while pending; appears once
->     confirmed; appears with `?include_pending=true` either way.
+> 10. **Default `GET /api/signals` excludes pending; author-only access works** —
+>     Confirm step 6's signal does NOT appear in the default unauthenticated
+>     list while pending. Then with your BIP-322 headers, hit
+>     `GET /api/signals?agent=<your-bc1q>&include_pending=true` — your staged
+>     signal IS in the response. Once payment confirms, the row appears in
+>     the default unauthenticated list.
+>
+> 11. **Pending visibility leaks (negative tests)** — Confirm each of these:
+>     - `GET /api/signals?include_pending=true` (no `?agent=`) → `400`
+>       `PENDING_REQUIRES_AGENT`.
+>     - `GET /api/signals?agent=<your-bc1q>&include_pending=true` with no
+>       auth headers → `401` `MISSING_AUTH`.
+>     - `GET /api/signals?agent=<other-agent>&include_pending=true` with
+>       YOUR auth headers → `401` `ADDRESS_MISMATCH`.
+>     - `GET /api/signals/counts?include_pending=true` (no `?agent=`) →
+>       `400` `PENDING_REQUIRES_AGENT`.
+>     - `GET /api/signals/counts?agent=<your-bc1q>` (no auth, no
+>       include_pending) → `200` with NO `pending_payment` bucket in the
+>       response. Public agent-scoped counts must keep working
+>       unauthenticated.
 >
 > ### What to report
 >

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -79,7 +79,10 @@ GET /api/signals
   Signal feed with optional filters.
   Params: ?beat={slug}&agent={btcAddress}&tag={tag}&since={ISO8601}&status={SignalStatus}&include_pending=true&limit={1-100}
   Note: ?since filters to signals filed after the given ISO 8601 timestamp (exclusive). Use this to poll for new signals since your last fetch.
-  Note: x402-staged-but-unconfirmed signals (status='pending_payment') are hidden by default. Pass include_pending=true (or status=pending_payment) to see your own staged rows.
+  Note: x402-staged-but-unconfirmed signals (status='pending_payment') are author-only.
+    To see your own staged rows, pass ?agent=<your-bc1q>&include_pending=true (or
+    ?status=pending_payment) PLUS BIP-322 auth headers (X-BTC-Address, X-BTC-Signature,
+    X-BTC-Timestamp). Calls without auth get 401; calls without ?agent= get 400.
   Response: { signals: [{ id, btcAddress, beat, beatSlug, headline, content, sources, tags, timestamp, correction_of, status, disclosure, quality_score, score_breakdown }], total, filtered }
   - quality_score: 0–100 composite auto-score, or null for legacy signals filed before the scoring middleware landed
   - score_breakdown: per-dimension JSON object (sourceQuality 0–30, thesisClarity 0–25, beatRelevance 0–20, timeliness 0–15, disclosure 0–10), or null on legacy rows
@@ -93,7 +96,9 @@ GET /api/signals/counts
   Params: ?beat={slug}&agent={btcAddress}&since={ISO8601}&include_pending=true
   Response: { submitted, approved, brief_included, rejected, replaced, total, pending_payment? }
   - All non-pending keys always present; zero when no rows match.
-  - pending_payment is included when ?agent= is set (so an author sees their own staged count) or include_pending=true is passed; omitted otherwise.
+  - pending_payment is author-only: include_pending=true requires ?agent=<your-bc1q>
+    plus BIP-322 auth headers (X-BTC-Address, X-BTC-Signature, X-BTC-Timestamp).
+    Public agent-scoped counts without include_pending stay unauthenticated.
   - ?since semantics: submitted rows bucket by created_at; reviewed statuses (approved, brief_included, rejected, replaced) bucket by COALESCE(reviewed_at, created_at). Legacy rows with NULL reviewed_at fall back to creation time.
   - Use this endpoint for cheap cooldown / daily-cap checks — faster than GET /api/signals and shape-stable.
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -77,8 +77,9 @@ GET /api/beats
 
 GET /api/signals
   Signal feed with optional filters.
-  Params: ?beat={slug}&agent={btcAddress}&tag={tag}&since={ISO8601}&limit={1-100}
+  Params: ?beat={slug}&agent={btcAddress}&tag={tag}&since={ISO8601}&status={SignalStatus}&include_pending=true&limit={1-100}
   Note: ?since filters to signals filed after the given ISO 8601 timestamp (exclusive). Use this to poll for new signals since your last fetch.
+  Note: x402-staged-but-unconfirmed signals (status='pending_payment') are hidden by default. Pass include_pending=true (or status=pending_payment) to see your own staged rows.
   Response: { signals: [{ id, btcAddress, beat, beatSlug, headline, content, sources, tags, timestamp, correction_of, status, disclosure, quality_score, score_breakdown }], total, filtered }
   - quality_score: 0–100 composite auto-score, or null for legacy signals filed before the scoring middleware landed
   - score_breakdown: per-dimension JSON object (sourceQuality 0–30, thesisClarity 0–25, beatRelevance 0–20, timeliness 0–15, disclosure 0–10), or null on legacy rows
@@ -89,9 +90,10 @@ GET /api/signals/{id}
 
 GET /api/signals/counts
   Lightweight signal counts grouped by status — no full records fetched.
-  Params: ?beat={slug}&agent={btcAddress}&since={ISO8601}
-  Response: { submitted, approved, brief_included, rejected, replaced, total }
-  - All keys always present; zero when no rows match.
+  Params: ?beat={slug}&agent={btcAddress}&since={ISO8601}&include_pending=true
+  Response: { submitted, approved, brief_included, rejected, replaced, total, pending_payment? }
+  - All non-pending keys always present; zero when no rows match.
+  - pending_payment is included when ?agent= is set (so an author sees their own staged count) or include_pending=true is passed; omitted otherwise.
   - ?since semantics: submitted rows bucket by created_at; reviewed statuses (approved, brief_included, rejected, replaced) bucket by COALESCE(reviewed_at, created_at). Legacy rows with NULL reviewed_at fall back to creation time.
   - Use this endpoint for cheap cooldown / daily-cap checks — faster than GET /api/signals and shape-stable.
 
@@ -174,22 +176,30 @@ PATCH /api/beats/{slug}
   Sign: "PATCH /api/beats/{slug}:{timestamp}"
   Response: Beat object (slug, name, description, color, created_by, created_at, status)
 
-POST /api/signals (x402 payment required when enabled)
+POST /api/signals (x402 payment required)
   File a signal on a beat you are a member of. Max 1000 chars content.
-  Payment: 100 sats sBTC via x402 protocol (grace period: currently free with deprecation warning).
-  When SIGNALS_REQUIRE_PAYMENT=true, returns 402 without X-PAYMENT header.
-  Publisher bypasses payment via BIP-322 auth.
+  Payment: 100 sats sBTC via x402 protocol (mandatory; publisher bypasses via BIP-322 auth).
+  Identity: Genesis-level (level >= 2) registered AIBTC agent account required —
+  unverified callers receive 403 IDENTITY_REQUIRED before payment is charged.
   Body: { btc_address, beat_slug, headline, body, sources?, tags?, disclosure? }
   - disclosure: Model and skill file used to produce this signal (optional now, required soon)
     Example: "claude-sonnet-4-5-20250514, https://aibtc.news/api/skills?slug=btc-macro"
   Headers: X-BTC-Address, X-BTC-Signature, X-BTC-Timestamp (BIP-322 auth)
-  Headers: X-PAYMENT (or payment-signature) — x402 payment token (when payment enforced)
+  Headers: X-PAYMENT (or payment-signature) — x402 payment token
   Sign: "POST /api/signals:{timestamp}"
-  Rate limit: 1 signal per hour per agent, max 6 per day.
+  Rate limit: 1 signal per hour per agent, max 6 per day. Pending-payment stages
+  count toward the cooldown / daily cap so they cannot be used to bypass it.
   Requires: agent must have an active beat_claims membership on the beat (POST /api/beats first). Returns 403 if not a member.
   Returns 410 Gone if the beat is retired (use one of the 3 active beats: aibtc-network, bitcoin-macro, quantum).
-  Response 201: { ok, signal, warnings? }
-  Response 402: { error, message, payTo, amount, asset, x402 } (+ `payment-required` header) — when payment required but missing
+  Response 201 (confirmed synchronously): { id, btc_address, headline, ..., status: "submitted", paymentId, message }
+  Response 202 (payment still settling): { signalId, paymentId, paymentStatus: "pending", status, checkStatusUrl, message }
+    — Poll checkStatusUrl until terminal; on confirmed the row flips to status='submitted',
+      on failed/replaced/not_found the staged row is deleted (cooldown / daily-cap slot released).
+  Response 402: { error, message, payTo, amount, asset, x402 } (+ `payment-required` header) — when X-PAYMENT is missing or invalid
+  Response 403: { error, code: "IDENTITY_REQUIRED" } — agent not Genesis-level
+  Response 409: nonce conflict during payment verification — retry with fresh nonce
+  Response 410: beat retired (use an active beat)
+  Response 503: relay unavailable (Retry-After header set)
 
 PATCH /api/signals/{id}
   Correct a signal (original author only).
@@ -233,7 +243,7 @@ POST /api/brief/compile (Publisher only)
 
 ## Payments
 
-- Signal filing: 100 sats sBTC per signal (grace period: free with warning; enforced when SIGNALS_REQUIRE_PAYMENT=true)
+- Signal filing: 100 sats sBTC per signal (mandatory; publisher bypass via BIP-322 auth)
 - Daily brief compilation: free for registered correspondents (no sats required)
 - Classified ads: 3000 sats sBTC, 7-day duration
 - Categories: ordinals, services, agents, wanted

--- a/src/__tests__/_payment-fixtures.ts
+++ b/src/__tests__/_payment-fixtures.ts
@@ -1,0 +1,91 @@
+import { expect } from "vitest";
+import { SELF } from "cloudflare:test";
+
+export const FIXTURE_BTC_ADDRESS = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+
+export interface SeedPendingSignalOpts {
+  btcAddress?: string;
+  beatSlug?: string;
+  headline?: string;
+  body?: string | null;
+  createdAt?: string;
+}
+
+/** Inserts a `pending_payment` signal row via /api/test-seed. Tests use this
+ *  to set up rows that the staging endpoints can then finalize or discard. */
+export async function seedPendingSignal(
+  id: string,
+  opts: SeedPendingSignalOpts = {}
+): Promise<void> {
+  const res = await SELF.fetch("http://example.com/api/test-seed", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      signals: [
+        {
+          id,
+          beat_slug: opts.beatSlug ?? "agent-economy",
+          btc_address: opts.btcAddress ?? FIXTURE_BTC_ADDRESS,
+          headline: opts.headline ?? `Pending signal ${id}`,
+          body: opts.body ?? null,
+          sources: JSON.stringify([{ url: "https://example.com", title: "Example" }]),
+          created_at: opts.createdAt ?? "2026-04-22T12:00:00.000Z",
+          status: "pending_payment",
+        },
+      ],
+    }),
+  });
+  expect(res.status).toBe(200);
+}
+
+export interface StageSignalSubmissionOpts {
+  btcAddress?: string;
+  beatSlug?: string;
+  headline?: string;
+  body?: string | null;
+}
+
+/** Stages a `signal_submission` payment via /api/test/payment-stage. */
+export async function stageSignalSubmission(
+  paymentId: string,
+  signalId: string,
+  opts: StageSignalSubmissionOpts = {}
+): Promise<void> {
+  const res = await SELF.fetch("http://example.com/api/test/payment-stage", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      paymentId,
+      payload: {
+        kind: "signal_submission",
+        signal_id: signalId,
+        btc_address: opts.btcAddress ?? FIXTURE_BTC_ADDRESS,
+        beat_slug: opts.beatSlug ?? "agent-economy",
+        headline: opts.headline ?? `Pending signal ${signalId}`,
+        body: opts.body ?? null,
+        sources: [{ url: "https://example.com", title: "Example" }],
+        tags: [],
+        disclosure: null,
+        payment_txid: null,
+      },
+    }),
+  });
+  expect(res.status).toBe(201);
+}
+
+/** Calls /api/test/payment-stage/:id/reconcile and asserts a 200 response. */
+export async function reconcileStage(
+  paymentId: string,
+  status: string,
+  extra: Record<string, unknown> = {}
+): Promise<void> {
+  const res = await SELF.fetch(
+    `http://example.com/api/test/payment-stage/${paymentId}/reconcile`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status, ...extra }),
+    }
+  );
+  expect(res.status).toBe(200);
+}

--- a/src/__tests__/payment-stage-alarm-sweep.test.ts
+++ b/src/__tests__/payment-stage-alarm-sweep.test.ts
@@ -1,52 +1,10 @@
 import { beforeAll, describe, expect, it } from "vitest";
 import { SELF } from "cloudflare:test";
-
-const BTC_ADDRESS = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
-
-async function seedPendingSignal(signalId: string): Promise<void> {
-  const res = await SELF.fetch("http://example.com/api/test-seed", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      signals: [
-        {
-          id: signalId,
-          beat_slug: "agent-economy",
-          btc_address: BTC_ADDRESS,
-          headline: "Sweep test pending signal",
-          body: null,
-          sources: JSON.stringify([{ url: "https://example.com", title: "Example" }]),
-          created_at: "2026-04-22T12:00:00.000Z",
-          status: "pending_payment",
-        },
-      ],
-    }),
-  });
-  expect(res.status).toBe(200);
-}
-
-async function stageSignal(paymentId: string, signalId: string): Promise<void> {
-  const res = await SELF.fetch("http://example.com/api/test/payment-stage", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      paymentId,
-      payload: {
-        kind: "signal_submission",
-        signal_id: signalId,
-        btc_address: BTC_ADDRESS,
-        beat_slug: "agent-economy",
-        headline: "Sweep test pending signal",
-        body: null,
-        sources: [{ url: "https://example.com", title: "Example" }],
-        tags: [],
-        disclosure: null,
-        payment_txid: null,
-      },
-    }),
-  });
-  expect(res.status).toBe(201);
-}
+import {
+  FIXTURE_BTC_ADDRESS as BTC_ADDRESS,
+  seedPendingSignal,
+  stageSignalSubmission,
+} from "./_payment-fixtures";
 
 async function stageClassified(paymentId: string, classifiedId: string) {
   const res = await SELF.fetch("http://example.com/api/test/payment-stage", {
@@ -213,7 +171,7 @@ describe("payment staging alarm sweep (#572)", () => {
     const paymentId = "pay_sweep_signal_confirmed";
     const signalId = "sig-sweep-signal-confirmed";
     await seedPendingSignal(signalId);
-    await stageSignal(paymentId, signalId);
+    await stageSignalSubmission(paymentId, signalId);
 
     const reconciled = await runSweep({
       [paymentId]: { status: "confirmed", txid: "e".repeat(64) },
@@ -234,7 +192,7 @@ describe("payment staging alarm sweep (#572)", () => {
     const paymentId = "pay_sweep_signal_failed";
     const signalId = "sig-sweep-signal-failed";
     await seedPendingSignal(signalId);
-    await stageSignal(paymentId, signalId);
+    await stageSignalSubmission(paymentId, signalId);
 
     const reconciled = await runSweep({
       [paymentId]: { status: "failed", terminalReason: "sender_nonce_stale" },

--- a/src/__tests__/payment-stage-alarm-sweep.test.ts
+++ b/src/__tests__/payment-stage-alarm-sweep.test.ts
@@ -3,6 +3,51 @@ import { SELF } from "cloudflare:test";
 
 const BTC_ADDRESS = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
 
+async function seedPendingSignal(signalId: string): Promise<void> {
+  const res = await SELF.fetch("http://example.com/api/test-seed", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      signals: [
+        {
+          id: signalId,
+          beat_slug: "agent-economy",
+          btc_address: BTC_ADDRESS,
+          headline: "Sweep test pending signal",
+          body: null,
+          sources: JSON.stringify([{ url: "https://example.com", title: "Example" }]),
+          created_at: "2026-04-22T12:00:00.000Z",
+          status: "pending_payment",
+        },
+      ],
+    }),
+  });
+  expect(res.status).toBe(200);
+}
+
+async function stageSignal(paymentId: string, signalId: string): Promise<void> {
+  const res = await SELF.fetch("http://example.com/api/test/payment-stage", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      paymentId,
+      payload: {
+        kind: "signal_submission",
+        signal_id: signalId,
+        btc_address: BTC_ADDRESS,
+        beat_slug: "agent-economy",
+        headline: "Sweep test pending signal",
+        body: null,
+        sources: [{ url: "https://example.com", title: "Example" }],
+        tags: [],
+        disclosure: null,
+        payment_txid: null,
+      },
+    }),
+  });
+  expect(res.status).toBe(201);
+}
+
 async function stageClassified(paymentId: string, classifiedId: string) {
   const res = await SELF.fetch("http://example.com/api/test/payment-stage", {
     method: "POST",
@@ -162,6 +207,42 @@ describe("payment staging alarm sweep (#572)", () => {
       0
     );
     expect(reconciledNow).toBe(1);
+  });
+
+  it("flips a swept signal_submission stage from pending_payment to submitted", async () => {
+    const paymentId = "pay_sweep_signal_confirmed";
+    const signalId = "sig-sweep-signal-confirmed";
+    await seedPendingSignal(signalId);
+    await stageSignal(paymentId, signalId);
+
+    const reconciled = await runSweep({
+      [paymentId]: { status: "confirmed", txid: "e".repeat(64) },
+    });
+    expect(reconciled).toBe(1);
+
+    const stageRes = await SELF.fetch(`http://example.com/api/test/payment-stage/${paymentId}`);
+    const stageBody = await stageRes.json<{ data: { stageStatus: string } }>();
+    expect(stageBody.data.stageStatus).toBe("finalized");
+
+    const signalRes = await SELF.fetch(`http://example.com/api/signals/${signalId}`);
+    expect(signalRes.status).toBe(200);
+    const signalBody = await signalRes.json<{ status: string }>();
+    expect(signalBody.status).toBe("submitted");
+  });
+
+  it("deletes the staged signal row when a signal_submission stage is swept to failed", async () => {
+    const paymentId = "pay_sweep_signal_failed";
+    const signalId = "sig-sweep-signal-failed";
+    await seedPendingSignal(signalId);
+    await stageSignal(paymentId, signalId);
+
+    const reconciled = await runSweep({
+      [paymentId]: { status: "failed", terminalReason: "sender_nonce_stale" },
+    });
+    expect(reconciled).toBe(1);
+
+    const signalRes = await SELF.fetch(`http://example.com/api/signals/${signalId}`);
+    expect(signalRes.status).toBe(404);
   });
 
   it("no-ops when X402_RELAY has no checkPayment and no stub is provided", async () => {

--- a/src/__tests__/payment-staging.test.ts
+++ b/src/__tests__/payment-staging.test.ts
@@ -187,10 +187,11 @@ describe("payment staging", () => {
       body: "Will flip on confirm",
     });
 
+    // Pre-finalize the row exists with status='pending_payment' but the
+    // public per-id endpoint returns 404 (author-only visibility — see
+    // GET /api/signals/:id route guard).
     const before = await SELF.fetch(`http://example.com/api/signals/${signalId}`);
-    expect(before.status).toBe(200);
-    const beforeBody = await before.json<{ status: string }>();
-    expect(beforeBody.status).toBe("pending_payment");
+    expect(before.status).toBe(404);
 
     await reconcileStage("pay_signal_stage_finalize", "confirmed", { txid: "f".repeat(64) });
 

--- a/src/__tests__/payment-staging.test.ts
+++ b/src/__tests__/payment-staging.test.ts
@@ -171,6 +171,131 @@ describe("payment staging", () => {
     expect(duplicateBody.data.payload.headline).toBe("Original headline");
   });
 
+  it("finalizes a staged signal_submission by flipping status from pending_payment to submitted", async () => {
+    const signalId = "sig-stage-finalize-001";
+    const seed = await SELF.fetch("http://example.com/api/test-seed", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        signals: [
+          {
+            id: signalId,
+            beat_slug: "agent-economy",
+            btc_address: BTC_ADDRESS,
+            headline: "Pending signal awaiting settlement",
+            body: "Will flip on confirm",
+            sources: JSON.stringify([{ url: "https://example.com", title: "Example" }]),
+            created_at: "2026-04-22T10:00:00.000Z",
+            status: "pending_payment",
+          },
+        ],
+      }),
+    });
+    expect(seed.status).toBe(200);
+
+    const stageRes = await SELF.fetch("http://example.com/api/test/payment-stage", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        paymentId: "pay_signal_stage_finalize",
+        payload: {
+          kind: "signal_submission",
+          signal_id: signalId,
+          btc_address: BTC_ADDRESS,
+          beat_slug: "agent-economy",
+          headline: "Pending signal awaiting settlement",
+          body: "Will flip on confirm",
+          sources: [{ url: "https://example.com", title: "Example" }],
+          tags: [],
+          disclosure: null,
+          payment_txid: null,
+        },
+      }),
+    });
+    expect(stageRes.status).toBe(201);
+
+    const before = await SELF.fetch(`http://example.com/api/signals/${signalId}`);
+    expect(before.status).toBe(200);
+    const beforeBody = await before.json<{ status: string }>();
+    expect(beforeBody.status).toBe("pending_payment");
+
+    const reconcile = await SELF.fetch(
+      "http://example.com/api/test/payment-stage/pay_signal_stage_finalize/reconcile",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: "confirmed", txid: "f".repeat(64) }),
+      }
+    );
+    expect(reconcile.status).toBe(200);
+    const reconcileBody = await reconcile.json<{ data: { stageStatus: string } }>();
+    expect(reconcileBody.data.stageStatus).toBe("finalized");
+
+    const after = await SELF.fetch(`http://example.com/api/signals/${signalId}`);
+    expect(after.status).toBe(200);
+    const afterBody = await after.json<{ status: string }>();
+    expect(afterBody.status).toBe("submitted");
+  });
+
+  it("deletes the staged signal row when the signal_submission stage is discarded", async () => {
+    const signalId = "sig-stage-discard-001";
+    const seed = await SELF.fetch("http://example.com/api/test-seed", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        signals: [
+          {
+            id: signalId,
+            beat_slug: "agent-economy",
+            btc_address: BTC_ADDRESS,
+            headline: "Pending signal that fails to settle",
+            body: null,
+            sources: JSON.stringify([{ url: "https://example.com", title: "Example" }]),
+            created_at: "2026-04-22T11:00:00.000Z",
+            status: "pending_payment",
+          },
+        ],
+      }),
+    });
+    expect(seed.status).toBe(200);
+
+    const stageRes = await SELF.fetch("http://example.com/api/test/payment-stage", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        paymentId: "pay_signal_stage_discard",
+        payload: {
+          kind: "signal_submission",
+          signal_id: signalId,
+          btc_address: BTC_ADDRESS,
+          beat_slug: "agent-economy",
+          headline: "Pending signal that fails to settle",
+          body: null,
+          sources: [{ url: "https://example.com", title: "Example" }],
+          tags: [],
+          disclosure: null,
+          payment_txid: null,
+        },
+      }),
+    });
+    expect(stageRes.status).toBe(201);
+
+    const reconcile = await SELF.fetch(
+      "http://example.com/api/test/payment-stage/pay_signal_stage_discard/reconcile",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: "failed", terminalReason: "sender_nonce_stale" }),
+      }
+    );
+    expect(reconcile.status).toBe(200);
+    const reconcileBody = await reconcile.json<{ data: { stageStatus: string } }>();
+    expect(reconcileBody.data.stageStatus).toBe("discarded");
+
+    const after = await SELF.fetch(`http://example.com/api/signals/${signalId}`);
+    expect(after.status).toBe(404);
+  });
+
   it("rejects unsupported staged payload kinds", async () => {
     const res = await SELF.fetch("http://example.com/api/test/payment-stage", {
       method: "POST",

--- a/src/__tests__/payment-staging.test.ts
+++ b/src/__tests__/payment-staging.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { SELF } from "cloudflare:test";
-
-const BTC_ADDRESS = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+import {
+  FIXTURE_BTC_ADDRESS as BTC_ADDRESS,
+  reconcileStage,
+  seedPendingSignal,
+  stageSignalSubmission,
+} from "./_payment-fixtures";
 
 describe("payment staging", () => {
   it("keeps staged records provisional when reconciliation sees mempool", async () => {
@@ -173,63 +177,22 @@ describe("payment staging", () => {
 
   it("finalizes a staged signal_submission by flipping status from pending_payment to submitted", async () => {
     const signalId = "sig-stage-finalize-001";
-    const seed = await SELF.fetch("http://example.com/api/test-seed", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        signals: [
-          {
-            id: signalId,
-            beat_slug: "agent-economy",
-            btc_address: BTC_ADDRESS,
-            headline: "Pending signal awaiting settlement",
-            body: "Will flip on confirm",
-            sources: JSON.stringify([{ url: "https://example.com", title: "Example" }]),
-            created_at: "2026-04-22T10:00:00.000Z",
-            status: "pending_payment",
-          },
-        ],
-      }),
+    await seedPendingSignal(signalId, {
+      headline: "Pending signal awaiting settlement",
+      body: "Will flip on confirm",
+      createdAt: "2026-04-22T10:00:00.000Z",
     });
-    expect(seed.status).toBe(200);
-
-    const stageRes = await SELF.fetch("http://example.com/api/test/payment-stage", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        paymentId: "pay_signal_stage_finalize",
-        payload: {
-          kind: "signal_submission",
-          signal_id: signalId,
-          btc_address: BTC_ADDRESS,
-          beat_slug: "agent-economy",
-          headline: "Pending signal awaiting settlement",
-          body: "Will flip on confirm",
-          sources: [{ url: "https://example.com", title: "Example" }],
-          tags: [],
-          disclosure: null,
-          payment_txid: null,
-        },
-      }),
+    await stageSignalSubmission("pay_signal_stage_finalize", signalId, {
+      headline: "Pending signal awaiting settlement",
+      body: "Will flip on confirm",
     });
-    expect(stageRes.status).toBe(201);
 
     const before = await SELF.fetch(`http://example.com/api/signals/${signalId}`);
     expect(before.status).toBe(200);
     const beforeBody = await before.json<{ status: string }>();
     expect(beforeBody.status).toBe("pending_payment");
 
-    const reconcile = await SELF.fetch(
-      "http://example.com/api/test/payment-stage/pay_signal_stage_finalize/reconcile",
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ status: "confirmed", txid: "f".repeat(64) }),
-      }
-    );
-    expect(reconcile.status).toBe(200);
-    const reconcileBody = await reconcile.json<{ data: { stageStatus: string } }>();
-    expect(reconcileBody.data.stageStatus).toBe("finalized");
+    await reconcileStage("pay_signal_stage_finalize", "confirmed", { txid: "f".repeat(64) });
 
     const after = await SELF.fetch(`http://example.com/api/signals/${signalId}`);
     expect(after.status).toBe(200);
@@ -239,48 +202,15 @@ describe("payment staging", () => {
 
   it("deletes the staged signal row when the signal_submission stage is discarded", async () => {
     const signalId = "sig-stage-discard-001";
-    const seed = await SELF.fetch("http://example.com/api/test-seed", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        signals: [
-          {
-            id: signalId,
-            beat_slug: "agent-economy",
-            btc_address: BTC_ADDRESS,
-            headline: "Pending signal that fails to settle",
-            body: null,
-            sources: JSON.stringify([{ url: "https://example.com", title: "Example" }]),
-            created_at: "2026-04-22T11:00:00.000Z",
-            status: "pending_payment",
-          },
-        ],
-      }),
+    await seedPendingSignal(signalId, {
+      headline: "Pending signal that fails to settle",
+      createdAt: "2026-04-22T11:00:00.000Z",
     });
-    expect(seed.status).toBe(200);
-
-    const stageRes = await SELF.fetch("http://example.com/api/test/payment-stage", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        paymentId: "pay_signal_stage_discard",
-        payload: {
-          kind: "signal_submission",
-          signal_id: signalId,
-          btc_address: BTC_ADDRESS,
-          beat_slug: "agent-economy",
-          headline: "Pending signal that fails to settle",
-          body: null,
-          sources: [{ url: "https://example.com", title: "Example" }],
-          tags: [],
-          disclosure: null,
-          payment_txid: null,
-        },
-      }),
+    await stageSignalSubmission("pay_signal_stage_discard", signalId, {
+      headline: "Pending signal that fails to settle",
     });
-    expect(stageRes.status).toBe(201);
 
-    const reconcile = await SELF.fetch(
+    const reconcileTrigger = await SELF.fetch(
       "http://example.com/api/test/payment-stage/pay_signal_stage_discard/reconcile",
       {
         method: "POST",
@@ -288,8 +218,8 @@ describe("payment staging", () => {
         body: JSON.stringify({ status: "failed", terminalReason: "sender_nonce_stale" }),
       }
     );
-    expect(reconcile.status).toBe(200);
-    const reconcileBody = await reconcile.json<{ data: { stageStatus: string } }>();
+    expect(reconcileTrigger.status).toBe(200);
+    const reconcileBody = await reconcileTrigger.json<{ data: { stageStatus: string } }>();
     expect(reconcileBody.data.stageStatus).toBe("discarded");
 
     const after = await SELF.fetch(`http://example.com/api/signals/${signalId}`);

--- a/src/__tests__/scoring-math.test.ts
+++ b/src/__tests__/scoring-math.test.ts
@@ -374,8 +374,10 @@ describe("referral_credits: weight x" + SCORING_WEIGHTS.referral_credits, () => 
 
 describe("edge case: same-day multi-signals count as 1 days_active", () => {
   it("three signals on the same date produce days_active=1", async () => {
-    // Use the same date-prefix to ensure same SQLite date() value
-    const sameDate = "2026-03-10";
+    // Anchor to a recent UTC date so the rows stay inside the leaderboard's
+    // 30-day rolling window regardless of when the test runs (the previous
+    // hardcoded "2026-03-10" silently aged out and zeroed signalCount).
+    const sameDate = recentTs(5).slice(0, 10);
     const ts1 = sameDate + "T08:00:00.000Z";
     const ts2 = sameDate + "T12:00:00.000Z";
     const ts3 = sameDate + "T20:00:00.000Z";

--- a/src/__tests__/signal-payment-flow.test.ts
+++ b/src/__tests__/signal-payment-flow.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+import { SELF } from "cloudflare:test";
+
+const BTC_ADDRESS = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+
+/**
+ * End-to-end coverage for the visibility / counts / finalize behaviour of
+ * x402-paid signal submissions. The full HTTP path through `POST /api/signals`
+ * (verifyPayment + identity gate + BIP-322 auth) is exercised separately by
+ * the smoke test on the staging preview; these tests pin the parts of the
+ * registry contract that any unit or integration regression would touch:
+ *
+ *  - default `GET /api/signals` hides `pending_payment` rows
+ *  - `?include_pending=true` and `?status=pending_payment` opt the author in
+ *  - `GET /api/signals/counts` adds the `pending_payment` bucket only when
+ *    the request is agent-scoped or `include_pending=true` is set
+ *  - finalize via the staging endpoint flips the row to `submitted`, after
+ *    which it shows up in the default listing
+ *  - a discarded stage deletes the row entirely (cooldown / daily-cap slot is
+ *    naturally released because the row no longer exists)
+ */
+
+async function seedPendingSignal(id: string, btcAddress = BTC_ADDRESS): Promise<void> {
+  const res = await SELF.fetch("http://example.com/api/test-seed", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      signals: [
+        {
+          id,
+          beat_slug: "agent-economy",
+          btc_address: btcAddress,
+          headline: `Pending signal ${id}`,
+          body: null,
+          sources: JSON.stringify([{ url: "https://example.com", title: "Example" }]),
+          created_at: "2026-04-22T13:00:00.000Z",
+          status: "pending_payment",
+        },
+      ],
+    }),
+  });
+  expect(res.status).toBe(200);
+}
+
+async function stage(paymentId: string, signalId: string): Promise<void> {
+  const res = await SELF.fetch("http://example.com/api/test/payment-stage", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      paymentId,
+      payload: {
+        kind: "signal_submission",
+        signal_id: signalId,
+        btc_address: BTC_ADDRESS,
+        beat_slug: "agent-economy",
+        headline: `Pending signal ${signalId}`,
+        body: null,
+        sources: [{ url: "https://example.com", title: "Example" }],
+        tags: [],
+        disclosure: null,
+        payment_txid: null,
+      },
+    }),
+  });
+  expect(res.status).toBe(201);
+}
+
+async function reconcile(paymentId: string, status: string, extra: Record<string, unknown> = {}): Promise<void> {
+  const res = await SELF.fetch(
+    `http://example.com/api/test/payment-stage/${paymentId}/reconcile`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status, ...extra }),
+    }
+  );
+  expect(res.status).toBe(200);
+}
+
+describe("signal x402 visibility + finalize flow", () => {
+  it("hides pending_payment from default GET /api/signals listings", async () => {
+    const id = "sig-visibility-default-001";
+    await seedPendingSignal(id);
+
+    const res = await SELF.fetch(`http://example.com/api/signals?agent=${BTC_ADDRESS}`);
+    expect(res.status).toBe(200);
+    const body = await res.json<{ signals: Array<{ id: string }> }>();
+    expect(body.signals.find((s) => s.id === id)).toBeUndefined();
+  });
+
+  it("returns pending_payment rows when ?include_pending=true is passed", async () => {
+    const id = "sig-visibility-include-pending-001";
+    await seedPendingSignal(id);
+
+    const res = await SELF.fetch(
+      `http://example.com/api/signals?agent=${BTC_ADDRESS}&include_pending=true`
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json<{ signals: Array<{ id: string; status: string }> }>();
+    const found = body.signals.find((s) => s.id === id);
+    expect(found).toBeDefined();
+    expect(found?.status).toBe("pending_payment");
+  });
+
+  it("returns pending_payment rows when ?status=pending_payment is passed", async () => {
+    const id = "sig-visibility-status-pending-001";
+    await seedPendingSignal(id);
+
+    const res = await SELF.fetch(
+      `http://example.com/api/signals?agent=${BTC_ADDRESS}&status=pending_payment`
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json<{ signals: Array<{ id: string; status: string }> }>();
+    expect(body.signals.every((s) => s.status === "pending_payment")).toBe(true);
+    expect(body.signals.find((s) => s.id === id)).toBeDefined();
+  });
+
+  it("excludes pending_payment from /api/signals/counts when neither agent= nor include_pending=true is set", async () => {
+    await seedPendingSignal("sig-counts-exclude-001");
+
+    const res = await SELF.fetch("http://example.com/api/signals/counts");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ pending_payment?: number }>();
+    expect(body.pending_payment).toBeUndefined();
+  });
+
+  it("includes pending_payment bucket on /api/signals/counts when agent is scoped", async () => {
+    const isolatedAddr = "bc1qpending0counts0agent000000000000000000";
+    await seedPendingSignal("sig-counts-include-agent-001", isolatedAddr);
+
+    const res = await SELF.fetch(`http://example.com/api/signals/counts?agent=${isolatedAddr}`);
+    expect(res.status).toBe(200);
+    const body = await res.json<{ pending_payment?: number }>();
+    expect(body.pending_payment).toBeGreaterThanOrEqual(1);
+  });
+
+  it("includes pending_payment bucket on /api/signals/counts when include_pending=true", async () => {
+    await seedPendingSignal("sig-counts-include-flag-001");
+
+    const res = await SELF.fetch("http://example.com/api/signals/counts?include_pending=true");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ pending_payment?: number }>();
+    expect(body.pending_payment).toBeGreaterThanOrEqual(1);
+  });
+
+  it("flips a finalised signal into the default listing after a confirmed reconcile", async () => {
+    const signalId = "sig-flow-finalise-001";
+    await seedPendingSignal(signalId);
+    await stage("pay_signal_flow_finalize", signalId);
+
+    const beforeRes = await SELF.fetch(`http://example.com/api/signals?agent=${BTC_ADDRESS}`);
+    const beforeBody = await beforeRes.json<{ signals: Array<{ id: string }> }>();
+    expect(beforeBody.signals.find((s) => s.id === signalId)).toBeUndefined();
+
+    await reconcile("pay_signal_flow_finalize", "confirmed", { txid: "a".repeat(64) });
+
+    const afterRes = await SELF.fetch(`http://example.com/api/signals?agent=${BTC_ADDRESS}`);
+    const afterBody = await afterRes.json<{ signals: Array<{ id: string; status: string }> }>();
+    const found = afterBody.signals.find((s) => s.id === signalId);
+    expect(found).toBeDefined();
+    expect(found?.status).toBe("submitted");
+  });
+
+  it("removes the staged row entirely when a signal_submission stage is discarded", async () => {
+    const signalId = "sig-flow-discard-001";
+    await seedPendingSignal(signalId);
+    await stage("pay_signal_flow_discard", signalId);
+
+    await reconcile("pay_signal_flow_discard", "failed", { terminalReason: "sender_nonce_stale" });
+
+    const directRes = await SELF.fetch(`http://example.com/api/signals/${signalId}`);
+    expect(directRes.status).toBe(404);
+
+    const includePendingRes = await SELF.fetch(
+      `http://example.com/api/signals?agent=${BTC_ADDRESS}&include_pending=true`
+    );
+    const includePendingBody = await includePendingRes.json<{ signals: Array<{ id: string }> }>();
+    expect(includePendingBody.signals.find((s) => s.id === signalId)).toBeUndefined();
+  });
+});

--- a/src/__tests__/signal-payment-flow.test.ts
+++ b/src/__tests__/signal-payment-flow.test.ts
@@ -25,34 +25,33 @@ describe("signal x402 visibility + finalize flow", () => {
     expect(body.signals.find((s) => s.id === id)).toBeUndefined();
   });
 
-  it("returns pending_payment rows when ?include_pending=true is passed", async () => {
-    const id = "sig-visibility-include-pending-001";
-    await seedPendingSignal(id);
-
+  it("rejects ?include_pending=true without an agent filter (400)", async () => {
     const res = await SELF.fetch(
-      `http://example.com/api/signals?agent=${BTC_ADDRESS}&include_pending=true`
+      "http://example.com/api/signals?include_pending=true"
     );
-    expect(res.status).toBe(200);
-    const body = await res.json<{ signals: Array<{ id: string; status: string }> }>();
-    const found = body.signals.find((s) => s.id === id);
-    expect(found).toBeDefined();
-    expect(found?.status).toBe("pending_payment");
+    expect(res.status).toBe(400);
+    const body = await res.json<{ code: string }>();
+    expect(body.code).toBe("PENDING_REQUIRES_AGENT");
   });
 
-  it("returns pending_payment rows when ?status=pending_payment is passed", async () => {
-    const id = "sig-visibility-status-pending-001";
-    await seedPendingSignal(id);
-
+  it("rejects ?status=pending_payment without BIP-322 auth (401)", async () => {
     const res = await SELF.fetch(
       `http://example.com/api/signals?agent=${BTC_ADDRESS}&status=pending_payment`
     );
-    expect(res.status).toBe(200);
-    const body = await res.json<{ signals: Array<{ id: string; status: string }> }>();
-    expect(body.signals.every((s) => s.status === "pending_payment")).toBe(true);
-    expect(body.signals.find((s) => s.id === id)).toBeDefined();
+    expect(res.status).toBe(401);
+    const body = await res.json<{ code: string }>();
+    expect(body.code).toBe("MISSING_AUTH");
   });
 
-  it("excludes pending_payment from /api/signals/counts when neither agent= nor include_pending=true is set", async () => {
+  it("hides x402-staged signals from the public per-id endpoint (404)", async () => {
+    const id = "sig-visibility-per-id-hidden-001";
+    await seedPendingSignal(id);
+
+    const res = await SELF.fetch(`http://example.com/api/signals/${id}`);
+    expect(res.status).toBe(404);
+  });
+
+  it("excludes pending_payment from /api/signals/counts by default", async () => {
     await seedPendingSignal("sig-counts-exclude-001");
 
     const res = await SELF.fetch("http://example.com/api/signals/counts");
@@ -61,23 +60,28 @@ describe("signal x402 visibility + finalize flow", () => {
     expect(body.pending_payment).toBeUndefined();
   });
 
-  it("includes pending_payment bucket on /api/signals/counts when agent is scoped", async () => {
+  it("rejects /api/signals/counts?include_pending=true without ?agent= (400)", async () => {
+    const res = await SELF.fetch("http://example.com/api/signals/counts?include_pending=true");
+    expect(res.status).toBe(400);
+    const body = await res.json<{ code: string }>();
+    expect(body.code).toBe("PENDING_REQUIRES_AGENT");
+  });
+
+  it("rejects /api/signals/counts?include_pending=true without auth (401)", async () => {
+    const res = await SELF.fetch(
+      `http://example.com/api/signals/counts?agent=${BTC_ADDRESS}&include_pending=true`
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("serves agent-scoped /api/signals/counts unauthenticated (no pending bucket)", async () => {
     const isolatedAddr = "bc1qpending0counts0agent000000000000000000";
     await seedPendingSignal("sig-counts-include-agent-001", { btcAddress: isolatedAddr });
 
     const res = await SELF.fetch(`http://example.com/api/signals/counts?agent=${isolatedAddr}`);
     expect(res.status).toBe(200);
     const body = await res.json<{ pending_payment?: number }>();
-    expect(body.pending_payment).toBeGreaterThanOrEqual(1);
-  });
-
-  it("includes pending_payment bucket on /api/signals/counts when include_pending=true", async () => {
-    await seedPendingSignal("sig-counts-include-flag-001");
-
-    const res = await SELF.fetch("http://example.com/api/signals/counts?include_pending=true");
-    expect(res.status).toBe(200);
-    const body = await res.json<{ pending_payment?: number }>();
-    expect(body.pending_payment).toBeGreaterThanOrEqual(1);
+    expect(body.pending_payment).toBeUndefined();
   });
 
   it("flips a finalised signal into the default listing after a confirmed reconcile", async () => {
@@ -108,10 +112,10 @@ describe("signal x402 visibility + finalize flow", () => {
     const directRes = await SELF.fetch(`http://example.com/api/signals/${signalId}`);
     expect(directRes.status).toBe(404);
 
-    const includePendingRes = await SELF.fetch(
-      `http://example.com/api/signals?agent=${BTC_ADDRESS}&include_pending=true`
-    );
-    const includePendingBody = await includePendingRes.json<{ signals: Array<{ id: string }> }>();
-    expect(includePendingBody.signals.find((s) => s.id === signalId)).toBeUndefined();
+    // The staged-payment record is also discarded — confirms cleanup ran.
+    const stageRes = await SELF.fetch(`http://example.com/api/test/payment-stage/pay_signal_flow_discard`);
+    expect(stageRes.status).toBe(200);
+    const stageBody = await stageRes.json<{ data: { stageStatus: string } }>();
+    expect(stageBody.data.stageStatus).toBe("discarded");
   });
 });

--- a/src/__tests__/signal-payment-flow.test.ts
+++ b/src/__tests__/signal-payment-flow.test.ts
@@ -43,6 +43,23 @@ describe("signal x402 visibility + finalize flow", () => {
     expect(body.code).toBe("MISSING_AUTH");
   });
 
+  it("rejects ?agent=A&include_pending=true when X-BTC-Address is B (401 ADDRESS_MISMATCH)", async () => {
+    const otherAddress = "bc1qotheragent0000000000000000000000000000";
+    const res = await SELF.fetch(
+      `http://example.com/api/signals?agent=${BTC_ADDRESS}&include_pending=true`,
+      {
+        headers: {
+          "X-BTC-Address": otherAddress,
+          "X-BTC-Signature": "AAAA",
+          "X-BTC-Timestamp": String(Math.floor(Date.now() / 1000)),
+        },
+      }
+    );
+    expect(res.status).toBe(401);
+    const body = await res.json<{ code: string }>();
+    expect(body.code).toBe("ADDRESS_MISMATCH");
+  });
+
   it("hides x402-staged signals from the public per-id endpoint (404)", async () => {
     const id = "sig-visibility-per-id-hidden-001";
     await seedPendingSignal(id);

--- a/src/__tests__/signal-payment-flow.test.ts
+++ b/src/__tests__/signal-payment-flow.test.ts
@@ -1,81 +1,18 @@
 import { describe, expect, it } from "vitest";
 import { SELF } from "cloudflare:test";
-
-const BTC_ADDRESS = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+import {
+  FIXTURE_BTC_ADDRESS as BTC_ADDRESS,
+  reconcileStage,
+  seedPendingSignal,
+  stageSignalSubmission,
+} from "./_payment-fixtures";
 
 /**
- * End-to-end coverage for the visibility / counts / finalize behaviour of
- * x402-paid signal submissions. The full HTTP path through `POST /api/signals`
- * (verifyPayment + identity gate + BIP-322 auth) is exercised separately by
- * the smoke test on the staging preview; these tests pin the parts of the
- * registry contract that any unit or integration regression would touch:
- *
- *  - default `GET /api/signals` hides `pending_payment` rows
- *  - `?include_pending=true` and `?status=pending_payment` opt the author in
- *  - `GET /api/signals/counts` adds the `pending_payment` bucket only when
- *    the request is agent-scoped or `include_pending=true` is set
- *  - finalize via the staging endpoint flips the row to `submitted`, after
- *    which it shows up in the default listing
- *  - a discarded stage deletes the row entirely (cooldown / daily-cap slot is
- *    naturally released because the row no longer exists)
+ * Coverage for the visibility / counts / finalize behaviour of x402-paid signal
+ * submissions. The full HTTP path through POST /api/signals (verifyPayment +
+ * identity gate + BIP-322 auth) is exercised by the staging-preview smoke test;
+ * these tests pin the registry contract that any regression would touch.
  */
-
-async function seedPendingSignal(id: string, btcAddress = BTC_ADDRESS): Promise<void> {
-  const res = await SELF.fetch("http://example.com/api/test-seed", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      signals: [
-        {
-          id,
-          beat_slug: "agent-economy",
-          btc_address: btcAddress,
-          headline: `Pending signal ${id}`,
-          body: null,
-          sources: JSON.stringify([{ url: "https://example.com", title: "Example" }]),
-          created_at: "2026-04-22T13:00:00.000Z",
-          status: "pending_payment",
-        },
-      ],
-    }),
-  });
-  expect(res.status).toBe(200);
-}
-
-async function stage(paymentId: string, signalId: string): Promise<void> {
-  const res = await SELF.fetch("http://example.com/api/test/payment-stage", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      paymentId,
-      payload: {
-        kind: "signal_submission",
-        signal_id: signalId,
-        btc_address: BTC_ADDRESS,
-        beat_slug: "agent-economy",
-        headline: `Pending signal ${signalId}`,
-        body: null,
-        sources: [{ url: "https://example.com", title: "Example" }],
-        tags: [],
-        disclosure: null,
-        payment_txid: null,
-      },
-    }),
-  });
-  expect(res.status).toBe(201);
-}
-
-async function reconcile(paymentId: string, status: string, extra: Record<string, unknown> = {}): Promise<void> {
-  const res = await SELF.fetch(
-    `http://example.com/api/test/payment-stage/${paymentId}/reconcile`,
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ status, ...extra }),
-    }
-  );
-  expect(res.status).toBe(200);
-}
 
 describe("signal x402 visibility + finalize flow", () => {
   it("hides pending_payment from default GET /api/signals listings", async () => {
@@ -126,7 +63,7 @@ describe("signal x402 visibility + finalize flow", () => {
 
   it("includes pending_payment bucket on /api/signals/counts when agent is scoped", async () => {
     const isolatedAddr = "bc1qpending0counts0agent000000000000000000";
-    await seedPendingSignal("sig-counts-include-agent-001", isolatedAddr);
+    await seedPendingSignal("sig-counts-include-agent-001", { btcAddress: isolatedAddr });
 
     const res = await SELF.fetch(`http://example.com/api/signals/counts?agent=${isolatedAddr}`);
     expect(res.status).toBe(200);
@@ -146,13 +83,13 @@ describe("signal x402 visibility + finalize flow", () => {
   it("flips a finalised signal into the default listing after a confirmed reconcile", async () => {
     const signalId = "sig-flow-finalise-001";
     await seedPendingSignal(signalId);
-    await stage("pay_signal_flow_finalize", signalId);
+    await stageSignalSubmission("pay_signal_flow_finalize", signalId);
 
     const beforeRes = await SELF.fetch(`http://example.com/api/signals?agent=${BTC_ADDRESS}`);
     const beforeBody = await beforeRes.json<{ signals: Array<{ id: string }> }>();
     expect(beforeBody.signals.find((s) => s.id === signalId)).toBeUndefined();
 
-    await reconcile("pay_signal_flow_finalize", "confirmed", { txid: "a".repeat(64) });
+    await reconcileStage("pay_signal_flow_finalize", "confirmed", { txid: "a".repeat(64) });
 
     const afterRes = await SELF.fetch(`http://example.com/api/signals?agent=${BTC_ADDRESS}`);
     const afterBody = await afterRes.json<{ signals: Array<{ id: string; status: string }> }>();
@@ -164,9 +101,9 @@ describe("signal x402 visibility + finalize flow", () => {
   it("removes the staged row entirely when a signal_submission stage is discarded", async () => {
     const signalId = "sig-flow-discard-001";
     await seedPendingSignal(signalId);
-    await stage("pay_signal_flow_discard", signalId);
+    await stageSignalSubmission("pay_signal_flow_discard", signalId);
 
-    await reconcile("pay_signal_flow_discard", "failed", { terminalReason: "sender_nonce_stale" });
+    await reconcileStage("pay_signal_flow_discard", "failed", { terminalReason: "sender_nonce_stale" });
 
     const directRes = await SELF.fetch(`http://example.com/api/signals/${signalId}`);
     expect(directRes.status).toBe(404);

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -96,7 +96,10 @@ export const BRIEF_PRICE_SATS = 1000;
 export const CORRESPONDENT_SHARE = 0.7;
 
 // ── Signal statuses (editorial pipeline) ──
+// `pending_payment` is intentionally OUT of REVIEWABLE_SIGNAL_STATUSES — staged
+// signals are invisible to the editorial pipeline until x402 payment finalises.
 export const SIGNAL_STATUSES = [
+  "pending_payment",
   "submitted",
   "approved",
   "replaced",

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -110,6 +110,9 @@ export const SIGNAL_STATUSES = [
   "brief_included",
 ] as const;
 
+/** Single source of truth for the staged-but-unconfirmed status string. */
+export const PENDING_PAYMENT_STATUS = "pending_payment" as const;
+
 export const REVIEWABLE_SIGNAL_STATUSES = [
   "submitted",
   "approved",

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,5 +1,8 @@
 // ── Payment constants ──
-export const TREASURY_STX_ADDRESS = "SP236MA9EWHF1DN3X84EQAJEW7R6BDZZ93K3EMC3C";
+// Migrated from SP236… (legacy publisher address) to the SP1KGHF treasury
+// in the x402 signal-payment rollout. Any stranded sBTC at the legacy
+// address is recovered out-of-band by the operator.
+export const TREASURY_STX_ADDRESS = "SP1KGHF33817ZXW27CG50JXWC0Y6BNXAQ4E7YGAHM";
 export const SBTC_CONTRACT_MAINNET =
   "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token";
 export const X402_RELAY_URL = "https://x402-relay.aibtc.com";

--- a/src/lib/do-client.ts
+++ b/src/lib/do-client.ts
@@ -596,12 +596,20 @@ export async function getPaymentStage(
 
 /** Delete a `pending_payment` signal row (and its tags). Safe-by-construction:
  *  the DO-side route is scoped to status='pending_payment' so it cannot delete
- *  a finalised signal. Used to roll back stage-payment failure leaks. */
-export async function deletePendingSignal(env: Env, signalId: string): Promise<void> {
+ *  a finalised signal. Used to roll back stage-payment failure leaks. Returns
+ *  `{ok}` so callers can surface a rollback failure (which would strand the
+ *  agent's cooldown slot — the alarm sweep can't reach an orphan with no
+ *  payment_staging row). */
+export async function deletePendingSignal(
+  env: Env,
+  signalId: string
+): Promise<{ ok: boolean }> {
   const stub = getStub(env);
-  await stub.fetch(`https://do/signals/${encodeURIComponent(signalId)}/pending`, {
-    method: "DELETE",
-  });
+  const res = await stub.fetch(
+    `https://do/signals/${encodeURIComponent(signalId)}/pending`,
+    { method: "DELETE" }
+  );
+  return { ok: res.ok };
 }
 
 export interface ReviewClassifiedInput {

--- a/src/lib/do-client.ts
+++ b/src/lib/do-client.ts
@@ -579,6 +579,31 @@ export async function reconcilePaymentStage(
   });
 }
 
+/** Fetch a payment stage by id; null if missing. Used by the signals route to
+ *  detect idempotent retries — same paymentId resubmitted should return the
+ *  original 202 response instead of running cooldown again. */
+export async function getPaymentStage(
+  env: Env,
+  paymentId: string
+): Promise<PaymentStageMaterialized | null> {
+  const stub = getStub(env);
+  const result = await doFetch<PaymentStageMaterialized>(
+    stub,
+    `/payment-staging/${encodeURIComponent(paymentId)}`
+  );
+  return result.ok ? (result.data ?? null) : null;
+}
+
+/** Delete a `pending_payment` signal row (and its tags). Safe-by-construction:
+ *  the DO-side route is scoped to status='pending_payment' so it cannot delete
+ *  a finalised signal. Used to roll back stage-payment failure leaks. */
+export async function deletePendingSignal(env: Env, signalId: string): Promise<void> {
+  const stub = getStub(env);
+  await stub.fetch(`https://do/signals/${encodeURIComponent(signalId)}/pending`, {
+    method: "DELETE",
+  });
+}
+
 export interface ReviewClassifiedInput {
   btc_address: string;
   status: ClassifiedStatus;

--- a/src/lib/do-client.ts
+++ b/src/lib/do-client.ts
@@ -165,6 +165,13 @@ export interface SignalFilters {
   limit?: number;
   /** Offset for pagination (skip first N results). */
   offset?: number;
+  /**
+   * When true, x402-staged-but-unconfirmed signals (status='pending_payment')
+   * are included alongside the default editorial set. Authors set this to see
+   * their own staged rows; passing status='pending_payment' explicitly has
+   * the same effect.
+   */
+  include_pending?: boolean;
 }
 
 export interface FrontPagePageResult {
@@ -199,6 +206,7 @@ export async function listSignalsPage(
   if (filters.since) params.set("since", filters.since);
   if (filters.date) params.set("date", filters.date);
   if (filters.status) params.set("status", filters.status);
+  if (filters.include_pending) params.set("include_pending", "true");
   if (filters.limit !== undefined) params.set("limit", String(filters.limit));
   if (filters.offset !== undefined) params.set("offset", String(filters.offset));
   const qs = params.toString();
@@ -357,6 +365,7 @@ export interface SignalCountsFilters {
   beat?: string;
   agent?: string;
   since?: string;
+  include_pending?: boolean;
 }
 
 export interface SignalCounts {
@@ -365,6 +374,8 @@ export interface SignalCounts {
   replaced: number;
   rejected: number;
   brief_included: number;
+  /** Present only when include_pending=true (or agent is scoped on the request). */
+  pending_payment?: number;
   total: number;
 }
 
@@ -377,6 +388,7 @@ export async function getSignalCounts(
   if (filters.beat) params.set("beat", filters.beat);
   if (filters.agent) params.set("agent", filters.agent);
   if (filters.since) params.set("since", filters.since);
+  if (filters.include_pending) params.set("include_pending", "true");
   const qs = params.toString();
   const result = await doFetch<SignalCounts>(stub, `/signals/counts${qs ? `?${qs}` : ""}`);
   if (!result.ok) throw new Error(result.error ?? "Failed to get signal counts");

--- a/src/lib/do-client.ts
+++ b/src/lib/do-client.ts
@@ -293,6 +293,18 @@ export interface CreateSignalInput {
   tags: string[];
   signature?: string;
   disclosure?: string;
+  /**
+   * Caller-provided id when the route is staging a pending_payment row.
+   * The route allocates this id pre-stage so it can return it in the
+   * 202 body alongside paymentId. Omit (or empty) to have the DO mint one.
+   */
+  signal_id?: string;
+  /**
+   * When true, the row lands at status='pending_payment' and the DO defers
+   * streak / correspondent_stats / referral commit effects until the
+   * x402 finalize hook fires (or deletes the row on discard).
+   */
+  pending_payment?: boolean;
 }
 
 export interface CooldownInfo {

--- a/src/lib/do-client.ts
+++ b/src/lib/do-client.ts
@@ -305,6 +305,13 @@ export interface CreateSignalInput {
    * x402 finalize hook fires (or deletes the row on discard).
    */
   pending_payment?: boolean;
+  /**
+   * On-chain sBTC settlement txid. Used by the x402 HTTP-fallback path that
+   * confirms synchronously without a paymentId — the row is written directly
+   * with status='submitted' so we attach the txid here. Omitted for the
+   * staged path (finalize stamps it from the staging payload).
+   */
+  payment_txid?: string | null;
 }
 
 export interface CooldownInfo {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -433,7 +433,7 @@ export interface DOResult<T> {
   hasMore?: boolean;
 }
 
-export type PaymentStageKind = "brief_access" | "classified_submission";
+export type PaymentStageKind = "brief_access" | "classified_submission" | "signal_submission";
 export type PaymentStageLifecycle = "staged" | "finalized" | "discarded" | "expired";
 
 export interface BriefAccessStagePayload {
@@ -453,7 +453,23 @@ export interface ClassifiedSubmissionStagePayload {
   payment_txid: string | null;
 }
 
-export type PaymentStagePayload = BriefAccessStagePayload | ClassifiedSubmissionStagePayload;
+export interface SignalSubmissionStagePayload {
+  kind: "signal_submission";
+  signal_id: string;
+  btc_address: string;
+  beat_slug: string;
+  headline: string;
+  body: string | null;
+  sources: Source[];
+  tags: string[];
+  disclosure: string | null;
+  payment_txid: string | null;
+}
+
+export type PaymentStagePayload =
+  | BriefAccessStagePayload
+  | ClassifiedSubmissionStagePayload
+  | SignalSubmissionStagePayload;
 
 export interface PaymentStageRecord {
   payment_id: string;

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -437,14 +437,142 @@ function finalizeBriefAccess(payload: PaymentStagePayload, ctx: FinalizeContext)
 }
 
 /**
- * Flips an already-staged signals row from `pending_payment` → `submitted`
- * and stamps `payment_txid`. The signal content was inserted at stage time,
- * so finalize is a status-only update; the WHERE clause restricts the
- * update to the matching pending row, making concurrent poll+sweep finalises
- * a no-op on the second run.
+ * Bumps the materialised correspondent_stats row for a paid signal that is
+ * landing on `submitted`. Mirrors the semantics of the legacy class method
+ * (signal_count++, last/first_signal_at min/max, days_active recomputed)
+ * but excludes `pending_payment` rows from the days_active subquery so a
+ * still-staged signal does not inflate the visible total.
+ *
+ * Free function form so the finalize registry can call it; the createSignal
+ * route handler wraps it with `applyCorrespondentStatsBumpForInsert`.
+ */
+function applyCorrespondentStatsBump(
+  sql: DurableObjectState["storage"]["sql"],
+  btcAddress: string,
+  signalCreatedAt: string
+): void {
+  sql.exec(
+    `INSERT INTO correspondent_stats (btc_address, signal_count, last_signal_at, first_signal_at, days_active, updated_at)
+     VALUES (?1, 1, ?2, ?2, 1, datetime('now'))
+     ON CONFLICT(btc_address) DO UPDATE SET
+       signal_count = correspondent_stats.signal_count + 1,
+       last_signal_at = MAX(correspondent_stats.last_signal_at, excluded.last_signal_at),
+       first_signal_at = MIN(correspondent_stats.first_signal_at, excluded.first_signal_at),
+       days_active = (
+         SELECT COUNT(DISTINCT date(created_at)) FROM signals
+         WHERE btc_address = ?1
+           AND correction_of IS NULL
+           AND status != 'pending_payment'
+       ),
+       updated_at = datetime('now')`,
+    btcAddress,
+    signalCreatedAt
+  );
+}
+
+/**
+ * Updates the streaks row for a finalized (non-correction) signal. Computes
+ * day-over-day continuation from the streaks record's previous
+ * `last_signal_date`, anchored to the *signal's* UTC date — not the moment
+ * of finalization — so that an x402 settlement that crosses a UTC midnight
+ * still credits the day the agent actually filed.
+ */
+function applyStreakBumpForSignal(
+  sql: DurableObjectState["storage"]["sql"],
+  btcAddress: string,
+  signalCreatedAt: string
+): { totalSignals: number } {
+  const signalDate = signalCreatedAt.slice(0, 10);
+  const yesterday = getUTCYesterday(new Date(signalCreatedAt));
+
+  const streakRows = sql
+    .exec("SELECT * FROM streaks WHERE btc_address = ?", btcAddress)
+    .toArray();
+
+  let currentStreak = 1;
+  let longestStreak = 1;
+  let totalSignals = 1;
+  const rec = streakRows[0] as unknown as Streak | undefined;
+
+  if (rec) {
+    totalSignals = (rec.total_signals ?? 0) + 1;
+    if (rec.last_signal_date === signalDate) {
+      currentStreak = rec.current_streak ?? 1;
+      longestStreak = rec.longest_streak ?? 1;
+    } else if (rec.last_signal_date === yesterday) {
+      currentStreak = (rec.current_streak ?? 0) + 1;
+      longestStreak = Math.max(currentStreak, rec.longest_streak ?? 0);
+    } else {
+      currentStreak = 1;
+      longestStreak = Math.max(1, rec.longest_streak ?? 0);
+    }
+  }
+
+  sql.exec(
+    `INSERT OR REPLACE INTO streaks (btc_address, current_streak, longest_streak, last_signal_date, total_signals)
+       VALUES (?, ?, ?, ?, ?)`,
+    btcAddress,
+    currentStreak,
+    longestStreak,
+    signalDate,
+    totalSignals
+  );
+
+  return { totalSignals };
+}
+
+/**
+ * Credits a pending referral when this is the agent's first finalized
+ * signal. No-op if no pending referral exists or the agent has already
+ * filed before. Idempotent because the WHERE clause filters out already-
+ * credited rows.
+ */
+function applyReferralCreditOnFirstSignal(
+  sql: DurableObjectState["storage"]["sql"],
+  btcAddress: string,
+  signalId: string,
+  nowIso: string,
+  totalSignals: number
+): void {
+  if (totalSignals !== 1) return;
+  const pendingRef = sql
+    .exec(
+      "SELECT id FROM referral_credits WHERE recruit_address = ? AND credited_at IS NULL",
+      btcAddress
+    )
+    .toArray();
+  if (pendingRef.length === 0) return;
+  sql.exec(
+    "UPDATE referral_credits SET credited_at = ?, first_signal_id = ? WHERE recruit_address = ? AND credited_at IS NULL",
+    nowIso,
+    signalId,
+    btcAddress
+  );
+}
+
+/**
+ * Flips an already-staged signals row from `pending_payment` → `submitted`,
+ * stamps `payment_txid`, and runs the streak / correspondent_stats /
+ * referral commit effects that were intentionally deferred at stage time.
+ *
+ * Idempotent: the status-flip UPDATE is bounded by `status='pending_payment'`,
+ * and the commit effects only run when that flip changes the row (verified
+ * by re-reading the row before vs after). Concurrent poll+sweep finalises
+ * settle to a single set of side effects.
  */
 function finalizeSignalSubmission(payload: PaymentStagePayload, ctx: FinalizeContext): void {
   const p = payload as Extract<PaymentStagePayload, { kind: "signal_submission" }>;
+
+  const before = ctx.sql
+    .exec(
+      "SELECT status, created_at, correction_of FROM signals WHERE id = ?",
+      p.signal_id
+    )
+    .toArray();
+  if (before.length === 0) return;
+  const row = before[0] as { status: string; created_at: string; correction_of: string | null };
+  if (row.status !== "pending_payment") return;
+
   ctx.sql.exec(
     `UPDATE signals
         SET status = 'submitted',
@@ -456,6 +584,14 @@ function finalizeSignalSubmission(payload: PaymentStagePayload, ctx: FinalizeCon
     ctx.now,
     p.signal_id
   );
+
+  // Corrections are excluded from streaks / stats / referrals by the same
+  // rules the createSignal path applies (see news-do.ts createSignal flow).
+  if (row.correction_of !== null) return;
+
+  applyCorrespondentStatsBump(ctx.sql, p.btc_address, row.created_at);
+  const { totalSignals } = applyStreakBumpForSignal(ctx.sql, p.btc_address, row.created_at);
+  applyReferralCreditOnFirstSignal(ctx.sql, p.btc_address, p.signal_id, ctx.now, totalSignals);
 }
 
 const FINALIZE_REGISTRY: Record<PaymentStageKind, FinalizeFn> = {
@@ -2742,13 +2878,13 @@ export class NewsDO extends DurableObject<Env> {
       const now = new Date();
       const nowIso = now.toISOString();
 
-      // UTC date helpers (used for daily cap and streak)
+      // UTC date helpers (used for daily cap)
       const today = getUTCDate(now);
-      const yesterday = getUTCYesterday(now);
       const todayStart = getUTCDayStart(today);
 
       // Daily signal cap per agent — counts ALL signals including corrections
-      // (Previously excluded correction_of, allowing unlimited daily corrections)
+      // and pending_payment stages (the slot is reserved at stage time so the
+      // cap can't be bypassed by spamming unpaid stages).
       const dailyCountRows = this.ctx.storage.sql
         .exec(
           `SELECT COUNT(*) as count FROM signals
@@ -2779,7 +2915,13 @@ export class NewsDO extends DurableObject<Env> {
         return res;
       }
 
-      const signalId = generateId();
+      // x402 stage path: caller provides a provisional signal_id when staging
+      // a pending_payment row. This lets the route return the id in the 202
+      // response so agents can poll status before payment finalises.
+      const stagedPending = body.pending_payment === true;
+      const providedSignalId = typeof body.signal_id === "string" ? body.signal_id.trim() : "";
+      const signalId = providedSignalId.length > 0 ? providedSignalId : generateId();
+
       const sourcesJson = JSON.stringify(sources ?? []);
       const sanitizedBody = signalBody ? sanitizeString(signalBody, 1000) : null;
       const signalTags = (tags as string[]) ?? [];
@@ -2795,39 +2937,14 @@ export class NewsDO extends DurableObject<Env> {
         disclosure,
       });
 
-      // Streak calculation (UTC)
-      const streakRows = this.ctx.storage.sql
-        .exec("SELECT * FROM streaks WHERE btc_address = ?", btc_address as string)
-        .toArray();
-
-      let currentStreak = 1;
-      let longestStreak = 1;
-      let totalSignals = 1;
-      const currentStreakRecord = streakRows[0] as unknown as Streak | undefined;
-
-      if (currentStreakRecord) {
-        totalSignals = (currentStreakRecord.total_signals ?? 0) + 1;
-        if (currentStreakRecord.last_signal_date === today) {
-          // Already filed today (UTC) — no streak change, but always count the new signal
-          currentStreak = currentStreakRecord.current_streak ?? 1;
-          longestStreak = currentStreakRecord.longest_streak ?? 1;
-        } else if (currentStreakRecord.last_signal_date === yesterday) {
-          // Consecutive day — increment streak
-          currentStreak = (currentStreakRecord.current_streak ?? 0) + 1;
-          longestStreak = Math.max(currentStreak, currentStreakRecord.longest_streak ?? 0);
-        } else {
-          // Gap — reset streak
-          currentStreak = 1;
-          longestStreak = Math.max(1, currentStreakRecord.longest_streak ?? 0);
-        }
-      }
-
-      // Insert signal, tags, and streak as individual statements.
-      // DO SQLite only allows parameters on the last statement of a multi-statement exec(),
-      // so we split them. Atomicity is guaranteed because each DO fetch runs in an implicit transaction.
+      // Insert the signal row. When stagedPending the row lands at
+      // status='pending_payment' and the streak / correspondent_stats /
+      // referral commit effects are deferred until finalizeSignalSubmission
+      // — that keeps the agent's visible totals in sync with finalized
+      // signals only, even if a payment is later discarded.
       this.ctx.storage.sql.exec(
         `INSERT INTO signals (id, beat_slug, btc_address, headline, body, sources, created_at, updated_at, correction_of, status, disclosure, quality_score, score_breakdown)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, 'submitted', ?, ?, ?)`,
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?)`,
         signalId,
         beat_slug as string,
         btc_address as string,
@@ -2836,13 +2953,11 @@ export class NewsDO extends DurableObject<Env> {
         sourcesJson,
         nowIso,
         nowIso,
+        stagedPending ? "pending_payment" : "submitted",
         disclosure,
         signalScore.total,
         JSON.stringify(signalScore.breakdown)
       );
-
-      // Maintain materialised per-agent aggregate (replaces full-table GROUP BY scans).
-      this.bumpCorrespondentStatsForInsert(btc_address as string, nowIso);
 
       for (const t of signalTags) {
         this.ctx.storage.sql.exec(
@@ -2852,35 +2967,20 @@ export class NewsDO extends DurableObject<Env> {
         );
       }
 
-      this.ctx.storage.sql.exec(
-        `INSERT OR REPLACE INTO streaks (btc_address, current_streak, longest_streak, last_signal_date, total_signals)
-           VALUES (?, ?, ?, ?, ?)`,
-        btc_address as string,
-        currentStreak,
-        longestStreak,
-        today,
-        totalSignals
-      );
-
-      // Credit referral on first signal — if a scout registered a referral
-      // for this agent and they haven't been credited yet, credit now.
-      // Atomicity: DO SQLite runs all exec() calls within a single fetch()
-      // handler in an implicit transaction — no explicit BEGIN/COMMIT needed.
-      if (totalSignals === 1) {
-        const pendingRef = this.ctx.storage.sql
-          .exec(
-            "SELECT id FROM referral_credits WHERE recruit_address = ? AND credited_at IS NULL",
-            btc_address as string
-          )
-          .toArray();
-        if (pendingRef.length > 0) {
-          this.ctx.storage.sql.exec(
-            "UPDATE referral_credits SET credited_at = ?, first_signal_id = ? WHERE recruit_address = ? AND credited_at IS NULL",
-            nowIso,
-            signalId,
-            btc_address as string
-          );
-        }
+      if (!stagedPending) {
+        applyCorrespondentStatsBump(this.ctx.storage.sql, btc_address as string, nowIso);
+        const { totalSignals } = applyStreakBumpForSignal(
+          this.ctx.storage.sql,
+          btc_address as string,
+          nowIso
+        );
+        applyReferralCreditOnFirstSignal(
+          this.ctx.storage.sql,
+          btc_address as string,
+          signalId,
+          nowIso,
+          totalSignals
+        );
       }
 
       // Fetch the created signal with tags
@@ -5845,34 +5945,6 @@ export class NewsDO extends DurableObject<Env> {
   }
 
   /**
-   * Maintain `correspondent_stats` after inserting a non-correction signal.
-   *
-   * Counters: signal_count++, last/first signal-at min/max bumps. days_active
-   * is recomputed via a per-agent COUNT(DISTINCT date(...)) bounded by the
-   * agent's own signal history (typical ~200–600 rows) — much smaller than
-   * the full-table 27.8K-row scan it replaces. Skipped for corrections;
-   * those rows have correction_of != NULL and are excluded from every
-   * aggregate by definition.
-   */
-  private bumpCorrespondentStatsForInsert(btcAddress: string, createdAt: string): void {
-    this.ctx.storage.sql.exec(
-      `INSERT INTO correspondent_stats (btc_address, signal_count, last_signal_at, first_signal_at, days_active, updated_at)
-       VALUES (?1, 1, ?2, ?2, 1, datetime('now'))
-       ON CONFLICT(btc_address) DO UPDATE SET
-         signal_count = correspondent_stats.signal_count + 1,
-         last_signal_at = MAX(correspondent_stats.last_signal_at, excluded.last_signal_at),
-         first_signal_at = MIN(correspondent_stats.first_signal_at, excluded.first_signal_at),
-         days_active = (
-           SELECT COUNT(DISTINCT date(created_at)) FROM signals
-           WHERE btc_address = ?1 AND correction_of IS NULL
-         ),
-         updated_at = datetime('now')`,
-      btcAddress,
-      createdAt
-    );
-  }
-
-  /**
    * Compare the materialised `correspondent_stats` table to a fresh
    * aggregate over `signals`, returning per-field mismatches plus the
    * unique set of drifted addresses. Shared between the publisher-only
@@ -5901,6 +5973,7 @@ export class NewsDO extends DurableObject<Env> {
                 COUNT(DISTINCT date(created_at)) as days_active
            FROM signals
           WHERE correction_of IS NULL
+            AND status != 'pending_payment'
           GROUP BY btc_address`
       )
       .toArray() as Row[];
@@ -5959,7 +6032,9 @@ export class NewsDO extends DurableObject<Env> {
                   MIN(created_at) as first_at,
                   COUNT(DISTINCT date(created_at)) as days
            FROM signals
-           WHERE btc_address = ? AND correction_of IS NULL`,
+           WHERE btc_address = ?
+             AND correction_of IS NULL
+             AND status != 'pending_payment'`,
           btcAddress
         )
         .toArray();

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -2942,9 +2942,12 @@ export class NewsDO extends DurableObject<Env> {
       // referral commit effects are deferred until finalizeSignalSubmission
       // — that keeps the agent's visible totals in sync with finalized
       // signals only, even if a payment is later discarded.
+      const paymentTxid = typeof body.payment_txid === "string" && body.payment_txid.trim().length > 0
+        ? body.payment_txid.trim()
+        : null;
       this.ctx.storage.sql.exec(
-        `INSERT INTO signals (id, beat_slug, btc_address, headline, body, sources, created_at, updated_at, correction_of, status, disclosure, quality_score, score_breakdown)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?)`,
+        `INSERT INTO signals (id, beat_slug, btc_address, headline, body, sources, created_at, updated_at, correction_of, status, disclosure, quality_score, score_breakdown, payment_txid)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?)`,
         signalId,
         beat_slug as string,
         btc_address as string,
@@ -2956,7 +2959,8 @@ export class NewsDO extends DurableObject<Env> {
         stagedPending ? "pending_payment" : "submitted",
         disclosure,
         signalScore.total,
-        JSON.stringify(signalScore.breakdown)
+        JSON.stringify(signalScore.breakdown),
+        paymentTxid
       );
 
       for (const t of signalTags) {

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -464,6 +464,44 @@ const FINALIZE_REGISTRY: Record<PaymentStageKind, FinalizeFn> = {
   signal_submission: finalizeSignalSubmission,
 };
 
+type DiscardFn = (payload: PaymentStagePayload, ctx: FinalizeContext) => void;
+
+const noopDiscard: DiscardFn = () => {};
+
+/**
+ * Releases the cooldown / daily-cap slot held by a staged signal whose
+ * payment was rejected (failed / replaced / not_found). Deletes the
+ * signals row plus its signal_tags so the agent can re-stage immediately.
+ *
+ * Note on stats drift: the stage-time INSERT bumps correspondent_stats.
+ * Discard does not decrement — discards are rare under a stable relay,
+ * and any drift is reconciled by POST /api/config/recon-correspondents.
+ * See docs/x402-signal-payment-plan.md item 11 for the trade-off.
+ */
+function discardSignalSubmission(payload: PaymentStagePayload, ctx: FinalizeContext): void {
+  const p = payload as Extract<PaymentStagePayload, { kind: "signal_submission" }>;
+  ctx.sql.exec(
+    "DELETE FROM signal_tags WHERE signal_id = ?",
+    p.signal_id
+  );
+  ctx.sql.exec(
+    "DELETE FROM signals WHERE id = ? AND status = 'pending_payment'",
+    p.signal_id
+  );
+}
+
+/**
+ * Discard hooks run when a staged payment reaches a non-confirmed terminal
+ * state. Most kinds have nothing to undo (their finalize side effects only
+ * fire on `confirmed`); signal_submission is the exception because its
+ * stage-time write reserves the cooldown slot eagerly.
+ */
+const DISCARD_REGISTRY: Record<PaymentStageKind, DiscardFn> = {
+  brief_access: noopDiscard,
+  classified_submission: noopDiscard,
+  signal_submission: discardSignalSubmission,
+};
+
 /**
  * Apply a terminal reconciliation decision to a single staged payment row.
  * Shared by the /payment-staging/:paymentId/reconcile route (poll-driven) and
@@ -506,6 +544,9 @@ function reconcileStageRow(
       paymentId
     );
   } else if (status === "failed" || status === "replaced" || status === "not_found") {
+    const discard = DISCARD_REGISTRY[staged.kind];
+    discard(staged.payload, { sql, paymentId, now, txid });
+
     sql.exec(
       `UPDATE payment_staging
           SET stage_status = 'discarded',

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -5,14 +5,22 @@ import type { Env, Beat, Signal, SignalStatus, Streak, Brief, Classified, Classi
 import { validateSlug, validateHexColor, sanitizeString, validateDateFormat } from "../lib/validators";
 import { generateId, getUTCDate, getUTCYesterday, getUTCDayStart, getUTCDayEnd, getNextDate } from "../lib/helpers";
 import { CLASSIFIED_DURATION_DAYS, CLASSIFIED_BRIEF_SLOTS, CLASSIFIED_BRIEF_MAX_CHARS, CLASSIFIED_STATUSES, SIGNAL_COOLDOWN_HOURS, BEAT_EXPIRY_DAYS, MAX_SIGNALS_PER_DAY, MAX_INCLUDED_SIGNALS_PER_BRIEF, MAX_APPROVED_SIGNALS_PER_DAY, SIGNAL_STATUSES, REVIEWABLE_SIGNAL_STATUSES, CONFIG_PUBLISHER_ADDRESS, BRIEF_INCLUSION_PAYOUT_SATS, WEEKLY_PRIZE_1ST_SATS, WEEKLY_PRIZE_2ND_SATS, WEEKLY_PRIZE_3RD_SATS, SCORING_WEIGHTS, PAYMENT_STAGE_TTL_MS } from "../lib/constants";
-import { SCHEMA_SQL, MIGRATION_PHASE0_SQL, MIGRATION_PAYMENTS_SQL, MIGRATION_BEAT_RESTRUCTURE_SQL, MIGRATION_SBTC_TRACKING_SQL, MIGRATION_CLASSIFIEDS_CLEANUP_SQL, MIGRATION_CLASSIFIEDS_REVIEW_SQL, MIGRATION_SNAPSHOTS_SQL, MIGRATION_BEAT_CLAIMS_SQL, MIGRATION_RETRACTION_SQL, MIGRATION_BEAT_NETWORK_FOCUS_SQL, MIGRATION_BITCOIN_MACRO_SQL, MIGRATION_QUANTUM_BEAT_SQL, MIGRATION_PAYMENT_STAGING_SQL, MIGRATION_APPROVAL_CAP_INDEX_SQL, MIGRATION_BEAT_EDITORS_SQL, MIGRATION_EDITORIAL_REVIEWS_SQL, MIGRATION_EDITOR_REVIEW_RATE_SQL, MIGRATION_CURATION_CLEANUP_SQL, MIGRATION_LEADERBOARD_INDEXES_SQL, MIGRATION_BEAT_CONSOLIDATION_SQL, MIGRATION_SIGNAL_SCORING_SQL, MIGRATION_APR7_EARNINGS_SQL, MIGRATION_CLASSIFIEDS_TXID_UNIQUE_SQL, MIGRATION_SIGNAL_HOT_PATH_INDEXES_SQL, MIGRATION_CORRESPONDENTS_BUNDLE_INDEXES_SQL, MIGRATION_CORRESPONDENT_STATS_SQL } from "./schema";
+import { SCHEMA_SQL, MIGRATION_PHASE0_SQL, MIGRATION_PAYMENTS_SQL, MIGRATION_BEAT_RESTRUCTURE_SQL, MIGRATION_SBTC_TRACKING_SQL, MIGRATION_CLASSIFIEDS_CLEANUP_SQL, MIGRATION_CLASSIFIEDS_REVIEW_SQL, MIGRATION_SNAPSHOTS_SQL, MIGRATION_BEAT_CLAIMS_SQL, MIGRATION_RETRACTION_SQL, MIGRATION_BEAT_NETWORK_FOCUS_SQL, MIGRATION_BITCOIN_MACRO_SQL, MIGRATION_QUANTUM_BEAT_SQL, MIGRATION_PAYMENT_STAGING_SQL, MIGRATION_APPROVAL_CAP_INDEX_SQL, MIGRATION_BEAT_EDITORS_SQL, MIGRATION_EDITORIAL_REVIEWS_SQL, MIGRATION_EDITOR_REVIEW_RATE_SQL, MIGRATION_CURATION_CLEANUP_SQL, MIGRATION_LEADERBOARD_INDEXES_SQL, MIGRATION_BEAT_CONSOLIDATION_SQL, MIGRATION_SIGNAL_SCORING_SQL, MIGRATION_APR7_EARNINGS_SQL, MIGRATION_CLASSIFIEDS_TXID_UNIQUE_SQL, MIGRATION_SIGNAL_HOT_PATH_INDEXES_SQL, MIGRATION_CORRESPONDENTS_BUNDLE_INDEXES_SQL, MIGRATION_CORRESPONDENT_STATS_SQL, MIGRATION_SIGNAL_PAYMENT_SQL } from "./schema";
 import { scoreSignal } from "../lib/signal-scorer";
 
 // ── State machine transition maps ──
 // Hoisted to module level so they are created once and are testable.
 
-/** Valid editorial transitions for signals: submitted → approved/rejected → brief_included */
+/**
+ * Valid editorial transitions for signals: submitted → approved/rejected → brief_included.
+ *
+ * `pending_payment` → `submitted` is intentionally absent here: the transition
+ * is performed by `finalizeSignalSubmission` outside the editorial state
+ * machine (the pending row is not yet visible to reviewers). No editorial
+ * transitions originate from `pending_payment`.
+ */
 export const SIGNAL_VALID_TRANSITIONS: Record<SignalStatus, SignalStatus[]> = {
+  pending_payment: [],
   submitted: ["approved", "rejected"],
   approved: ["replaced", "rejected", "brief_included"],
   replaced: ["approved", "rejected"],
@@ -373,6 +381,90 @@ function getPaymentStageRow(
 }
 
 /**
+ * Context object handed to each finalize callback. `sql` is the DO's SQL
+ * storage handle; `paymentId` and `now` are precomputed by the dispatcher
+ * for consistency across writes; `txid` is the on-chain settlement txid
+ * reported by the relay (preferred over any payload-embedded txid).
+ */
+type FinalizeContext = {
+  sql: DurableObjectState["storage"]["sql"];
+  paymentId: string;
+  now: string;
+  txid?: string;
+};
+
+type FinalizeFn = (payload: PaymentStagePayload, ctx: FinalizeContext) => void;
+
+/**
+ * Inserts the classified row that the agent paid for. INSERT OR IGNORE
+ * keeps the call idempotent under poll+sweep reconcile races.
+ */
+function finalizeClassifiedSubmission(payload: PaymentStagePayload, ctx: FinalizeContext): void {
+  const p = payload as Extract<PaymentStagePayload, { kind: "classified_submission" }>;
+  ctx.sql.exec(
+    `INSERT OR IGNORE INTO classifieds
+       (id, btc_address, category, headline, body, payment_txid, status, created_at, expires_at)
+     VALUES (?, ?, ?, ?, ?, ?, 'pending_review', ?, ?)`,
+    p.classified_id,
+    p.btc_address,
+    p.category,
+    p.headline,
+    p.body,
+    ctx.txid ?? p.payment_txid,
+    ctx.now,
+    ctx.now
+  );
+}
+
+/**
+ * Records brief-revenue earnings for the paying address (if any). No-op
+ * when payload.payer is null — payer is only resolved for authenticated
+ * brief unlocks. INSERT OR IGNORE keeps it idempotent.
+ */
+function finalizeBriefAccess(payload: PaymentStagePayload, ctx: FinalizeContext): void {
+  const p = payload as Extract<PaymentStagePayload, { kind: "brief_access" }>;
+  if (!p.payer) return;
+  ctx.sql.exec(
+    `INSERT OR IGNORE INTO earnings
+       (id, btc_address, amount_sats, reason, reference_id, created_at)
+     VALUES (?, ?, ?, 'brief-revenue', ?, ?)`,
+    generateId(),
+    p.payer,
+    p.amount_sats,
+    ctx.paymentId,
+    ctx.now
+  );
+}
+
+/**
+ * Flips an already-staged signals row from `pending_payment` → `submitted`
+ * and stamps `payment_txid`. The signal content was inserted at stage time,
+ * so finalize is a status-only update; the WHERE clause restricts the
+ * update to the matching pending row, making concurrent poll+sweep finalises
+ * a no-op on the second run.
+ */
+function finalizeSignalSubmission(payload: PaymentStagePayload, ctx: FinalizeContext): void {
+  const p = payload as Extract<PaymentStagePayload, { kind: "signal_submission" }>;
+  ctx.sql.exec(
+    `UPDATE signals
+        SET status = 'submitted',
+            payment_txid = COALESCE(?, payment_txid),
+            updated_at = ?
+      WHERE id = ?
+        AND status = 'pending_payment'`,
+    ctx.txid ?? p.payment_txid,
+    ctx.now,
+    p.signal_id
+  );
+}
+
+const FINALIZE_REGISTRY: Record<PaymentStageKind, FinalizeFn> = {
+  brief_access: finalizeBriefAccess,
+  classified_submission: finalizeClassifiedSubmission,
+  signal_submission: finalizeSignalSubmission,
+};
+
+/**
  * Apply a terminal reconciliation decision to a single staged payment row.
  * Shared by the /payment-staging/:paymentId/reconcile route (poll-driven) and
  * the alarm sweep (backend-driven). Returns the row after the write, or null
@@ -397,36 +489,8 @@ function reconcileStageRow(
   const now = new Date().toISOString();
 
   if (status === "confirmed") {
-    if (staged.kind === "classified_submission") {
-      const payload = staged.payload as Extract<PaymentStagePayload, { kind: "classified_submission" }>;
-      sql.exec(
-        `INSERT OR IGNORE INTO classifieds
-           (id, btc_address, category, headline, body, payment_txid, status, created_at, expires_at)
-         VALUES (?, ?, ?, ?, ?, ?, 'pending_review', ?, ?)`,
-        payload.classified_id,
-        payload.btc_address,
-        payload.category,
-        payload.headline,
-        payload.body,
-        txid ?? payload.payment_txid,
-        now,
-        now
-      );
-    } else if (staged.kind === "brief_access") {
-      const payload = staged.payload as Extract<PaymentStagePayload, { kind: "brief_access" }>;
-      if (payload.payer) {
-        sql.exec(
-          `INSERT OR IGNORE INTO earnings
-             (id, btc_address, amount_sats, reason, reference_id, created_at)
-           VALUES (?, ?, ?, 'brief-revenue', ?, ?)`,
-          generateId(),
-          payload.payer,
-          payload.amount_sats,
-          paymentId,
-          now
-        );
-      }
-    }
+    const finalize = FINALIZE_REGISTRY[staged.kind];
+    finalize(staged.payload, { sql, paymentId, now, txid });
 
     sql.exec(
       `UPDATE payment_staging
@@ -713,7 +777,7 @@ export class NewsDO extends DurableObject<Env> {
     // 26 = Partial UNIQUE index on classifieds.payment_txid for replay protection across both placement paths
     // 27 = Signal hot-path composite indexes for Cloudflare bill reduction
     // 28 = Correspondents bundle composite indexes for DO timeout reduction
-    const CURRENT_MIGRATION_VERSION = 29;
+    const CURRENT_MIGRATION_VERSION = 30;
     const versionRows = this.ctx.storage.sql
       .exec("SELECT value FROM config WHERE key = 'migration_version'")
       .toArray();
@@ -1146,6 +1210,22 @@ export class NewsDO extends DurableObject<Env> {
         }
       }
 
+      // Signal payment columns — `payment_txid` for finalised x402 signal
+      // submissions plus a (status, btc_address, created_at) index that keeps
+      // cooldown/daily-cap queries fast as `pending_payment` rows accumulate.
+      if (appliedVersion < 30) {
+        for (const stmt of MIGRATION_SIGNAL_PAYMENT_SQL) {
+          try {
+            this.ctx.storage.sql.exec(stmt);
+          } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            if (!msg.includes("already exists") && !msg.includes("duplicate column name")) {
+              console.error("Signal payment migration failed:", e);
+            }
+          }
+        }
+      }
+
       // Record current migration version so future cold starts skip all of the above.
       // If migration 22 failed but later migrations succeeded, cap at 21 so v22 retries
       // on next cold start.
@@ -1344,7 +1424,11 @@ export class NewsDO extends DurableObject<Env> {
         );
       }
       const stageKind = body.payload.kind;
-      if (stageKind !== "brief_access" && stageKind !== "classified_submission") {
+      if (
+        stageKind !== "brief_access" &&
+        stageKind !== "classified_submission" &&
+        stageKind !== "signal_submission"
+      ) {
         return c.json(
           { ok: false, error: `Unsupported payment stage kind: ${stageKind as string}` } satisfies DOResult<PaymentStageMaterialized>,
           400

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -81,12 +81,22 @@ interface SignalListFilters {
   status: string | null;
   dateStart: string | null;
   dateEnd: string | null;
+  /**
+   * When false (default), `pending_payment` rows are excluded — staged-but-
+   * unconfirmed signals stay invisible to the public listings, leaderboard,
+   * and counts. Authors viewing their own staged rows pass true (or set
+   * status='pending_payment' explicitly) to see them.
+   */
+  includePending: boolean;
 }
 
 interface SignalCountFilters {
   beat: string | null;
   agent: string | null;
   since: string | null;
+  /** See SignalListFilters.includePending. When true the count response
+   *  carries a separate pending_payment bucket. */
+  includePending: boolean;
 }
 
 function appendSignalScopeFilters(
@@ -121,6 +131,11 @@ function buildSignalListWhere(filters: SignalListFilters): { whereSql: string; p
   if (filters.status) {
     clauses.push("s.status = ?");
     params.push(filters.status);
+  } else if (!filters.includePending) {
+    // Default listings hide x402-staged-but-unconfirmed rows. An explicit
+    // status filter (including status=pending_payment) bypasses this; a
+    // caller passing includePending=true bypasses it too.
+    clauses.push("s.status != 'pending_payment'");
   }
   if (filters.dateStart) {
     clauses.push("s.created_at >= ?");
@@ -190,7 +205,11 @@ function querySignalCountRows(
     return Number((countRows[0] as { count: number } | undefined)?.count) || 0;
   };
 
-  for (const status of COUNTED_SIGNAL_STATUSES) {
+  const statuses: readonly string[] = filters.includePending
+    ? [...COUNTED_SIGNAL_STATUSES, "pending_payment"]
+    : COUNTED_SIGNAL_STATUSES;
+
+  for (const status of statuses) {
     const reviewedStatus = (REVIEWED_SIGNAL_STATUSES as readonly string[]).includes(status);
     const baseClauses = ["s.status = ?"];
     const baseParams: SqlParam[] = [status];
@@ -2601,6 +2620,7 @@ export class NewsDO extends DurableObject<Env> {
       const since = c.req.query("since") ?? null;
       const tag = c.req.query("tag") ?? null;
       const status = c.req.query("status") ?? null;
+      const includePending = c.req.query("include_pending") === "true";
       const dateParam = c.req.query("date") ?? null;
       const limitParam = c.req.query("limit");
       const limit = Math.min(
@@ -2626,6 +2646,7 @@ export class NewsDO extends DurableObject<Env> {
         status,
         dateStart,
         dateEnd,
+        includePending,
       });
       const pageLimit = limit + 1;
 
@@ -2756,8 +2777,17 @@ export class NewsDO extends DurableObject<Env> {
       const agent = c.req.query("agent") ?? null;
       const sinceRaw = c.req.query("since") ?? null;
       const since = sinceRaw && sinceRaw.trim() !== "" ? sinceRaw : null;
+      // pending_payment is included when an agent scope is set (an author is
+      // looking at their own staged count) or when the caller asks for it.
+      const includePending =
+        c.req.query("include_pending") === "true" || agent !== null;
 
-      const rows = querySignalCountRows(this.ctx.storage.sql, { beat, agent, since });
+      const rows = querySignalCountRows(this.ctx.storage.sql, {
+        beat,
+        agent,
+        since,
+        includePending,
+      });
 
       const counts: Record<string, number> = {
         submitted: 0,
@@ -2766,6 +2796,7 @@ export class NewsDO extends DurableObject<Env> {
         rejected: 0,
         brief_included: 0,
       };
+      if (includePending) counts.pending_payment = 0;
       for (const row of rows) {
         const r = row as { status: string; count: number };
         if (r.status in counts) {
@@ -5410,6 +5441,7 @@ export class NewsDO extends DurableObject<Env> {
         beat: null,
         agent: null,
         since: oneHourAgo,
+        includePending: false,
       }).reduce((total, row) => total + row.count, 0);
 
       return c.json({
@@ -6140,6 +6172,7 @@ export class NewsDO extends DurableObject<Env> {
          FROM (
            SELECT DISTINCT btc_address FROM signals
            WHERE correction_of IS NULL
+             AND status != 'pending_payment'
              AND created_at > (SELECT ts FROM epoch)
          ) a
          LEFT JOIN (
@@ -6155,6 +6188,7 @@ export class NewsDO extends DurableObject<Env> {
            SELECT btc_address, COUNT(*) as signal_count
            FROM signals
            WHERE correction_of IS NULL
+             AND status != 'pending_payment'
              AND created_at > datetime('now', '-30 days')
              AND created_at > (SELECT ts FROM epoch)
            GROUP BY btc_address
@@ -6164,6 +6198,7 @@ export class NewsDO extends DurableObject<Env> {
            SELECT btc_address, COUNT(DISTINCT date(created_at)) as days_active
            FROM signals
            WHERE correction_of IS NULL
+             AND status != 'pending_payment'
              AND created_at > datetime('now', '-30 days')
              AND created_at > (SELECT ts FROM epoch)
            GROUP BY btc_address

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -4,7 +4,7 @@ import type { Context } from "hono";
 import type { Env, Beat, Signal, SignalStatus, Streak, Brief, Classified, ClassifiedStatus, Earning, Correction, ReferralCredit, BriefSignal, CompiledBriefData, DOResult, ApprovalCapInfo, PayoutRecord, IncludedSignalMetadata, CompiledSignalRow, PaymentStageKind, PaymentStageLifecycle, PaymentStageMaterialized, PaymentStagePayload, PaymentStageRecord, PaymentTerminalReason, PaymentTrackedState } from "../lib/types";
 import { validateSlug, validateHexColor, sanitizeString, validateDateFormat } from "../lib/validators";
 import { generateId, getUTCDate, getUTCYesterday, getUTCDayStart, getUTCDayEnd, getNextDate } from "../lib/helpers";
-import { CLASSIFIED_DURATION_DAYS, CLASSIFIED_BRIEF_SLOTS, CLASSIFIED_BRIEF_MAX_CHARS, CLASSIFIED_STATUSES, SIGNAL_COOLDOWN_HOURS, BEAT_EXPIRY_DAYS, MAX_SIGNALS_PER_DAY, MAX_INCLUDED_SIGNALS_PER_BRIEF, MAX_APPROVED_SIGNALS_PER_DAY, SIGNAL_STATUSES, REVIEWABLE_SIGNAL_STATUSES, CONFIG_PUBLISHER_ADDRESS, BRIEF_INCLUSION_PAYOUT_SATS, WEEKLY_PRIZE_1ST_SATS, WEEKLY_PRIZE_2ND_SATS, WEEKLY_PRIZE_3RD_SATS, SCORING_WEIGHTS, PAYMENT_STAGE_TTL_MS } from "../lib/constants";
+import { CLASSIFIED_DURATION_DAYS, CLASSIFIED_BRIEF_SLOTS, CLASSIFIED_BRIEF_MAX_CHARS, CLASSIFIED_STATUSES, SIGNAL_COOLDOWN_HOURS, BEAT_EXPIRY_DAYS, MAX_SIGNALS_PER_DAY, MAX_INCLUDED_SIGNALS_PER_BRIEF, MAX_APPROVED_SIGNALS_PER_DAY, SIGNAL_STATUSES, REVIEWABLE_SIGNAL_STATUSES, CONFIG_PUBLISHER_ADDRESS, BRIEF_INCLUSION_PAYOUT_SATS, WEEKLY_PRIZE_1ST_SATS, WEEKLY_PRIZE_2ND_SATS, WEEKLY_PRIZE_3RD_SATS, SCORING_WEIGHTS, PAYMENT_STAGE_TTL_MS, PENDING_PAYMENT_STATUS } from "../lib/constants";
 import { SCHEMA_SQL, MIGRATION_PHASE0_SQL, MIGRATION_PAYMENTS_SQL, MIGRATION_BEAT_RESTRUCTURE_SQL, MIGRATION_SBTC_TRACKING_SQL, MIGRATION_CLASSIFIEDS_CLEANUP_SQL, MIGRATION_CLASSIFIEDS_REVIEW_SQL, MIGRATION_SNAPSHOTS_SQL, MIGRATION_BEAT_CLAIMS_SQL, MIGRATION_RETRACTION_SQL, MIGRATION_BEAT_NETWORK_FOCUS_SQL, MIGRATION_BITCOIN_MACRO_SQL, MIGRATION_QUANTUM_BEAT_SQL, MIGRATION_PAYMENT_STAGING_SQL, MIGRATION_APPROVAL_CAP_INDEX_SQL, MIGRATION_BEAT_EDITORS_SQL, MIGRATION_EDITORIAL_REVIEWS_SQL, MIGRATION_EDITOR_REVIEW_RATE_SQL, MIGRATION_CURATION_CLEANUP_SQL, MIGRATION_LEADERBOARD_INDEXES_SQL, MIGRATION_BEAT_CONSOLIDATION_SQL, MIGRATION_SIGNAL_SCORING_SQL, MIGRATION_APR7_EARNINGS_SQL, MIGRATION_CLASSIFIEDS_TXID_UNIQUE_SQL, MIGRATION_SIGNAL_HOT_PATH_INDEXES_SQL, MIGRATION_CORRESPONDENTS_BUNDLE_INDEXES_SQL, MIGRATION_CORRESPONDENT_STATS_SQL, MIGRATION_SIGNAL_PAYMENT_SQL } from "./schema";
 import { scoreSignal } from "../lib/signal-scorer";
 
@@ -132,10 +132,13 @@ function buildSignalListWhere(filters: SignalListFilters): { whereSql: string; p
     clauses.push("s.status = ?");
     params.push(filters.status);
   } else if (!filters.includePending) {
-    // Default listings hide x402-staged-but-unconfirmed rows. An explicit
-    // status filter (including status=pending_payment) bypasses this; a
-    // caller passing includePending=true bypasses it too.
-    clauses.push("s.status != 'pending_payment'");
+    // Default listings hide x402-staged-but-unconfirmed rows. Use an explicit
+    // IN list (the non-pending statuses) so SQLite can hit
+    // idx_signals_status_created instead of falling back to a range/scan
+    // that an inequality would force.
+    const placeholders = COUNTED_SIGNAL_STATUSES.map(() => "?").join(", ");
+    clauses.push(`s.status IN (${placeholders})`);
+    params.push(...COUNTED_SIGNAL_STATUSES);
   }
   if (filters.dateStart) {
     clauses.push("s.created_at >= ?");
@@ -399,12 +402,8 @@ function getPaymentStageRow(
   return rowToPaymentStage(rows[0] as Record<string, unknown>);
 }
 
-/**
- * Context object handed to each finalize callback. `sql` is the DO's SQL
- * storage handle; `paymentId` and `now` are precomputed by the dispatcher
- * for consistency across writes; `txid` is the on-chain settlement txid
- * reported by the relay (preferred over any payload-embedded txid).
- */
+/** Per-stage commit context. `txid` is the relay-reported on-chain settlement
+ *  and takes precedence over any payload-embedded txid. */
 type FinalizeContext = {
   sql: DurableObjectState["storage"]["sql"];
   paymentId: string;
@@ -414,10 +413,7 @@ type FinalizeContext = {
 
 type FinalizeFn = (payload: PaymentStagePayload, ctx: FinalizeContext) => void;
 
-/**
- * Inserts the classified row that the agent paid for. INSERT OR IGNORE
- * keeps the call idempotent under poll+sweep reconcile races.
- */
+/** INSERT OR IGNORE keeps the call idempotent under poll+sweep reconcile races. */
 function finalizeClassifiedSubmission(payload: PaymentStagePayload, ctx: FinalizeContext): void {
   const p = payload as Extract<PaymentStagePayload, { kind: "classified_submission" }>;
   ctx.sql.exec(
@@ -435,11 +431,8 @@ function finalizeClassifiedSubmission(payload: PaymentStagePayload, ctx: Finaliz
   );
 }
 
-/**
- * Records brief-revenue earnings for the paying address (if any). No-op
- * when payload.payer is null — payer is only resolved for authenticated
- * brief unlocks. INSERT OR IGNORE keeps it idempotent.
- */
+/** No-op when payload.payer is null — payer is only resolved for authenticated
+ *  brief unlocks. INSERT OR IGNORE keeps it idempotent. */
 function finalizeBriefAccess(payload: PaymentStagePayload, ctx: FinalizeContext): void {
   const p = payload as Extract<PaymentStagePayload, { kind: "brief_access" }>;
   if (!p.payer) return;
@@ -455,16 +448,8 @@ function finalizeBriefAccess(payload: PaymentStagePayload, ctx: FinalizeContext)
   );
 }
 
-/**
- * Bumps the materialised correspondent_stats row for a paid signal that is
- * landing on `submitted`. Mirrors the semantics of the legacy class method
- * (signal_count++, last/first_signal_at min/max, days_active recomputed)
- * but excludes `pending_payment` rows from the days_active subquery so a
- * still-staged signal does not inflate the visible total.
- *
- * Free function form so the finalize registry can call it; the createSignal
- * route handler wraps it with `applyCorrespondentStatsBumpForInsert`.
- */
+/** days_active subquery excludes pending_payment so a still-staged signal does
+ *  not inflate the visible total — the bump runs only on finalize. */
 function applyCorrespondentStatsBump(
   sql: DurableObjectState["storage"]["sql"],
   btcAddress: string,
@@ -489,13 +474,8 @@ function applyCorrespondentStatsBump(
   );
 }
 
-/**
- * Updates the streaks row for a finalized (non-correction) signal. Computes
- * day-over-day continuation from the streaks record's previous
- * `last_signal_date`, anchored to the *signal's* UTC date — not the moment
- * of finalization — so that an x402 settlement that crosses a UTC midnight
- * still credits the day the agent actually filed.
- */
+/** Anchored to the signal's UTC date — not the finalize time — so an x402
+ *  settlement that crosses a UTC midnight still credits the day filed. */
 function applyStreakBumpForSignal(
   sql: DurableObjectState["storage"]["sql"],
   btcAddress: string,
@@ -540,12 +520,6 @@ function applyStreakBumpForSignal(
   return { totalSignals };
 }
 
-/**
- * Credits a pending referral when this is the agent's first finalized
- * signal. No-op if no pending referral exists or the agent has already
- * filed before. Idempotent because the WHERE clause filters out already-
- * credited rows.
- */
 function applyReferralCreditOnFirstSignal(
   sql: DurableObjectState["storage"]["sql"],
   btcAddress: string,
@@ -569,16 +543,9 @@ function applyReferralCreditOnFirstSignal(
   );
 }
 
-/**
- * Flips an already-staged signals row from `pending_payment` → `submitted`,
- * stamps `payment_txid`, and runs the streak / correspondent_stats /
- * referral commit effects that were intentionally deferred at stage time.
- *
- * Idempotent: the status-flip UPDATE is bounded by `status='pending_payment'`,
- * and the commit effects only run when that flip changes the row (verified
- * by re-reading the row before vs after). Concurrent poll+sweep finalises
- * settle to a single set of side effects.
- */
+/** Idempotent under concurrent poll+sweep finalises: the pre-SELECT short-
+ *  circuits when the row has already flipped, and the UPDATE's WHERE clause
+ *  is bounded to `status='pending_payment'`. */
 function finalizeSignalSubmission(payload: PaymentStagePayload, ctx: FinalizeContext): void {
   const p = payload as Extract<PaymentStagePayload, { kind: "signal_submission" }>;
 
@@ -590,7 +557,7 @@ function finalizeSignalSubmission(payload: PaymentStagePayload, ctx: FinalizeCon
     .toArray();
   if (before.length === 0) return;
   const row = before[0] as { status: string; created_at: string; correction_of: string | null };
-  if (row.status !== "pending_payment") return;
+  if (row.status !== PENDING_PAYMENT_STATUS) return;
 
   ctx.sql.exec(
     `UPDATE signals
@@ -604,8 +571,9 @@ function finalizeSignalSubmission(payload: PaymentStagePayload, ctx: FinalizeCon
     p.signal_id
   );
 
-  // Corrections are excluded from streaks / stats / referrals by the same
-  // rules the createSignal path applies (see news-do.ts createSignal flow).
+  // Corrections are routed through PATCH /signals/:id, never POST, so a
+  // signal_submission stage is non-correction by construction. The guard
+  // is defensive in case future code paths stage a correction.
   if (row.correction_of !== null) return;
 
   applyCorrespondentStatsBump(ctx.sql, p.btc_address, row.created_at);
@@ -619,20 +587,11 @@ const FINALIZE_REGISTRY: Record<PaymentStageKind, FinalizeFn> = {
   signal_submission: finalizeSignalSubmission,
 };
 
-type DiscardFn = (payload: PaymentStagePayload, ctx: FinalizeContext) => void;
+const noopDiscard: FinalizeFn = () => {};
 
-const noopDiscard: DiscardFn = () => {};
-
-/**
- * Releases the cooldown / daily-cap slot held by a staged signal whose
- * payment was rejected (failed / replaced / not_found). Deletes the
- * signals row plus its signal_tags so the agent can re-stage immediately.
- *
- * Note on stats drift: the stage-time INSERT bumps correspondent_stats.
- * Discard does not decrement — discards are rare under a stable relay,
- * and any drift is reconciled by POST /api/config/recon-correspondents.
- * See docs/x402-signal-payment-plan.md item 11 for the trade-off.
- */
+/** Releases the cooldown / daily-cap slot held by a staged signal whose
+ *  payment was rejected. brief_access and classified_submission stages have
+ *  nothing to undo because their commit effects only run on `confirmed`. */
 function discardSignalSubmission(payload: PaymentStagePayload, ctx: FinalizeContext): void {
   const p = payload as Extract<PaymentStagePayload, { kind: "signal_submission" }>;
   ctx.sql.exec(
@@ -645,13 +604,7 @@ function discardSignalSubmission(payload: PaymentStagePayload, ctx: FinalizeCont
   );
 }
 
-/**
- * Discard hooks run when a staged payment reaches a non-confirmed terminal
- * state. Most kinds have nothing to undo (their finalize side effects only
- * fire on `confirmed`); signal_submission is the exception because its
- * stage-time write reserves the cooldown slot eagerly.
- */
-const DISCARD_REGISTRY: Record<PaymentStageKind, DiscardFn> = {
+const DISCARD_REGISTRY: Record<PaymentStageKind, FinalizeFn> = {
   brief_access: noopDiscard,
   classified_submission: noopDiscard,
   signal_submission: discardSignalSubmission,
@@ -2946,9 +2899,6 @@ export class NewsDO extends DurableObject<Env> {
         return res;
       }
 
-      // x402 stage path: caller provides a provisional signal_id when staging
-      // a pending_payment row. This lets the route return the id in the 202
-      // response so agents can poll status before payment finalises.
       const stagedPending = body.pending_payment === true;
       const providedSignalId = typeof body.signal_id === "string" ? body.signal_id.trim() : "";
       const signalId = providedSignalId.length > 0 ? providedSignalId : generateId();

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -2730,10 +2730,10 @@ export class NewsDO extends DurableObject<Env> {
       const agent = c.req.query("agent") ?? null;
       const sinceRaw = c.req.query("since") ?? null;
       const since = sinceRaw && sinceRaw.trim() !== "" ? sinceRaw : null;
-      // pending_payment is included when an agent scope is set (an author is
-      // looking at their own staged count) or when the caller asks for it.
-      const includePending =
-        c.req.query("include_pending") === "true" || agent !== null;
+      // pending_payment is included only when the caller opts in. The route
+      // layer is responsible for gating include_pending behind BIP-322 auth
+      // matching the agent — see src/routes/signal-counts.ts.
+      const includePending = c.req.query("include_pending") === "true";
 
       const rows = querySignalCountRows(this.ctx.storage.sql, {
         beat,
@@ -2786,6 +2786,23 @@ export class NewsDO extends DurableObject<Env> {
       const signal = rowToSignal(rows[0] as Record<string, unknown>);
 
       return c.json({ ok: true, data: signal } satisfies DOResult<Signal>);
+    });
+
+    // DELETE /signals/:id/pending — orphan cleanup for the route layer when
+    // stagePayment fails after a pending_payment row has been inserted. The
+    // status='pending_payment' guard is the safety net: nothing finalised
+    // can ever be deleted through this path.
+    this.router.delete("/signals/:id/pending", (c) => {
+      const id = c.req.param("id");
+      this.ctx.storage.sql.exec(
+        "DELETE FROM signal_tags WHERE signal_id = ?",
+        id
+      );
+      this.ctx.storage.sql.exec(
+        "DELETE FROM signals WHERE id = ? AND status = 'pending_payment'",
+        id
+      );
+      return c.json({ ok: true, data: { id } });
     });
 
     // POST /signals — atomic insert: signal + tags + streak + earning

--- a/src/objects/schema.ts
+++ b/src/objects/schema.ts
@@ -34,7 +34,8 @@ CREATE TABLE IF NOT EXISTS signals (
   reviewed_at       TEXT,
   disclosure        TEXT NOT NULL DEFAULT '',
   quality_score     INTEGER DEFAULT NULL,
-  score_breakdown   TEXT DEFAULT NULL
+  score_breakdown   TEXT DEFAULT NULL,
+  payment_txid      TEXT DEFAULT NULL
 );
 
 CREATE TABLE IF NOT EXISTS signal_tags (
@@ -133,6 +134,7 @@ CREATE INDEX IF NOT EXISTS idx_signals_btc_address      ON signals(btc_address);
 CREATE INDEX IF NOT EXISTS idx_signals_btc_created      ON signals(btc_address, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_signals_created_at       ON signals(created_at);
 CREATE INDEX IF NOT EXISTS idx_signals_status_created   ON signals(status, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_signals_status_btc_created ON signals(status, btc_address, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_signals_status_reviewed_created ON signals(status, reviewed_at DESC, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_signals_correction_of    ON signals(correction_of);
 CREATE INDEX IF NOT EXISTS idx_earnings_btc_address     ON earnings(btc_address);
@@ -806,6 +808,21 @@ export const MIGRATION_CORRESPONDENT_STATS_SQL = [
      first_signal_at = excluded.first_signal_at,
      days_active = excluded.days_active,
      updated_at = excluded.updated_at`,
+] as const;
+
+/**
+ * MIGRATION_SIGNAL_PAYMENT_SQL — x402 payment columns on signals.
+ *
+ * Adds `payment_txid` so finalizeSignalSubmission can record the on-chain
+ * sBTC txid backing a paid signal submission. The signals table has no
+ * CHECK constraint on `status`, so introducing the new `pending_payment`
+ * status requires no schema change — only the TS-side SIGNAL_STATUSES
+ * constant. The added (status, btc_address, created_at) index keeps
+ * cooldown / daily-cap queries fast as `pending_payment` rows accumulate.
+ */
+export const MIGRATION_SIGNAL_PAYMENT_SQL = [
+  "ALTER TABLE signals ADD COLUMN payment_txid TEXT",
+  "CREATE INDEX IF NOT EXISTS idx_signals_status_btc_created ON signals(status, btc_address, created_at DESC)",
 ] as const;
 
 export const MIGRATION_APR7_EARNINGS_SQL = [

--- a/src/objects/schema.ts
+++ b/src/objects/schema.ts
@@ -792,6 +792,9 @@ export const MIGRATION_CORRESPONDENT_STATS_SQL = [
   "CREATE INDEX IF NOT EXISTS idx_correspondent_stats_signal_count ON correspondent_stats(signal_count DESC)",
   "CREATE INDEX IF NOT EXISTS idx_correspondent_stats_last_signal ON correspondent_stats(last_signal_at DESC)",
   // Backfill from existing signals — idempotent via ON CONFLICT.
+  // Excludes pending_payment so x402-staged-but-unconfirmed signals do
+  // not inflate the materialised totals; they're added by the finalize
+  // path when payment confirms.
   `INSERT INTO correspondent_stats (btc_address, signal_count, last_signal_at, first_signal_at, days_active, updated_at)
      SELECT btc_address,
             COUNT(*),
@@ -801,6 +804,7 @@ export const MIGRATION_CORRESPONDENT_STATS_SQL = [
             datetime('now')
        FROM signals
       WHERE correction_of IS NULL
+        AND status != 'pending_payment'
       GROUP BY btc_address
    ON CONFLICT(btc_address) DO UPDATE SET
      signal_count = excluded.signal_count,

--- a/src/objects/schema.ts
+++ b/src/objects/schema.ts
@@ -815,14 +815,10 @@ export const MIGRATION_CORRESPONDENT_STATS_SQL = [
 ] as const;
 
 /**
- * MIGRATION_SIGNAL_PAYMENT_SQL — x402 payment columns on signals.
- *
- * Adds `payment_txid` so finalizeSignalSubmission can record the on-chain
- * sBTC txid backing a paid signal submission. The signals table has no
- * CHECK constraint on `status`, so introducing the new `pending_payment`
- * status requires no schema change — only the TS-side SIGNAL_STATUSES
- * constant. The added (status, btc_address, created_at) index keeps
- * cooldown / daily-cap queries fast as `pending_payment` rows accumulate.
+ * x402 payment columns on signals. The signals.status column has no CHECK
+ * constraint, so the new `pending_payment` status needs only the TS-side
+ * SIGNAL_STATUSES update — no schema change. The composite index keeps
+ * cooldown / daily-cap queries fast as pending rows accumulate.
  */
 export const MIGRATION_SIGNAL_PAYMENT_SQL = [
   "ALTER TABLE signals ADD COLUMN payment_txid TEXT",

--- a/src/routes/signal-counts.ts
+++ b/src/routes/signal-counts.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import type { Env, AppVariables } from "../lib/types";
 import { getSignalCounts } from "../lib/do-client";
 import { edgeCacheMatch, edgeCachePut } from "../lib/edge-cache";
+import { verifyAuth } from "../services/auth";
 
 const signalCountsRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>();
 
@@ -21,6 +22,27 @@ signalCountsRouter.get("/api/signals/counts", async (c) => {
   const agent = c.req.query("agent");
   const since = c.req.query("since");
   const includePending = c.req.query("include_pending") === "true";
+
+  // The pending_payment bucket leaks "this agent has staged paid submissions
+  // right now" — author-only. Require an `agent` filter that matches the
+  // BIP-322-signed X-BTC-* trio so callers can only enumerate their own
+  // staged counts. Public agent-scoped counts (without include_pending) stay
+  // unauthenticated and are served from the same edge cache as before.
+  if (includePending) {
+    if (!agent) {
+      return c.json(
+        {
+          error: "include_pending=true requires ?agent=<bc1q-address> filter",
+          code: "PENDING_REQUIRES_AGENT",
+        },
+        400
+      );
+    }
+    const authResult = verifyAuth(c.req.raw.headers, agent, "GET", "/api/signals/counts");
+    if (!authResult.valid) {
+      return c.json({ error: authResult.error, code: authResult.code }, 401);
+    }
+  }
 
   try {
     const counts = await getSignalCounts(c.env, {

--- a/src/routes/signal-counts.ts
+++ b/src/routes/signal-counts.ts
@@ -20,9 +20,15 @@ signalCountsRouter.get("/api/signals/counts", async (c) => {
   const beat = c.req.query("beat");
   const agent = c.req.query("agent");
   const since = c.req.query("since");
+  const includePending = c.req.query("include_pending") === "true";
 
   try {
-    const counts = await getSignalCounts(c.env, { beat, agent, since });
+    const counts = await getSignalCounts(c.env, {
+      beat,
+      agent,
+      since,
+      include_pending: includePending,
+    });
     c.header("Cache-Control", "public, max-age=30, s-maxage=60");
     const response = c.json(counts);
     edgeCachePut(c, response);

--- a/src/routes/signal-counts.ts
+++ b/src/routes/signal-counts.ts
@@ -10,14 +10,6 @@ const signalCountsRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>(
 // Returns counts grouped by status without fetching full signal records.
 // Supports optional filters: beat, agent, since.
 signalCountsRouter.get("/api/signals/counts", async (c) => {
-  // Edge-cache short-circuit. The archive page fires four of these in
-  // parallel (today / week / month / quarter windows) on every paint.
-  // Without a cache each window pays a DO round-trip. s-maxage=60 keeps
-  // counts fresh within a minute; cache key includes the full URL so
-  // each window + filter combo is a separate entry.
-  const cached = await edgeCacheMatch(c);
-  if (cached) return cached;
-
   const beat = c.req.query("beat");
   const agent = c.req.query("agent");
   const since = c.req.query("since");
@@ -44,6 +36,21 @@ signalCountsRouter.get("/api/signals/counts", async (c) => {
     }
   }
 
+  // Edge-cache short-circuit. The archive page fires four of these in
+  // parallel (today / week / month / quarter windows) on every paint.
+  // Without a cache each window pays a DO round-trip. s-maxage=60 keeps
+  // counts fresh within a minute; cache key includes the full URL so
+  // each window + filter combo is a separate entry.
+  //
+  // Skipped for `include_pending=true` requests — the cache key has no
+  // notion of the BIP-322 X-BTC-* headers that gate the pending bucket,
+  // so caching the authed response would leak the per-agent pending
+  // count to any anonymous caller hitting the same URL.
+  if (!includePending) {
+    const cached = await edgeCacheMatch(c);
+    if (cached) return cached;
+  }
+
   try {
     const counts = await getSignalCounts(c.env, {
       beat,
@@ -51,9 +58,12 @@ signalCountsRouter.get("/api/signals/counts", async (c) => {
       since,
       include_pending: includePending,
     });
-    c.header("Cache-Control", "public, max-age=30, s-maxage=60");
+    c.header(
+      "Cache-Control",
+      includePending ? "private, no-store" : "public, max-age=30, s-maxage=60"
+    );
     const response = c.json(counts);
-    edgeCachePut(c, response);
+    if (!includePending) edgeCachePut(c, response);
     return response;
   } catch (err) {
     return c.json({ ok: false, error: "Failed to fetch signal counts" }, 500);

--- a/src/routes/signals.ts
+++ b/src/routes/signals.ts
@@ -364,12 +364,18 @@ signalsRouter.post("/api/signals", signalRateLimit, async (c) => {
     return res;
   }
   if (!identity.registered || identity.level === null || identity.level < 2) {
+    // Surface the agent's current level/registration so callers can tell
+    // whether they need to register fresh (registered=false) or just claim
+    // on X to bump from Level 1 → Genesis (registered=true, level=1).
     return c.json(
       {
         error:
           "Signal submission requires a registered AIBTC agent account at Genesis level. " +
           "Register at aibtc.com and reach Genesis (Level 2) by completing a claim on X.",
         code: "IDENTITY_REQUIRED",
+        registered: identity.registered,
+        level: identity.level,
+        levelName: identity.levelName,
       },
       403
     );

--- a/src/routes/signals.ts
+++ b/src/routes/signals.ts
@@ -72,6 +72,7 @@ signalsRouter.get("/api/signals", async (c) => {
   const since = c.req.query("since");
   const date = c.req.query("date");
   const status = c.req.query("status");
+  const includePending = c.req.query("include_pending") === "true";
 
   if (status && !(SIGNAL_STATUSES as readonly string[]).includes(status)) {
     return c.json({ error: `Invalid status. Must be one of: ${SIGNAL_STATUSES.join(", ")}` }, 400);
@@ -109,7 +110,7 @@ signalsRouter.get("/api/signals", async (c) => {
   }
 
   // date takes precedence over since — pass since only when date is absent
-  const { signals, total, hasMore } = await listSignalsPage(c.env, { beat, agent, tag, since: date ? undefined : since, date, status, limit: resolvedLimit, offset: resolvedOffset });
+  const { signals, total, hasMore } = await listSignalsPage(c.env, { beat, agent, tag, since: date ? undefined : since, date, status, limit: resolvedLimit, offset: resolvedOffset, include_pending: includePending });
 
   // Resolve agent display names for all signals in this response
   const signalAddresses = [...new Set(signals.map((s) => s.btc_address).filter(Boolean))];

--- a/src/routes/signals.ts
+++ b/src/routes/signals.ts
@@ -73,21 +73,6 @@ const signalReadRateLimit = createRateLimitMiddleware({
 
 // GET /api/signals — list signals with optional filters
 signalsRouter.get("/api/signals", async (c) => {
-  // Edge-cache short-circuit. The archive page pulls 50 signals on
-  // paint and +50 per Load More — previously every page, every
-  // filter-combo, every visitor paid a fresh DO round-trip. Cache key
-  // is the full request URL so ?beat=X&status=approved and
-  // ?agent=Y&limit=50 live as separate entries.
-  const cached = await edgeCacheMatch(c);
-  if (cached) return cached;
-
-  const blocked = await checkRateLimit(c, {
-    key: "signals-read",
-    binding: "read",
-    ...SIGNAL_READ_RATE_LIMIT,
-  });
-  if (blocked) return blocked;
-
   const beat = c.req.query("beat");
   const agent = c.req.query("agent");
   const tag = c.req.query("tag");
@@ -120,6 +105,28 @@ signalsRouter.get("/api/signals", async (c) => {
       return c.json({ error: authResult.error, code: authResult.code }, 401);
     }
   }
+
+  // Edge-cache short-circuit. The archive page pulls 50 signals on
+  // paint and +50 per Load More — previously every page, every
+  // filter-combo, every visitor paid a fresh DO round-trip. Cache key
+  // is the full request URL so ?beat=X&status=approved and
+  // ?agent=Y&limit=50 live as separate entries.
+  //
+  // Skipped for `wantsPending` requests because the cache key has no
+  // notion of the BIP-322 X-BTC-* headers that gate this path — caching
+  // an authed response would let an unauthenticated caller hit the same
+  // URL and get a cache HIT before the auth gate fires.
+  if (!wantsPending) {
+    const cached = await edgeCacheMatch(c);
+    if (cached) return cached;
+  }
+
+  const blocked = await checkRateLimit(c, {
+    key: "signals-read",
+    binding: "read",
+    ...SIGNAL_READ_RATE_LIMIT,
+  });
+  if (blocked) return blocked;
 
   if (since && Number.isNaN(new Date(since).getTime())) {
     return c.json({ error: "Invalid 'since' parameter. Use ISO 8601 format (e.g., 2026-03-25T00:00:00Z)" }, 400);
@@ -188,7 +195,10 @@ signalsRouter.get("/api/signals", async (c) => {
     };
   });
 
-  c.header("Cache-Control", "public, max-age=60, s-maxage=300");
+  c.header(
+    "Cache-Control",
+    wantsPending ? "private, no-store" : "public, max-age=60, s-maxage=300"
+  );
   c.header("X-Timezone", "UTC");
   const response = c.json({
     signals: transformed,
@@ -201,7 +211,7 @@ signalsRouter.get("/api/signals", async (c) => {
     limit: resolvedLimit,
     offset: resolvedOffset,
   });
-  edgeCachePut(c, response);
+  if (!wantsPending) edgeCachePut(c, response);
   return response;
 });
 
@@ -502,11 +512,19 @@ signalsRouter.post("/api/signals", signalRateLimit, async (c) => {
 
     // Idempotent retry: x402 reuses the same paymentId for retries of the
     // same signed transaction. If a previous attempt already staged this
-    // paymentId for a signal_submission, re-issue the original 202 instead
-    // of running cooldown / daily-cap (which would reject the retry) and
-    // creating a second staged row.
+    // paymentId for a signal_submission AND the stage is still live (not
+    // discarded by a prior terminal failure), re-issue the original 202
+    // instead of running cooldown / daily-cap (which would reject the
+    // retry) and creating a second staged row. A `discarded` stage means
+    // the relay has already terminally failed this paymentId — the agent
+    // needs a fresh paymentId, so we fall through to the normal stage
+    // path which will surface the relay error on the next attempt.
     const existingStage = await getPaymentStage(c.env, verification.paymentId);
-    if (existingStage && existingStage.payload.kind === "signal_submission") {
+    if (
+      existingStage &&
+      existingStage.payload.kind === "signal_submission" &&
+      existingStage.stageStatus !== "discarded"
+    ) {
       const checkStatusUrl = verification.checkStatusUrl
         ?? buildLocalPaymentStatusUrl(new URL(c.req.url).origin, verification.paymentId);
       return c.json(
@@ -555,8 +573,25 @@ signalsRouter.post("/api/signals", signalRateLimit, async (c) => {
     });
     if (!stageResult.ok || !stageResult.data) {
       // Roll back the pending row so a transient stagePayment failure does
-      // not strand the agent's cooldown / daily-cap slot for hours.
-      await deletePendingSignal(c.env, provisionalSignalId);
+      // not strand the agent's cooldown / daily-cap slot for hours. If the
+      // rollback itself fails the orphan can't be reached by the alarm
+      // sweep (no payment_staging row to reconcile against) — surface that
+      // as a 500 so the operator sees it instead of a misleading stage error.
+      const rollback = await deletePendingSignal(c.env, provisionalSignalId);
+      if (!rollback.ok) {
+        logger.error("rollback DELETE failed after stagePayment failure", {
+          signalId: provisionalSignalId,
+          paymentId: verification.paymentId,
+          stageError: stageResult.error,
+        });
+        return c.json(
+          {
+            error: "Failed to stage signal submission and rollback failed; pending row may be stranded",
+            signalId: provisionalSignalId,
+          },
+          500
+        );
+      }
       logger.warn("rolled back pending signal after stagePayment failure", {
         signalId: provisionalSignalId,
         paymentId: verification.paymentId,

--- a/src/routes/signals.ts
+++ b/src/routes/signals.ts
@@ -18,11 +18,14 @@ import {
   getBeat,
   getActiveBeatSlugs,
   getConfig,
+  reconcilePaymentStage,
+  stagePayment,
 } from "../lib/do-client";
 import { verifyAuth } from "../services/auth";
 import { checkAgentIdentity } from "../services/identity-gate";
-import { buildPaymentRequired, verifyPayment, mapVerificationError } from "../services/x402";
-import { toUTCDate, resolveNamesWithTimeout } from "../lib/helpers";
+import { buildLocalPaymentStatusUrl, buildPaymentRequired, verifyPayment, mapVerificationError } from "../services/x402";
+import { toUTCDate, resolveNamesWithTimeout, generateId } from "../lib/helpers";
+import { logPaymentEvent } from "../lib/payment-logging";
 import { edgeCacheMatch, edgeCachePut } from "../lib/edge-cache";
 
 const signalsRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>();
@@ -320,70 +323,255 @@ signalsRouter.post("/api/signals", signalRateLimit, async (c) => {
     );
   }
 
-  // Payment gate (when enabled)
+  // Payment gate (when enabled). The `requirePayment + !isPublisher` branch
+  // exits with its own 201 / 202 / 402 / 409 / 503 response — fall-through
+  // to the no-payment createSignal call below is only for publishers and
+  // for environments where SIGNALS_REQUIRE_PAYMENT is disabled (legacy /
+  // dev). Once payments are universally on, the only fall-through is the
+  // publisher bypass.
   const requirePayment = c.env.SIGNALS_REQUIRE_PAYMENT === "true";
+  const sanitizedBody = signalContent ? sanitizeString(signalContent, 1000) : null;
+  const sanitizedDisclosure = typeof disclosure === "string" ? disclosure : undefined;
 
-  if (!isPublisher) {
-    if (requirePayment) {
-      const paymentHeader =
-        c.req.header("X-PAYMENT") ?? c.req.header("payment-signature");
+  if (!isPublisher && requirePayment) {
+    const logger = c.get("logger");
+    const paymentHeader =
+      c.req.header("X-PAYMENT") ?? c.req.header("payment-signature");
 
-      if (!paymentHeader) {
-        const logger = c.get("logger");
-        logger.debug("402 payment required sent for POST /api/signals", {
+    if (!paymentHeader) {
+      logPaymentEvent(logger, "info", "payment.required", {
+        route: "/api/signals",
+        action: "return_402_payment_required",
+      });
+      return buildPaymentRequired({
+        amount: SIGNAL_PRICE_SATS,
+        description: `Signal submission — file a signal for ${SIGNAL_PRICE_SATS} sats sBTC`,
+      });
+    }
+
+    const verification = await verifyPayment(paymentHeader, SIGNAL_PRICE_SATS, c.env, {
+      logger,
+      route: "/api/signals",
+    });
+    if (!verification.valid) {
+      const { body: errorBody, status, headers } = mapVerificationError(verification);
+      logPaymentEvent(logger, status === 503 ? "error" : "warn", "payment.retry_decision", {
+        route: "/api/signals",
+        paymentId: verification.paymentId,
+        status: verification.paymentState ?? null,
+        terminalReason: verification.terminalReason ?? null,
+        action: status === 409
+          ? "retry_after_nonce_recovery"
+          : status === 503
+            ? "retry_after_relay_recovery"
+            : errorBody.retryable
+              ? "repay_or_resubmit"
+              : "stop_retry",
+      });
+
+      if (status === 409) {
+        logger.warn("nonce conflict during payment verification for POST /api/signals", {
+          btc_address, errorCode: verification.errorCode,
+        });
+      } else if (status === 503) {
+        logger.error("relay error during payment verification for POST /api/signals", {
           btc_address,
         });
-        return buildPaymentRequired({
-          amount: SIGNAL_PRICE_SATS,
-          description: `Signal submission — file a signal for ${SIGNAL_PRICE_SATS} sats sBTC`,
+      } else {
+        logger.warn("payment verification failed for POST /api/signals", {
+          btc_address, relayReason: verification.relayReason,
         });
       }
 
-      const verification = await verifyPayment(paymentHeader, SIGNAL_PRICE_SATS, c.env);
-      if (!verification.valid) {
-        const logger = c.get("logger");
-        const { body: errorBody, status, headers } = mapVerificationError(verification);
-
-        if (status === 409) {
-          logger.warn("nonce conflict during payment verification for POST /api/signals", {
-            btc_address, errorCode: verification.errorCode,
-          });
-        } else if (status === 503) {
-          logger.error("relay error during payment verification for POST /api/signals", {
-            btc_address,
-          });
-        } else {
-          logger.warn("payment verification failed for POST /api/signals", {
-            btc_address, relayReason: verification.relayReason,
-          });
-        }
-
-        if (status === 402 && verification.retryable !== false) {
-          return buildPaymentRequired({
-            amount: SIGNAL_PRICE_SATS,
-            description: `${errorBody.error} Please pay ${SIGNAL_PRICE_SATS} sats sBTC to file a signal.`,
-            code: errorBody.code,
-          });
-        }
-
-        if (headers) {
-          for (const [key, value] of Object.entries(headers)) {
-            c.header(key, value);
-          }
-        }
-        return c.json(errorBody, status);
+      if (status === 402 && verification.retryable !== false) {
+        return buildPaymentRequired({
+          amount: SIGNAL_PRICE_SATS,
+          description: `${errorBody.error} Please pay ${SIGNAL_PRICE_SATS} sats sBTC to file a signal.`,
+          code: errorBody.code,
+        });
       }
+
+      if (headers) {
+        for (const [key, value] of Object.entries(headers)) {
+          c.header(key, value);
+        }
+      }
+      return c.json(errorBody, status);
     }
+
+    const provisionalSignalId = generateId();
+    logPaymentEvent(logger, "info", "payment.accepted", {
+      route: "/api/signals",
+      paymentId: verification.paymentId,
+      status: verification.paymentState ?? "confirmed",
+      action: "payment_verified",
+      checkStatusUrl_present: Boolean(verification.checkStatusUrl),
+    });
+    logger.info("payment verified for POST /api/signals", {
+      btc_address,
+      txid: verification.txid,
+      paymentStatus: verification.paymentStatus,
+      paymentId: verification.paymentId,
+      stagedSignalId: provisionalSignalId,
+    });
+
+    // HTTP-fallback: relay confirmed synchronously without a paymentId.
+    // Write the signal directly with status='submitted' and the txid from
+    // the relay verification. No staging is needed because there is no
+    // payment lifecycle to track.
+    if (verification.paymentState === "confirmed" && !verification.paymentId) {
+      const createResult = await createSignal(c.env, {
+        signal_id: provisionalSignalId,
+        beat_slug: beat_slug as string,
+        btc_address: btc_address as string,
+        headline: headline as string,
+        body: sanitizedBody,
+        sources,
+        tags,
+        disclosure: sanitizedDisclosure,
+        payment_txid: verification.txid ?? null,
+      });
+      if (!createResult.ok) {
+        if (createResult.daily_limit) {
+          const res = c.json(
+            { error: createResult.error, daily_limit: createResult.daily_limit },
+            429
+          );
+          res.headers.set("Retry-After", String(createResult.daily_limit.retry_after));
+          return res;
+        }
+        if (createResult.cooldown) {
+          return c.json({ error: createResult.error, cooldown: createResult.cooldown }, 429);
+        }
+        return c.json({ error: createResult.error }, createResult.status ?? 400);
+      }
+      logPaymentEvent(logger, "info", "payment.delivery_confirmed", {
+        route: "/api/signals",
+        paymentId: null,
+        status: "confirmed",
+        action: "signal_submission_confirmed_http_fallback",
+        compat_shim_used: true,
+      });
+      return c.json({ ...(createResult.data as object), paymentId: null, message: "Signal submitted" }, 201);
+    }
+
+    if (!verification.paymentId) {
+      return c.json(
+        { error: "Relay accepted payment but did not provide a paymentId for signal staging" },
+        503
+      );
+    }
+
+    // Stage path: insert the signal at status='pending_payment' and stage
+    // the x402 record. The cooldown / daily-cap checks inside the DO are
+    // run pre-insert, so this call returns 429 (with cooldown / daily_limit
+    // metadata) when the agent is over-limit. We MUST do this before
+    // calling stagePayment so we don't end up with an orphaned staged
+    // payment for a request that the agent isn't allowed to file anyway.
+    const stagedSignalResult = await createSignal(c.env, {
+      signal_id: provisionalSignalId,
+      beat_slug: beat_slug as string,
+      btc_address: btc_address as string,
+      headline: headline as string,
+      body: sanitizedBody,
+      sources,
+      tags,
+      disclosure: sanitizedDisclosure,
+      pending_payment: true,
+    });
+    if (!stagedSignalResult.ok) {
+      if (stagedSignalResult.daily_limit) {
+        const res = c.json(
+          { error: stagedSignalResult.error, daily_limit: stagedSignalResult.daily_limit },
+          429
+        );
+        res.headers.set("Retry-After", String(stagedSignalResult.daily_limit.retry_after));
+        return res;
+      }
+      if (stagedSignalResult.cooldown) {
+        return c.json({ error: stagedSignalResult.error, cooldown: stagedSignalResult.cooldown }, 429);
+      }
+      return c.json({ error: stagedSignalResult.error }, stagedSignalResult.status ?? 400);
+    }
+
+    const stageResult = await stagePayment(c.env, {
+      paymentId: verification.paymentId,
+      payload: {
+        kind: "signal_submission",
+        signal_id: provisionalSignalId,
+        btc_address: btc_address as string,
+        beat_slug: beat_slug as string,
+        headline: headline as string,
+        body: sanitizedBody,
+        sources: sources as { url: string; title: string }[],
+        tags: tags as string[],
+        disclosure: sanitizedDisclosure ?? null,
+        payment_txid: verification.txid ?? null,
+      },
+    });
+    if (!stageResult.ok || !stageResult.data) {
+      return c.json({ error: stageResult.error ?? "Failed to stage signal submission" }, stageResult.status ?? 500);
+    }
+    logPaymentEvent(logger, "info", "payment.delivery_staged", {
+      route: "/api/signals",
+      paymentId: verification.paymentId,
+      status: verification.paymentState ?? "queued",
+      action: verification.paymentStatus === "pending"
+        ? "return_202_pending"
+        : "stage_signal_submission",
+      checkStatusUrl_present: Boolean(verification.checkStatusUrl),
+      compat_shim_used: false,
+    });
+
+    if (verification.paymentState === "confirmed") {
+      await reconcilePaymentStage(c.env, verification.paymentId, {
+        status: "confirmed",
+        txid: verification.txid,
+      });
+
+      const finalized = await getSignal(c.env, provisionalSignalId);
+      if (!finalized) {
+        return c.json({ error: "Failed to finalize confirmed signal submission" }, 500);
+      }
+      logger.info("signal finalized after confirmed payment", {
+        id: finalized.id,
+        paymentId: verification.paymentId,
+      });
+      logPaymentEvent(logger, "info", "payment.delivery_confirmed", {
+        route: "/api/signals",
+        paymentId: verification.paymentId,
+        status: "confirmed",
+        action: "signal_submission_finalized",
+      });
+      return c.json({ ...finalized, paymentId: verification.paymentId, message: "Signal submitted" }, 201);
+    }
+
+    const checkStatusUrl = verification.checkStatusUrl
+      ?? buildLocalPaymentStatusUrl(new URL(c.req.url).origin, verification.paymentId);
+
+    return c.json(
+      {
+        signalId: provisionalSignalId,
+        paymentId: verification.paymentId,
+        paymentStatus: "pending",
+        status: verification.paymentState ?? "queued",
+        checkStatusUrl,
+        message: "Signal submission is staged until the payment is confirmed.",
+      },
+      202
+    );
   }
 
+  // Publisher bypass / payments-disabled fall-through. createSignal writes
+  // the row at status='submitted' and runs commit effects in-band.
   const result = await createSignal(c.env, {
     beat_slug: beat_slug as string,
     btc_address: btc_address as string,
     headline: headline as string,
-    body: signalContent ? sanitizeString(signalContent, 1000) : null,
+    body: sanitizedBody,
     sources,
     tags,
-    disclosure: disclosure as string | undefined,
+    disclosure: sanitizedDisclosure,
   });
 
   if (!result.ok) {
@@ -411,20 +599,11 @@ signalsRouter.post("/api/signals", signalRateLimit, async (c) => {
     btc_address: btc_address as string,
   });
 
-  // Grace period warning: notify non-publisher agents that payment will be required
-  const disclosureValue = disclosure as string | undefined;
-  const warnings: string[] = [];
-  if (!isPublisher && !requirePayment) {
-    warnings.push(
-      "Signal submission will soon require a 100 sat sBTC x402 payment. " +
-      "Update your tooling to handle HTTP 402 responses on POST /api/signals."
-    );
-  }
-
   // Soft-launch disclosure enforcement: warn when disclosure is absent or empty,
   // including for non-AI signals, to encourage adoption across all correspondents.
   // Do NOT reject the signal — enforcement will be required in a future release.
-  if (!disclosureValue || disclosureValue.trim() === "") {
+  const warnings: string[] = [];
+  if (!sanitizedDisclosure || sanitizedDisclosure.trim() === "") {
     warnings.push(
       "disclosure is empty — you must declare the model and skill file used to produce this signal. " +
       'Example: "claude-sonnet-4-5-20250514, https://aibtc.news/api/skills?slug=btc-macro". ' +

--- a/src/routes/signals.ts
+++ b/src/routes/signals.ts
@@ -21,6 +21,8 @@ import {
   getConfig,
   reconcilePaymentStage,
   stagePayment,
+  getPaymentStage,
+  deletePendingSignal,
 } from "../lib/do-client";
 import type { Context } from "hono";
 import { verifyAuth } from "../services/auth";
@@ -96,6 +98,27 @@ signalsRouter.get("/api/signals", async (c) => {
 
   if (status && !(SIGNAL_STATUSES as readonly string[]).includes(status)) {
     return c.json({ error: `Invalid status. Must be one of: ${SIGNAL_STATUSES.join(", ")}` }, 400);
+  }
+
+  // Pending visibility is author-only. Require an `agent` filter that
+  // matches a BIP-322-signed X-BTC-* header trio so callers can only
+  // enumerate their own staged rows. Without this gate any caller could
+  // dump unpublished submissions for any agent address before settlement.
+  const wantsPending = includePending || status === "pending_payment";
+  if (wantsPending) {
+    if (!agent) {
+      return c.json(
+        {
+          error: "Pending visibility requires ?agent=<bc1q-address> filter",
+          code: "PENDING_REQUIRES_AGENT",
+        },
+        400
+      );
+    }
+    const authResult = verifyAuth(c.req.raw.headers, agent, "GET", "/api/signals");
+    if (!authResult.valid) {
+      return c.json({ error: authResult.error, code: authResult.code }, 401);
+    }
   }
 
   if (since && Number.isNaN(new Date(since).getTime())) {
@@ -193,6 +216,14 @@ signalsRouter.get("/api/signals/:id", signalReadRateLimit, async (c) => {
   }
   const s = await getSignal(c.env, id);
   if (!s) {
+    return c.json({ error: `Signal "${id}" not found` }, 404);
+  }
+  // x402-staged-but-unconfirmed rows are author-only; the public per-id
+  // endpoint hides them entirely so anyone holding a provisional signalId
+  // (returned in the 202 body) cannot fetch the unpublished content. The
+  // author can list their own pending rows via
+  // GET /api/signals?agent=<bc1q>&status=pending_payment with BIP-322 auth.
+  if (s.status === "pending_payment") {
     return c.json({ error: `Signal "${id}" not found` }, 404);
   }
 
@@ -463,6 +494,28 @@ signalsRouter.post("/api/signals", signalRateLimit, async (c) => {
       );
     }
 
+    // Idempotent retry: x402 reuses the same paymentId for retries of the
+    // same signed transaction. If a previous attempt already staged this
+    // paymentId for a signal_submission, re-issue the original 202 instead
+    // of running cooldown / daily-cap (which would reject the retry) and
+    // creating a second staged row.
+    const existingStage = await getPaymentStage(c.env, verification.paymentId);
+    if (existingStage && existingStage.payload.kind === "signal_submission") {
+      const checkStatusUrl = verification.checkStatusUrl
+        ?? buildLocalPaymentStatusUrl(new URL(c.req.url).origin, verification.paymentId);
+      return c.json(
+        {
+          signalId: existingStage.payload.signal_id,
+          paymentId: verification.paymentId,
+          paymentStatus: "pending",
+          status: verification.paymentState ?? "queued",
+          checkStatusUrl,
+          message: "Signal submission is staged until the payment is confirmed.",
+        },
+        202
+      );
+    }
+
     // Run cooldown / daily-cap checks via the DO before staging the payment
     // so an over-limit agent never produces an orphan staged payment for a
     // request that would have been rejected anyway.
@@ -495,6 +548,14 @@ signalsRouter.post("/api/signals", signalRateLimit, async (c) => {
       },
     });
     if (!stageResult.ok || !stageResult.data) {
+      // Roll back the pending row so a transient stagePayment failure does
+      // not strand the agent's cooldown / daily-cap slot for hours.
+      await deletePendingSignal(c.env, provisionalSignalId);
+      logger.warn("rolled back pending signal after stagePayment failure", {
+        signalId: provisionalSignalId,
+        paymentId: verification.paymentId,
+        stageError: stageResult.error,
+      });
       return c.json({ error: stageResult.error ?? "Failed to stage signal submission" }, stageResult.status ?? 500);
     }
     logPaymentEvent(logger, "info", "payment.delivery_staged", {

--- a/src/routes/signals.ts
+++ b/src/routes/signals.ts
@@ -10,6 +10,7 @@ import {
   validateTags,
   sanitizeString,
 } from "../lib/validators";
+import type { CreateSignalResult } from "../lib/do-client";
 import {
   listSignalsPage,
   getSignal,
@@ -21,6 +22,7 @@ import {
   reconcilePaymentStage,
   stagePayment,
 } from "../lib/do-client";
+import type { Context } from "hono";
 import { verifyAuth } from "../services/auth";
 import { checkAgentIdentity } from "../services/identity-gate";
 import { buildLocalPaymentStatusUrl, buildPaymentRequired, verifyPayment, mapVerificationError } from "../services/x402";
@@ -29,6 +31,24 @@ import { logPaymentEvent } from "../lib/payment-logging";
 import { edgeCacheMatch, edgeCachePut } from "../lib/edge-cache";
 
 const signalsRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>();
+
+/** Maps a non-ok createSignal response to the right HTTP shape. The DO
+ *  surfaces cooldown / daily_limit as 429 with structured metadata; everything
+ *  else uses `result.status` (400 / 403 / 404 / 410) or 400 fallback. */
+function respondCreateSignalError(
+  c: Context<{ Bindings: Env; Variables: AppVariables }>,
+  result: CreateSignalResult
+): Response {
+  if (result.daily_limit) {
+    const res = c.json({ error: result.error, daily_limit: result.daily_limit }, 429);
+    res.headers.set("Retry-After", String(result.daily_limit.retry_after));
+    return res;
+  }
+  if (result.cooldown) {
+    return c.json({ error: result.error, cooldown: result.cooldown }, 429);
+  }
+  return c.json({ error: result.error }, result.status ?? 400);
+}
 
 const signalRateLimit = createRateLimitMiddleware({
   key: "signals",
@@ -324,12 +344,6 @@ signalsRouter.post("/api/signals", signalRateLimit, async (c) => {
     );
   }
 
-  // Payment gate (when enabled). The `requirePayment + !isPublisher` branch
-  // exits with its own 201 / 202 / 402 / 409 / 503 response — fall-through
-  // to the no-payment createSignal call below is only for publishers and
-  // for environments where SIGNALS_REQUIRE_PAYMENT is disabled (legacy /
-  // dev). Once payments are universally on, the only fall-through is the
-  // publisher bypass.
   const requirePayment = c.env.SIGNALS_REQUIRE_PAYMENT === "true";
   const sanitizedBody = signalContent ? sanitizeString(signalContent, 1000) : null;
   const sanitizedDisclosure = typeof disclosure === "string" ? disclosure : undefined;
@@ -416,10 +430,9 @@ signalsRouter.post("/api/signals", signalRateLimit, async (c) => {
       stagedSignalId: provisionalSignalId,
     });
 
-    // HTTP-fallback: relay confirmed synchronously without a paymentId.
-    // Write the signal directly with status='submitted' and the txid from
-    // the relay verification. No staging is needed because there is no
-    // payment lifecycle to track.
+    // HTTP-fallback: relay confirmed synchronously without a paymentId. Write
+    // the signal at status='submitted' with the on-chain txid attached;
+    // there is no payment lifecycle to track.
     if (verification.paymentState === "confirmed" && !verification.paymentId) {
       const createResult = await createSignal(c.env, {
         signal_id: provisionalSignalId,
@@ -432,20 +445,7 @@ signalsRouter.post("/api/signals", signalRateLimit, async (c) => {
         disclosure: sanitizedDisclosure,
         payment_txid: verification.txid ?? null,
       });
-      if (!createResult.ok) {
-        if (createResult.daily_limit) {
-          const res = c.json(
-            { error: createResult.error, daily_limit: createResult.daily_limit },
-            429
-          );
-          res.headers.set("Retry-After", String(createResult.daily_limit.retry_after));
-          return res;
-        }
-        if (createResult.cooldown) {
-          return c.json({ error: createResult.error, cooldown: createResult.cooldown }, 429);
-        }
-        return c.json({ error: createResult.error }, createResult.status ?? 400);
-      }
+      if (!createResult.ok) return respondCreateSignalError(c, createResult);
       logPaymentEvent(logger, "info", "payment.delivery_confirmed", {
         route: "/api/signals",
         paymentId: null,
@@ -463,12 +463,9 @@ signalsRouter.post("/api/signals", signalRateLimit, async (c) => {
       );
     }
 
-    // Stage path: insert the signal at status='pending_payment' and stage
-    // the x402 record. The cooldown / daily-cap checks inside the DO are
-    // run pre-insert, so this call returns 429 (with cooldown / daily_limit
-    // metadata) when the agent is over-limit. We MUST do this before
-    // calling stagePayment so we don't end up with an orphaned staged
-    // payment for a request that the agent isn't allowed to file anyway.
+    // Run cooldown / daily-cap checks via the DO before staging the payment
+    // so an over-limit agent never produces an orphan staged payment for a
+    // request that would have been rejected anyway.
     const stagedSignalResult = await createSignal(c.env, {
       signal_id: provisionalSignalId,
       beat_slug: beat_slug as string,
@@ -480,20 +477,7 @@ signalsRouter.post("/api/signals", signalRateLimit, async (c) => {
       disclosure: sanitizedDisclosure,
       pending_payment: true,
     });
-    if (!stagedSignalResult.ok) {
-      if (stagedSignalResult.daily_limit) {
-        const res = c.json(
-          { error: stagedSignalResult.error, daily_limit: stagedSignalResult.daily_limit },
-          429
-        );
-        res.headers.set("Retry-After", String(stagedSignalResult.daily_limit.retry_after));
-        return res;
-      }
-      if (stagedSignalResult.cooldown) {
-        return c.json({ error: stagedSignalResult.error, cooldown: stagedSignalResult.cooldown }, 429);
-      }
-      return c.json({ error: stagedSignalResult.error }, stagedSignalResult.status ?? 400);
-    }
+    if (!stagedSignalResult.ok) return respondCreateSignalError(c, stagedSignalResult);
 
     const stageResult = await stagePayment(c.env, {
       paymentId: verification.paymentId,
@@ -563,8 +547,7 @@ signalsRouter.post("/api/signals", signalRateLimit, async (c) => {
     );
   }
 
-  // Publisher bypass / payments-disabled fall-through. createSignal writes
-  // the row at status='submitted' and runs commit effects in-band.
+  // Publisher bypass / payments-disabled fall-through.
   const result = await createSignal(c.env, {
     beat_slug: beat_slug as string,
     btc_address: btc_address as string,
@@ -575,23 +558,7 @@ signalsRouter.post("/api/signals", signalRateLimit, async (c) => {
     disclosure: sanitizedDisclosure,
   });
 
-  if (!result.ok) {
-    if (result.daily_limit) {
-      const res = c.json(
-        { error: result.error, daily_limit: result.daily_limit },
-        429
-      );
-      res.headers.set("Retry-After", String(result.daily_limit.retry_after));
-      return res;
-    }
-    if (result.cooldown) {
-      return c.json(
-        { error: result.error, cooldown: result.cooldown },
-        429
-      );
-    }
-    return c.json({ error: result.error }, result.status ?? 400);
-  }
+  if (!result.ok) return respondCreateSignalError(c, result);
 
   const logger = c.get("logger");
   logger.info("signal created", {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -13,7 +13,7 @@
     // Set to "false" to enable x402 paywall for past briefs; any other value (or omit) = free access
     "BRIEFS_FREE": "true",
     // Set to "true" to require x402 payment for signal submission; "false" = grace period with warnings
-    "SIGNALS_REQUIRE_PAYMENT": "false"
+    "SIGNALS_REQUIRE_PAYMENT": "true"
   },
 
   // KV namespace — rate limiting and agent cache
@@ -95,7 +95,7 @@
         // Set to "false" to enable x402 paywall for past briefs; any other value (or omit) = free access
         "BRIEFS_FREE": "true",
         // Set to "true" to require x402 payment for signal submission; "false" = grace period with warnings
-        "SIGNALS_REQUIRE_PAYMENT": "false"
+        "SIGNALS_REQUIRE_PAYMENT": "true"
       },
 
       "kv_namespaces": [
@@ -143,7 +143,7 @@
         // Set to "false" to enable x402 paywall for past briefs; any other value (or omit) = free access
         "BRIEFS_FREE": "true",
         // Set to "true" to require x402 payment for signal submission; "false" = grace period with warnings
-        "SIGNALS_REQUIRE_PAYMENT": "false"
+        "SIGNALS_REQUIRE_PAYMENT": "true"
       },
 
       "kv_namespaces": [


### PR DESCRIPTION
Refs #666.

Turns on x402 payments for signal submissions, with the canonical 202-pending / 201-confirmed pattern already used by `brief.ts` and `classifieds.ts`. Treats this as the template for every future paid endpoint.

## Summary

- 100-sat sBTC payment required for `POST /api/signals` (publisher bypass via BIP-322)
- Genesis (level >= 2) identity gate runs before payment so unverified agents aren't charged
- New `signal_submission` payment stage kind alongside `brief_access` / `classified_submission`
- Stage-time INSERTs the signal at `status='pending_payment'` so cooldown / daily-cap queries naturally include it (slot reserved at stage time)
- `pending_payment` rows are author-only — invisible to public listings, counts, leaderboard, and brief compilation; authors see their own with `?include_pending=true` + BIP-322 auth proving they own the agent address
- Discard cleanly DELETEs the staged row — no stats / streak / referral drift because commit effects only run at finalize
- Treasury migrated `SP236MA9...` → `SP1KGHF33...` (operator handles legacy recovery in #803)
- `SIGNALS_REQUIRE_PAYMENT=true` flips on; the in-band grace-period warning has been served on every successful submission since 2026-03-28 (~5 weeks of advance notice)

## Architecture

- `kind → finalize` callback registry in `news-do.ts:reconcileStageRow` replaces the inline if/else branches; `brief_access` and `classified_submission` migrate onto it alongside the new `signal_submission` (behaviour byte-identical for the existing two).
- `discardRegistry` parallel to `finalizeRegistry` — most kinds noop, `signal_submission` deletes the staged row.
- Three free helpers (`applyCorrespondentStatsBump`, `applyStreakBumpForSignal`, `applyReferralCreditOnFirstSignal`) extracted from `createSignal` so finalize can call them with the signal's own `created_at` (UTC-midnight-crossing settlements still credit the day filed).
- `correspondent_stats` queries (drift recompute, per-agent recompute, migration backfill) gain `status != 'pending_payment'` so totals only count finalized signals.

## Visibility / counts (post-review hardening)

- `GET /api/signals` excludes `pending_payment` by default; pass `?agent=<bc1q>&include_pending=true` (or `?status=pending_payment`) **with BIP-322 X-BTC-* headers proving you own the agent address** to see staged rows.
- `GET /api/signals/counts` adds a `pending_payment` bucket only when `?include_pending=true` is passed, requiring the same auth.
- `GET /api/signals/:id` returns 404 for `pending_payment` rows (anyone holding a provisional `signalId` from the 202 body must not be able to fetch unpublished content).
- Edge cache is bypassed entirely for any `wantsPending` request — `Cache-Control: private, no-store` on the response so no downstream CDN holds a copy either. Prevents the cache-key-doesn't-include-auth-headers leak that arc0btc caught (P1).
- Leaderboard subqueries (`signal_count`, `days_active`, distinct btc_address seed) all exclude pending.

## Schema migration v30

- Adds `signals.payment_txid TEXT`
- Adds `idx_signals_status_btc_created` (status, btc_address, created_at DESC) for cooldown/cap queries against pending rows

## Review feedback addressed in-PR

- **Codex P1** (idempotent paymentId retry) — `getPaymentStage` short-circuit before cooldown, filtered to `stageStatus !== "discarded"` so retries against a terminally-failed paymentId surface the relay's actual error
- **Codex P2** (orphan rollback) — `deletePendingSignal` helper + `DELETE /signals/:id/pending` DO route, scoped to `pending_payment` for safety; rollback failure now logs `error` and returns 500
- **Copilot** (auth gate on `include_pending`) — full BIP-322 gate on `/api/signals` and `/api/signals/counts`
- **Copilot** (`/api/signals/:id` leak) — 404 for pending rows
- **arc0btc P1** (edge cache bypass of auth gate) — cache short-circuit + `Cache-Control: private, no-store` on `wantsPending` paths
- **pbtc21 N2** (current level in 403) — IDENTITY_REQUIRED body now carries `registered`, `level`, `levelName`
- **pbtc21 S1** (`scoring-math.test.ts` flake) — fixed (was hardcoded `2026-03-10`, aged out of the 30-day rolling window). Full suite is now 418/418 — first all-green run on this branch.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — **418/418** (including the previously-flaky scoring-math test, fixed in this PR)
- [x] CI all green: typecheck, Analyze (actions + js-ts), preview, Workers Builds, CodeQL, Snyk
- [x] Targeted regression net (payment-staging, alarm-sweep, classifieds, brief-compile-reconciliation, pending-payment-route-guards, signals, correspondent-stats, leaderboard, referrals, signal-counts-since): all green
- [x] 14 new tests covering signal_submission stage / sweep / visibility / discard / auth gate / cache-bypass / cross-agent address-mismatch
- [x] Best-effort smoke test on staging preview by Arc — 8/11 steps pass; the 3 that don't are blocked by missing beat-seed data on the preview, **not by anything in this PR** (filed as #805). arc0btc explicitly said: *"PR itself looks good in everything we could test … filed in lieu of blocking PR #802."*
- [x] arc0btc APPROVED after the P1 cache-leak fix landed

## Follow-up issues filed

- #803 — operator recovery of stranded sBTC at legacy `SP236MA9...` treasury
- #804 — design: per-kind `PAYMENT_STAGE_TTL_MS` with discard-on-expiry for `signal_submission`
- #805 — staging preview missing beat-seed data (blocks 3 of 11 smoke-test steps)
- #806 — extract `scripts/test-signal-payment.ts` wrapper so future paid-endpoint rollouts get a reusable runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)