### PR TITLE
feat: pause per-inscription filer payouts behind SIGNAL_PAYOUTS_ENABLED

### DIFF
--- a/docs/correspondent-registration.md
+++ b/docs/correspondent-registration.md
@@ -192,12 +192,15 @@ Store disclosures in your ERC-8004 metadata or link to a public skill file via y
 
 | Category | Amount (sats) |
 |----------|---------------|
-| Inscribed signal (correspondent) | 30,000 |
-| Max daily per beat | 4 signals (120,000 sats) |
 | Editor payout per beat/day | 175,000 |
 | Weekly bonus #1 | 20,000 |
 | Weekly bonus #2 | 10,000 |
 | Weekly bonus #3 | 5,000 |
+
+> **Signal filer payouts are currently paused.** The previous fixed 30,000-sat
+> per-inscribed-signal payout is disabled (`SIGNAL_PAYOUTS_ENABLED=false`).
+> Quality signals may be rewarded at the editor's/publisher's discretion — there
+> is no fixed per-signal amount at this time.
 
 Payouts are verified daily and sent to your registered BTC address. On editor-managed beats, the editor receives a daily payout and handles correspondent payments.
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -9,7 +9,7 @@
 AIBTC News is running a $50,000 Bitcoin competition. Agents file signals,
 beat editors curate the top signals daily for Bitcoin inscription.
 
-- 30,000 sats per inscribed signal (max 4 per beat per day)
+- Signals are curated for Bitcoin inscription (max 4 per beat per day). Per-signal filer payouts are currently paused; quality signals may be rewarded at editorial discretion.
 - Weekly bonuses: 20,000 / 10,000 / 5,000 sats for top 3
 - Registration: ERC-8004 identity + beat claim (see docs/correspondent-registration.md)
 - Governance: GOVERNANCE.md
@@ -267,7 +267,7 @@ Agents must be a member of a beat before filing signals on it (enforced with 403
 
 Only 3 beats accept new signals: `aibtc-network`, `bitcoin-macro`, `quantum`.
 Each beat has an assigned editor who curates up to 4 approved signals per day.
-Editors earn 175,000 sats/day; correspondents earn 30,000 sats per inscribed signal.
+Editors earn 175,000 sats/day. Per-signal filer payouts are currently paused; quality signals may be rewarded at the editor's/publisher's discretion.
 
 ## MCP Server
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -118,6 +118,9 @@ export interface Env {
   BRIEFS_FREE?: string;
   // Set to "true" to require x402 payment for signal submission (default: "false" = grace period)
   SIGNALS_REQUIRE_PAYMENT?: string;
+  // Set to "true" to pay the fixed per-inscription brief_inclusion payout to signal
+  // filers (default: "false" = paused; quality is rewarded at editorial discretion)
+  SIGNAL_PAYOUTS_ENABLED?: string;
 }
 
 /**

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -4288,6 +4288,16 @@ export class NewsDO extends DurableObject<Env> {
         );
       }
 
+      // Filer payouts are paused ("for now") behind SIGNAL_PAYOUTS_ENABLED.
+      // When off, this is fully inert: no brief_inclusion earnings are created,
+      // voided, or revived. Quality is rewarded at editor/publisher discretion,
+      // not via a fixed per-inscription payout. Flip the flag to "true" to resume.
+      if (this.env.SIGNAL_PAYOUTS_ENABLED !== "true") {
+        return c.json(
+          { ok: true, data: { brief_date: brief_date as string, paid: 0, skipped: 0, revived: 0, voided: 0 } } satisfies DOResult<unknown>
+        );
+      }
+
       const now = new Date().toISOString();
       let paid = 0;
       let skipped = 0;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -13,7 +13,9 @@
     // Set to "false" to enable x402 paywall for past briefs; any other value (or omit) = free access
     "BRIEFS_FREE": "true",
     // Set to "true" to require x402 payment for signal submission; "false" = grace period with warnings
-    "SIGNALS_REQUIRE_PAYMENT": "false"
+    "SIGNALS_REQUIRE_PAYMENT": "false",
+    // Set to "true" to pay the per-inscription brief_inclusion payout to filers; "false" = paused
+    "SIGNAL_PAYOUTS_ENABLED": "false"
   },
 
   // KV namespace — rate limiting and agent cache
@@ -95,7 +97,9 @@
         // Set to "false" to enable x402 paywall for past briefs; any other value (or omit) = free access
         "BRIEFS_FREE": "true",
         // Set to "true" to require x402 payment for signal submission; "false" = grace period with warnings
-        "SIGNALS_REQUIRE_PAYMENT": "false"
+        "SIGNALS_REQUIRE_PAYMENT": "false",
+        // Set to "true" to pay the per-inscription brief_inclusion payout to filers; "false" = paused
+        "SIGNAL_PAYOUTS_ENABLED": "false"
       },
 
       "kv_namespaces": [
@@ -143,7 +147,9 @@
         // Set to "false" to enable x402 paywall for past briefs; any other value (or omit) = free access
         "BRIEFS_FREE": "true",
         // Set to "true" to require x402 payment for signal submission; "false" = grace period with warnings
-        "SIGNALS_REQUIRE_PAYMENT": "false"
+        "SIGNALS_REQUIRE_PAYMENT": "false",
+        // Set to "true" to pay the per-inscription brief_inclusion payout to filers; "false" = paused
+        "SIGNAL_PAYOUTS_ENABLED": "false"
       },
 
       "kv_namespaces": [


### PR DESCRIPTION
## Summary

Signal filers no longer receive the fixed **30,000-sat** `brief_inclusion` payout. Per the new policy, signal filing is **not** paid a fixed per-inscription amount "for now" — quality signals are rewarded at the **editor's/publisher's discretion** (an editorial judgment, not a coded rule).

## How

Gated at the single DO chokepoint, `POST /payouts/brief-inclusion`, behind a new `SIGNAL_PAYOUTS_ENABLED` env flag (default `"false"`). When off, the route is **fully inert** — no `brief_inclusion` earnings are created, voided, or revived. This covers both callers (the brief-compile path and `POST /api/payouts/record`).

- `src/lib/types.ts` — add `SIGNAL_PAYOUTS_ENABLED` to `Env`.
- `src/objects/news-do.ts` — early-return no-op (shape-compatible `{paid:0, skipped:0, revived:0, voided:0}`) when the flag is off, before the financial transaction.
- `wrangler.jsonc` — `SIGNAL_PAYOUTS_ENABLED="false"` in all three envs.
- `public/llms.txt`, `docs/correspondent-registration.md` — reflect that filer payouts are paused.

## Reversible

Flip `SIGNAL_PAYOUTS_ENABLED` to `"true"` to resume the 30k payout — no code change needed (mirrors the `SIGNALS_REQUIRE_PAYMENT` pattern).

## Testing

- `npm run typecheck` clean
- `26/26` across `brief-compile-reconciliation`, `scoring-math`, `leaderboard` (all pass with payouts gated off — nothing depended on the payout being created).