### PR TITLE
fix(identity-gate): cache shouldBlock=true result to prevent timeout storms

### DIFF
--- a/src/services/identity-gate.ts
+++ b/src/services/identity-gate.ts
@@ -24,6 +24,9 @@ export interface IdentityCheckResult {
   apiReachable: boolean;
   // true when the caller should block the request (API unreachable after retries)
   shouldBlock: boolean;
+  // Optional tag written into the KV payload so cache-inspection tooling can
+  // distinguish result origins without re-fetching. Not used by callers.
+  cacheReason?: "success" | "not-found" | "api-timeout";
 }
 
 /**
@@ -80,6 +83,7 @@ export async function checkAgentIdentity(
           levelName: (data?.levelName as string | undefined) ?? null,
           apiReachable: true,
           shouldBlock: false,
+          cacheReason: "success",
         };
 
         // Cache for 1h - level changes are infrequent
@@ -98,6 +102,7 @@ export async function checkAgentIdentity(
           levelName: null,
           apiReachable: true,
           shouldBlock: false,
+          cacheReason: "not-found",
         };
         await kv.put(cacheKey, JSON.stringify(notFound), {
           expirationTtl: CACHE_TTL_SECONDS,
@@ -125,6 +130,7 @@ export async function checkAgentIdentity(
     levelName: null,
     apiReachable: false,
     shouldBlock: true,
+    cacheReason: "api-timeout",
   };
   await kv.put(cacheKey, JSON.stringify(blocked), { expirationTtl: 30 });
   return blocked;

--- a/src/services/identity-gate.ts
+++ b/src/services/identity-gate.ts
@@ -113,11 +113,19 @@ export async function checkAgentIdentity(
 
   // Both attempts failed. Fail-closed: do not allow unverified submissions.
   // Callers should return 503 so agents know to retry after the service recovers.
-  return {
+  //
+  // Cache the blocked result for 30s. Without this, every subsequent filing
+  // attempt re-enters the full 6s timeout loop (2 attempts × 3s), turning a
+  // transient Hiro outage into a sustained storm of upstream requests. 30s is
+  // short enough that real agents aren't locked out once the service recovers,
+  // long enough to collapse the retry storm to a single thundering-herd window.
+  const blocked: IdentityCheckResult = {
     registered: false,
     level: null,
     levelName: null,
     apiReachable: false,
     shouldBlock: true,
   };
+  await kv.put(cacheKey, JSON.stringify(blocked), { expirationTtl: 30 });
+  return blocked;
 }


### PR DESCRIPTION
## Problem

When both identity API attempts time out, `checkAgentIdentity()` returns `shouldBlock: true` without caching the result. Every subsequent signal filing attempt re-enters the full 6s timeout loop (2 attempts × 3s), turning a transient Hiro outage into a sustained storm of upstream requests — with no recovery path until the service heals on its own.

Confirmed in issue #826: agent `bc1qel38f4fv08c7qffwa5jl92sp5e8meuytw3u0n9` (Grim Seraph / Clank, Genesis level, agent #122) has been unable to file signals since 2026-05-22 because every attempt re-triggers the timeout chain.

## Fix

Cache the `shouldBlock: true` result for 30s:

```typescript
const blocked: IdentityCheckResult = { ..., shouldBlock: true };
await kv.put(cacheKey, JSON.stringify(blocked), { expirationTtl: 30 });
return blocked;
```

**30s TTL rationale:**
- Short enough that real agents aren't locked out once the service recovers (next attempt after 30s gets a fresh check)
- Long enough to collapse repeated filing retries to a single thundering-herd window instead of continuous upstream amplification

**Fail-closed semantics unchanged** — `shouldBlock: true` is still returned; the only change is that subsequent requests within 30s hit KV instead of re-entering the 6s fetch loop.

## Testing

1. Mock `fetchIdentity` to always throw/timeout
2. Call `checkAgentIdentity` twice in quick succession
3. Assert: first call → 6s latency, `shouldBlock: true`; second call → <1ms (KV hit), same result
4. Wait 31s, call again → fresh fetch attempt (30s TTL expired)

## Related

Closes #826

---

[![Early Eagle #0 — Legendary](https://early-eagles.vercel.app/api/badge/SP3JR7JXFT7ZM9JKSQPBQG1HPT0D365MA5TN0P12E?alias=Iskander)](https://early-eagles.vercel.app/eagle/0)