### PR TITLE
perf(newsdo): batch N+1 queries and index payment_staging sweep

### DIFF
--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -2961,11 +2961,10 @@ export class NewsDO extends DurableObject<Env> {
         paymentTxid
       );
 
-      for (const t of signalTags) {
+      if (signalTags.length > 0) {
         this.ctx.storage.sql.exec(
-          "INSERT INTO signal_tags (signal_id, tag) VALUES (?, ?)",
-          signalId,
-          t
+          `INSERT INTO signal_tags (signal_id, tag) VALUES ${signalTags.map(() => "(?, ?)").join(", ")}`,
+          ...signalTags.flatMap((t) => [signalId, t])
         );
       }
 
@@ -3130,11 +3129,10 @@ export class NewsDO extends DurableObject<Env> {
         originalId
       );
 
-      for (const t of correctionTags) {
+      if (correctionTags.length > 0) {
         this.ctx.storage.sql.exec(
-          "INSERT INTO signal_tags (signal_id, tag) VALUES (?, ?)",
-          newId,
-          t
+          `INSERT INTO signal_tags (signal_id, tag) VALUES ${correctionTags.map(() => "(?, ?)").join(", ")}`,
+          ...correctionTags.flatMap((t) => [newId, t])
         );
       }
 
@@ -3388,30 +3386,27 @@ export class NewsDO extends DurableObject<Env> {
         1000
       );
 
-      // When agent is specified, return all their classifieds regardless of status/expiry
+      // When agent is specified, return all their classifieds regardless of status/expiry.
+      // The category filter is appended only when present so SQLite can use the
+      // btc_address / category indexes instead of a (?  IS NULL OR col = ?) scan.
       const rows = agent
         ? this.ctx.storage.sql
             .exec(
               `SELECT * FROM classifieds
-               WHERE btc_address = ?1
-                 AND (?2 IS NULL OR category = ?2)
+               WHERE btc_address = ?${category ? " AND category = ?" : ""}
                ORDER BY created_at DESC
-               LIMIT ?3`,
-              agent,
-              category,
-              limit
+               LIMIT ?`,
+              ...(category ? [agent, category, limit] : [agent, limit])
             )
             .toArray()
         : this.ctx.storage.sql
             .exec(
               `SELECT * FROM classifieds
                WHERE expires_at > ${ISO_NOW_SQL}
-                 AND status = 'approved'
-                 AND (?1 IS NULL OR category = ?1)
+                 AND status = 'approved'${category ? " AND category = ?" : ""}
                ORDER BY created_at DESC
-               LIMIT ?2`,
-              category,
-              limit
+               LIMIT ?`,
+              ...(category ? [category, limit] : [limit])
             )
             .toArray();
       return c.json({
@@ -4327,25 +4322,33 @@ export class NewsDO extends DurableObject<Env> {
         );
         voided = voidCursor.rowsWritten;
 
-        for (const signalId of validIds) {
+        // Batch the per-signal address lookup into one IN-list query instead of
+        // one PK SELECT per signal (validIds is deduped and non-empty here).
+        const payoutAddrById = new Map<string, string>();
+        {
           const sigRows = this.ctx.storage.sql
             .exec(
-              `SELECT btc_address
+              `SELECT id, btc_address
                FROM signals
-               WHERE id = ?1
-                 AND created_at >= ?2
-                 AND created_at < ?3`,
-              signalId,
+               WHERE id IN (${validIds.map(() => "?").join(", ")})
+                 AND created_at >= ? AND created_at < ?`,
+              ...validIds,
               dayStart,
               dayEnd
             )
             .toArray();
-          if (sigRows.length === 0) {
+          for (const r of sigRows) {
+            const row = r as { id: string; btc_address: string };
+            payoutAddrById.set(row.id, row.btc_address);
+          }
+        }
+
+        for (const signalId of validIds) {
+          const btcAddress = payoutAddrById.get(signalId);
+          if (btcAddress === undefined) {
             skipped++;
             continue;
           }
-
-          const btcAddress = (sigRows[0] as Record<string, unknown>).btc_address as string;
 
           const revivedCursor = this.ctx.storage.sql.exec(
             `UPDATE earnings
@@ -4662,28 +4665,37 @@ export class NewsDO extends DurableObject<Env> {
       const dayStart = getUTCDayStart(brief_date as string);
       const dayEnd = getUTCDayEnd(brief_date as string);
 
-      const selectedSignals: BriefSignal[] = [];
-      for (let i = 0; i < selectedIds.length; i++) {
-        const signalId = selectedIds[i];
+      // Batch the per-signal lookup into one IN-list query instead of one PK
+      // SELECT per selected signal (selectedIds is deduped and non-empty here).
+      const signalById = new Map<string, { id: string; btc_address: string; status: SignalStatus; created_at: string }>();
+      {
         const sigRows = this.ctx.storage.sql
           .exec(
             `SELECT id, btc_address, status, created_at
              FROM signals
-             WHERE id = ?1
-               AND created_at >= ?2
-               AND created_at < ?3`,
-            signalId,
+             WHERE id IN (${selectedIds.map(() => "?").join(", ")})
+               AND created_at >= ? AND created_at < ?`,
+            ...selectedIds,
             dayStart,
             dayEnd
           )
           .toArray();
-        if (sigRows.length === 0) {
+        for (const r of sigRows) {
+          const row = r as { id: string; btc_address: string; status: SignalStatus; created_at: string };
+          signalById.set(row.id, row);
+        }
+      }
+
+      const selectedSignals: BriefSignal[] = [];
+      for (let i = 0; i < selectedIds.length; i++) {
+        const signalId = selectedIds[i];
+        const signalRow = signalById.get(signalId);
+        if (signalRow === undefined) {
           return c.json(
             { ok: false, error: `Signal "${signalId}" is not part of brief date ${brief_date as string}` } satisfies DOResult<unknown>,
             400
           );
         }
-        const signalRow = sigRows[0] as { id: string; btc_address: string; status: SignalStatus; created_at: string };
         if (signalRow.status !== "approved" && signalRow.status !== "brief_included") {
           return c.json(
             { ok: false, error: `Signal "${signalId}" is not compile-eligible from status "${signalRow.status}"` } satisfies DOResult<unknown>,

--- a/src/objects/schema.ts
+++ b/src/objects/schema.ts
@@ -171,6 +171,7 @@ CREATE INDEX IF NOT EXISTS idx_corrections_address      ON corrections(btc_addre
 CREATE INDEX IF NOT EXISTS idx_referral_scout           ON referral_credits(scout_address);
 CREATE INDEX IF NOT EXISTS idx_referral_recruit         ON referral_credits(recruit_address);
 CREATE INDEX IF NOT EXISTS idx_payment_staging_status   ON payment_staging(stage_status);
+CREATE INDEX IF NOT EXISTS idx_payment_staging_status_created ON payment_staging(stage_status, created_at);
 `;
 
 /**


### PR DESCRIPTION
## Summary

A follow-up Cloudflare cost/performance audit (using `docs/cloudflare-cost-runbook.md` as the reference catalog) found four DO SQLite hot-path antipatterns that the April bill-reduction sprint (F1/F2/B1/B2) did not catch. This PR fixes all four. The sprint's own fixes are intact and untouched.

## Changes

| # | Fix | File | Class |
|---|-----|------|-------|
| 1 | `signal_tags` inserts → one multi-row `INSERT` instead of one `exec` per tag (create + correction paths) | `news-do.ts` | per-tag statement fan-out on every signal submission |
| 2 | Brief payout + compile signal lookups → single `WHERE id IN (...)` read into a `Map` instead of one PK `SELECT` per signal | `news-do.ts` | N+1 read loop |
| 3 | Classifieds list → drop `(? IS NULL OR category = ?)` for dynamic SQL so the `btc_address` / `category` indexes are usable | `news-do.ts` | the OR-NULL scan the runbook removed elsewhere |
| 4 | Add `idx_payment_staging_status_created (stage_status, created_at)` so the alarm sweep range-seeks instead of scanning all staged rows | `schema.ts` | missing composite index for `WHERE stage_status IN (...) AND created_at < ?` |

## Cost framing (honest)

- **#1** is the hottest path — it fires on every signal submission, so it matters most now that free filing is being re-opened. It mainly cuts statement-execution/CPU per request (the N rows are still written either way).
- **#2** is a correctness-neutral read-batching; brief compile is low-frequency (daily) and the reads were PK lookups, so the billing win is modest — included for consistency with the F1 IN-list pattern already used a few lines below.
- **#3 / #4** are the genuine read-scan-class items (the runbook's target), though both are currently low-volume.

All writes and error semantics are preserved exactly; #2 keeps the same skip/return behaviour, just sourced from a `Map`. Index #4 lives in the self-healing base `SCHEMA_SQL` so it applies to existing DOs on next cold start via `CREATE INDEX IF NOT EXISTS`.

## Testing

- `npm run typecheck` clean
- `68/68` passing across `signals`, `corrections`, `classifieds`, `brief-compile-reconciliation`, `payment-staging`, `payment-stage-alarm-sweep`