### PR TITLE
perf(init): global KV cache in front of /init DO call

### DIFF
--- a/src/lib/do-client.ts
+++ b/src/lib/do-client.ts
@@ -241,13 +241,72 @@ export interface InitBundle {
   signalsCount1h: number;
 }
 
-/** Fetch all initial page load data in a single DO round-trip. */
-export async function getInitBundle(env: Env): Promise<InitBundle> {
+/**
+ * Global KV cache in front of the `/init` DO call.
+ *
+ * `/api/init` is edge-cached (Workers Cache API), but that cache is *per-colo*
+ * — each of Cloudflare's ~300 data centers misses independently, and every
+ * miss recomputes the `/init` bundle on the singleton DO. The bundle's
+ * `queryLeaderboard()` scans the full `signals` table several times per call,
+ * so those per-colo misses dominated the DO's rows-read usage.
+ *
+ * KV is a *global* store, so a short-TTL entry collapses all per-colo edge
+ * misses into ~1 DO recompute per TTL window worldwide. The edge cache still
+ * serves the vast majority of requests; KV only catches the edge misses that
+ * previously fell straight through to the DO.
+ *
+ * TTL is 60s — the KV minimum, and well within the tolerance of a homepage
+ * bundle that is already served with `s-maxage` in the minutes range. The key
+ * carries a version token so a shape change to `InitBundle` cannot serve a
+ * stale, incompatible payload across a deploy (bump on any shape change).
+ */
+const INIT_BUNDLE_KV_KEY = "init-bundle:v1";
+const INIT_BUNDLE_KV_TTL_SECONDS = 60;
+
+/** Fetch the `/init` bundle straight from the DO, bypassing the KV cache. */
+async function fetchInitBundleFromDO(env: Env): Promise<InitBundle> {
   const stub = getStub(env);
   const result = await doFetch<InitBundle>(stub, "/init");
   if (!result.ok) throw new Error(result.error ?? "Failed to get init bundle");
   if (result.data === undefined) throw new Error("Missing data in response");
   return result.data;
+}
+
+/**
+ * Fetch all initial page load data in a single DO round-trip, served through a
+ * global KV cache (see above). Pass `waitUntil` (e.g.
+ * `(p) => c.executionCtx.waitUntil(p)`) so the cache write on a miss does not
+ * add latency to the response; without it the write is awaited inline.
+ *
+ * All KV access is best-effort: any cache read/write failure falls through to
+ * a direct DO fetch so the endpoint never breaks on a cache blip.
+ */
+export async function getInitBundle(
+  env: Env,
+  waitUntil?: (promise: Promise<unknown>) => void
+): Promise<InitBundle> {
+  try {
+    const cached = await env.NEWS_KV.get<InitBundle>(INIT_BUNDLE_KV_KEY, "json");
+    if (cached) return cached;
+  } catch (err) {
+    console.error("[getInitBundle] KV read failed, falling through to DO:", err);
+  }
+
+  const bundle = await fetchInitBundleFromDO(env);
+
+  const writeCache = (async () => {
+    try {
+      await env.NEWS_KV.put(INIT_BUNDLE_KV_KEY, JSON.stringify(bundle), {
+        expirationTtl: INIT_BUNDLE_KV_TTL_SECONDS,
+      });
+    } catch (err) {
+      console.error("[getInitBundle] KV write failed:", err);
+    }
+  })();
+  if (waitUntil) waitUntil(writeCache);
+  else await writeCache;
+
+  return bundle;
 }
 
 /** Fetch all approved + brief_included signals in a single DO call. */

--- a/src/routes/init.ts
+++ b/src/routes/init.ts
@@ -25,7 +25,7 @@ initRouter.get("/api/init", async (c) => {
   const cached = await edgeCacheMatch(c);
   if (cached) return cached;
 
-  const bundle = await getInitBundle(c.env);
+  const bundle = await getInitBundle(c.env, (p) => c.executionCtx.waitUntil(p));
   const today = getUTCDate();
 
   // --- Brief ---


### PR DESCRIPTION
## Problem

The `news-singleton` Durable Object reads **~18.7B SQLite rows/month** — ~75% of the shared 25B/month included tier and ~97% of the account's total DO row reads. Traced to a single hot path:

```
GET /  ·  GET /api/init  ·  client on load
        └─► edgeCacheMatch (Workers Cache API — PER-COLO) ──miss──► getInitBundle() ──► DO /init ──► queryLeaderboard(200)
```

The edge cache is **per-colo**: each of Cloudflare's ~300 data centers misses independently, and `getInitBundle()` had **no global cache** in front of it — so every per-colo miss recomputed the whole `/init` bundle on the singleton DO. That bundle's `queryLeaderboard()` scans the ~31k-row `signals` table several times per call (a `DISTINCT btc_address` since-epoch scan plus two 30-day `GROUP BY btc_address` re-scans), which indexes can't eliminate. Result: hundreds of thousands of full-table-scan `/init` calls per month.

This is Cloudflare's [#1 named Durable Objects anti-pattern](https://developers.cloudflare.com/durable-objects/best-practices/rules-of-durable-objects/) — a global singleton recomputing shared read state per request — and the docs' recommended remedy is exactly "optimize/cache queries."

## Fix

Wrap `getInitBundle()` in a **global KV cache** (`init-bundle:v1`, 60s TTL — the KV minimum). KV is global, so all per-colo edge misses collapse into **~1 DO recompute per 60s window worldwide**. The edge cache still serves the bulk of traffic; KV only catches the misses that previously fell straight through to the DO.

- **Best-effort** — any KV read/write failure is logged and falls through to a direct DO fetch, so the endpoint can never break on a cache blip.
- **Zero added latency** — the miss-path cache write is handed to `waitUntil()`.
- **Deploy-safe** — the key carries a `v1` version token; bump it on any `InitBundle` shape change so a stale payload can't be served across a deploy (60s TTL bounds this regardless).

## Expected impact

| Metric | Before | After |
|---|---|---|
| `/init` DO calls / mo | ~470k | ~44k (**~10×**) |
| DO rows read / mo | ~18.7B (75% of tier) | <~2B (comfortably in tier) |
| Added cost | — | 1 KV read per edge-miss (negligible) |

Staleness ceiling rises by ≤60s on a bundle already served with `s-maxage` in the minutes range — no UX change.

## Verification

- `npm run typecheck` ✅
- `biome lint` on changed files — clean ✅
- `npm test` — **427/427 pass** ✅
- `wrangler deploy --dry-run` — bundles, `NEWS_KV` bound ✅

## Follow-up (not in this PR)

Fix #2 — materialize the leaderboard like `correspondent_stats` already is (recompute on write / periodic alarm, read ~200 precomputed rows) — would cut the per-call cost too, driving rows read down further. Happy to open it next.