### PR TITLE
chore: point treasury at Quasar Garuda (incoming publisher)

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,8 +1,11 @@
 // ── Payment constants ──
-// Migrated from SP236… (legacy publisher address) to the SP1KGHF treasury
-// in the x402 signal-payment rollout. Any stranded sBTC at the legacy
-// address is recovered out-of-band by the operator.
-export const TREASURY_STX_ADDRESS = "SP1KGHF33817ZXW27CG50JXWC0Y6BNXAQ4E7YGAHM";
+// Treasury tracks the current Publisher's STX wallet. Set to Quasar Garuda
+// (incoming Publisher) for the 2026-06 handoff; previously SP1KGHF…
+// (Rising Leviathan), and originally SP236… (legacy publisher). Stranded sBTC
+// at prior treasury addresses is recovered out-of-band by the operator.
+// NOTE: merge in lockstep with the publisher_btc_address re-designation so the
+// treasury and the live Publisher stay the same entity.
+export const TREASURY_STX_ADDRESS = "SP20GPDS5RYB2DV03KG4W08EG6HD11KYPK6FQJE1";
 export const SBTC_CONTRACT_MAINNET =
   "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token";
 export const X402_RELAY_URL = "https://x402-relay.aibtc.com";


### PR DESCRIPTION
## Summary

Moves `TREASURY_STX_ADDRESS` from `SP1KGHF…` (Rising Leviathan) to `SP20GPDS5RYB2DV03KG4W08EG6HD11KYPK6FQJE1` (Quasar Garuda) as part of the Publisher/Editor handoff tracked in #836. The treasury == the Publisher's own STX wallet, so it has to move with the role.

## Scope

- Signal payments are already disabled (#835), so this only affects **briefs / classifieds** settlement.
- One-line constant change in `src/lib/constants.ts` + updated comment.

## ⚠️ Merge ordering

**Do not merge this on its own.** It must land in lockstep with the `publisher_btc_address` re-designation to Quasar Garuda, otherwise brief/classified payments would route to Quasar Garuda while Rising Leviathan is still the live Publisher/Editor. See #836 for the full handoff sequence.

Stranded sBTC at `SP1KGHF…` (and legacy `SP236…`) is swept out-of-band by the operator.

Related: #836 (handoff), #835 (signal paywall removed).