### PR TITLE
Fix status beat activity consistency

### DIFF
--- a/src/__tests__/agent-status.test.ts
+++ b/src/__tests__/agent-status.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { SELF } from "cloudflare:test";
+
+const AGENT_ADDR = "bc1qstatusactive000000000000000000000000";
+
+beforeAll(async () => {
+  const res = await SELF.fetch("http://example.com/api/test-seed", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      beat_claims: [
+        {
+          beat_slug: "bitcoin-macro",
+          btc_address: AGENT_ADDR,
+          claimed_at: new Date().toISOString(),
+          status: "active",
+        },
+      ],
+    }),
+  });
+  expect(res.status).toBe(200);
+});
+
+describe("GET /api/status/:address", () => {
+  it("does not report inactive beat status when the agent can file a signal", async () => {
+    const res = await SELF.fetch(`http://example.com/api/status/${AGENT_ADDR}`);
+    expect(res.status).toBe(200);
+
+    const body = await res.json<{
+      beatStatus: string | null;
+      beat: { beatStatus: string } | null;
+      beats: Array<{ beatStatus: string }>;
+      canFileSignal: boolean;
+      actions: Array<{ type: string }>;
+    }>();
+
+    expect(body.canFileSignal).toBe(true);
+    expect(body.actions.some((action) => action.type === "file-signal")).toBe(true);
+    expect(body.beatStatus).toBe("active");
+    expect(body.beat?.beatStatus).toBe("active");
+    expect(body.beats.every((beat) => beat.beatStatus === "active")).toBe(true);
+  });
+});

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -3889,10 +3889,6 @@ export class NewsDO extends DurableObject<Env> {
         });
       }
 
-      // Backward compat: expose first beat as `beat` / `beatStatus`
-      const beat = agentBeats.length > 0 ? agentBeats[0] : null;
-      const beatStatus = beat ? beat.beatStatus : null;
-
       // Last signal time for cooldown
       const lastSignalRows = this.ctx.storage.sql
         .exec(
@@ -3993,13 +3989,21 @@ export class NewsDO extends DurableObject<Env> {
         actions.push({ type: "inscribe-brief", description: "Today's brief is ready to inscribe" });
       }
 
+      const responseBeats = canFileSignal
+        ? agentBeats.map((b) => ({ ...b, beatStatus: "active" as const }))
+        : agentBeats;
+
+      // Backward compat: expose first beat as `beat` / `beatStatus`
+      const beat = responseBeats.length > 0 ? responseBeats[0] : null;
+      const beatStatus = beat ? beat.beatStatus : null;
+
       return c.json({
         ok: true,
         data: {
           address,
           beat,
           beatStatus,
-          beats: agentBeats,
+          beats: responseBeats,
           signals: signalRows,
           totalSignals,
           streak,
@@ -5680,6 +5684,7 @@ export class NewsDO extends DurableObject<Env> {
         streaks: 0,
         leaderboard_snapshots: 0,
         classifieds: 0,
+        beat_claims: 0,
       };
 
       // Seed signals
@@ -5819,6 +5824,25 @@ export class NewsDO extends DurableObject<Env> {
               (row.total_signals as number) ?? 0
             );
             inserted.streaks++;
+          } catch {
+            // Skip invalid rows silently
+          }
+        }
+      }
+
+      // Seed beat claims
+      if (Array.isArray(body.beat_claims)) {
+        for (const row of body.beat_claims as Array<Record<string, unknown>>) {
+          try {
+            this.ctx.storage.sql.exec(
+              `INSERT OR REPLACE INTO beat_claims (beat_slug, btc_address, claimed_at, status)
+               VALUES (?, ?, ?, ?)`,
+              row.beat_slug as string,
+              row.btc_address as string,
+              (row.claimed_at as string) ?? new Date().toISOString(),
+              (row.status as string) ?? "active"
+            );
+            inserted.beat_claims++;
           } catch {
             // Skip invalid rows silently
           }


### PR DESCRIPTION
## Summary
- keep `/api/status/:address` beat status consistent with `canFileSignal`
- report returned beats as active when the agent can file a signal
- add a focused integration test for the `beatStatus: inactive` + `canFileSignal: true` regression
- extend the test seed helper to seed `beat_claims` rows for status endpoint coverage

Fixes #832.

## Tests
- `npm test -- src/__tests__/agent-status.test.ts`
- `npm run typecheck`
- `npm run check` (passes with existing lint warnings)
- `npm test` (exited 0; Cloudflare workerd printed internal runtime noise during the full suite)