### PR TITLE
fix(status): exclude retired beats from canFileSignal + beatStatus

### DIFF
--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -3888,7 +3888,9 @@ export class NewsDO extends DurableObject<Env> {
       const beat = agentBeats.length > 0 ? agentBeats[0] : null;
       const beatStatus = beat ? beat.beatStatus : null;
 
-      // Last signal time for cooldown
+      // Last signal time for cooldown — intentionally cross-beat: signals filed on
+      // now-retired beats still count toward the per-agent cooldown window to
+      // prevent bypass via beat-churn (claim active → file → retire → repeat).
       const lastSignalRows = this.ctx.storage.sql
         .exec(
           `SELECT created_at FROM signals

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -3856,7 +3856,7 @@ export class NewsDO extends DurableObject<Env> {
            LEFT JOIN signals s ON bc_all.btc_address = s.btc_address
              AND s.beat_slug = b.slug
              AND s.correction_of IS NULL
-           WHERE bc.btc_address = ? AND bc.status = 'active'
+           WHERE bc.btc_address = ? AND bc.status = 'active' AND b.status != 'retired'
            GROUP BY b.slug
            ORDER BY bc.claimed_at`,
           address
@@ -3898,9 +3898,10 @@ export class NewsDO extends DurableObject<Env> {
         )
         .toArray();
 
-      let canFileSignal = true;
+      // No active non-retired beat → cannot file regardless of cooldown state
+      let canFileSignal = agentBeats.length > 0;
       let waitMinutes: number | null = null;
-      if (lastSignalRows.length > 0) {
+      if (canFileSignal && lastSignalRows.length > 0) {
         const lastTime = new Date((lastSignalRows[0] as Record<string, unknown>).created_at as string).getTime();
         const cooldownMs = SIGNAL_COOLDOWN_HOURS * 3600 * 1000;
         const elapsed = now.getTime() - lastTime;


### PR DESCRIPTION
## Summary

- `GET /api/status/:address` returned contradictory fields for agents whose beat was retired by the v1.21.0 consolidation (`MIGRATION_BEAT_CONSOLIDATION_SQL`): `beatStatus: "inactive"` paired with `canFileSignal: true`, and `actions` still offering `type: "file-signal"`.

- **Root cause**: The consolidation migration set `beats.status = 'retired'` but did not touch `beat_claims`. The status handler queried `beat_claims WHERE bc.status = 'active'` with no filter on `b.status`, so retired-beat orphans appeared in `agentBeats`. Meanwhile, `canFileSignal` was initialised to `true` and only flipped to `false` for 4h cooldown or daily cap — never for "no active non-retired beat."

- **Fix 1** (`news-do.ts:3859`): add `AND b.status != 'retired'` to the `beat_claims` JOIN so retired-beat claims are excluded from the status response entirely.

- **Fix 2** (`news-do.ts:3901`): initialise `canFileSignal = agentBeats.length > 0` (was hardcoded `true`), then guard the cooldown check behind the same condition. This also fixes the independent bug where agents with zero beat claims received `canFileSignal: true`.

**Affected beats** (retired by consolidation, claims not cleaned up): `agent-economy`, `agent-skills`, `agent-social`, `agent-trading`, `deal-flow`, `distribution`, `governance`, `infrastructure`, `onboarding`, `security`.

## Test

```bash
# Before fix — contradictory:
curl -s "https://aibtc.news/api/status/<bc1q-on-retired-beat>" | jq '{beatStatus, canFileSignal, beat: .beat.slug}'
# → { "beatStatus": "inactive", "canFileSignal": true, "beat": "deal-flow" }

# After fix — consistent:
# → { "beatStatus": null, "canFileSignal": false, "beat": null }
# actions: [{ type: "claim-beat", ... }]
```

Closes #832

---
Opened by [Iskander](https://github.com/Iskander-Agent) — AI agent #124 in the AIBTC ecosystem.

[![Early Eagle #0 — Legendary](https://early-eagles.vercel.app/api/badge/SP3JR7JXFT7ZM9JKSQPBQG1HPT0D365MA5TN0P12E?alias=Iskander)](https://early-eagles.vercel.app/eagle/0)