### PR TITLE
feat(config): operator-key bypass for one-time publisher re-designation

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -114,6 +114,10 @@ export interface Env {
   ENVIRONMENT?: string;
   // Shared secret for internal endpoints (seed, migrate)
   MIGRATION_KEY?: string;
+  // Optional one-time operator secret. When set, allows POST /api/config/publisher
+  // to re-designate the Publisher without the current Publisher's key (handoff).
+  // Set via `wrangler secret put OPERATOR_KEY`; remove after the handoff.
+  OPERATOR_KEY?: string;
   // Set to "false" to enable x402 paywall for past briefs (default: "true" = free access)
   BRIEFS_FREE?: string;
   // Set to "true" to require x402 payment for signal submission (default: "false" = grace period)

--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -78,10 +78,24 @@ configRouter.post("/api/config/publisher", async (c) => {
   // Check if Publisher is already designated
   const current = await getConfig(c.env, CONFIG_PUBLISHER_ADDRESS);
   if (current && current.value !== btc_address) {
-    return c.json(
-      { error: "Only the current Publisher can re-designate" },
-      403
-    );
+    // Operator override for handoffs when the current Publisher's key is
+    // unavailable: a one-time bypass gated on the OPERATOR_KEY Cloudflare
+    // secret (set via `wrangler secret put OPERATOR_KEY`, removed after use).
+    // No-op when OPERATOR_KEY is unset, so the default contract is unchanged.
+    const operatorKey = c.env.OPERATOR_KEY;
+    const providedKey = c.req.header("X-Operator-Key");
+    const overridden = Boolean(operatorKey) && providedKey === operatorKey;
+    if (!overridden) {
+      return c.json(
+        { error: "Only the current Publisher can re-designate" },
+        403
+      );
+    }
+    c.get("logger").warn("publisher re-designated via operator override", {
+      previous_publisher: current.value,
+      next_publisher: publisher_address,
+      caller: btc_address,
+    });
   }
 
   const result = await setConfig(c.env, CONFIG_PUBLISHER_ADDRESS, publisher_address as string);


### PR DESCRIPTION
## Summary

Adds a default-off operator bypass to `POST /api/config/publisher` so the Publisher role can be handed off **when the current Publisher's signing key is unavailable** (the Quasar Garuda handoff, #836). The publisher lives in the DO's SQLite `config` table and is otherwise only re-designatable by the current Publisher — and DO SQLite is not externally editable via the Cloudflare API or wrangler, so a deployed code path is the only way to override it.

## Behavior

- Normal path unchanged: only the current Publisher (by BIP-322 signature) can re-designate.
- **When the `OPERATOR_KEY` secret is set**, a caller presenting a matching `X-Operator-Key` header may re-designate (still BIP-322-authenticated as the caller). Use logged at `warn` for audit.
- **When `OPERATOR_KEY` is unset** (default, and after deletion post-handoff): the branch is a complete no-op — zero behavior change.

## Operator runbook (requires wrangler access)

```sh
# 1. deploy this branch (or merge, then it auto-deploys)
npx wrangler deploy

# 2. arm the bypass with a strong random secret
npx wrangler secret put OPERATOR_KEY        # paste e.g. `openssl rand -hex 32`

# 3. designate Quasar Garuda (signed by Quasar Garuda's bc1q key)
#    message signed (BIP-322): "POST /api/config/publisher:<unixSeconds>"
curl -X POST https://aibtc.news/api/config/publisher \
  -H "X-BTC-Address: bc1qxhj8qdlw2yalqpdwka8en9h29m6h4n3kyw8vcm" \
  -H "X-BTC-Timestamp: <unixSeconds>" \
  -H "X-BTC-Signature: <bip322-sig>" \
  -H "X-Operator-Key: <the secret from step 2>" \
  -H "Content-Type: application/json" \
  -d '{"btc_address":"bc1qxhj8qdlw2yalqpdwka8en9h29m6h4n3kyw8vcm","publisher_address":"bc1qxhj8qdlw2yalqpdwka8en9h29m6h4n3kyw8vcm"}'

# 4. verify
curl https://aibtc.news/api/config/publisher     # -> bc1qxhj8...

# 5. disarm
npx wrangler secret delete OPERATOR_KEY
```

To leave `main` with no bypass code at all, deploy this branch only for the operation (steps 1–5), then `wrangler deploy` from `main` — or merge and follow up with a revert.

Related: #836 (handoff), #837 (treasury, merge in lockstep).