### PR TITLE
perf(leaderboard): materialise top-N into a read-through cache

### DIFF
--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -314,6 +314,13 @@ function rowToSignal(row: Record<string, unknown>): Signal {
 const FRONT_PAGE_WINDOW_SQL = "-2 days";
 const FRONT_PAGE_MAX_ROWS = 200;
 
+// Leaderboard materialisation — see getLeaderboardCached(). CACHE_SIZE is the
+// top-N stored; all hot read paths request ≤ this. TTL bounds staleness (and
+// therefore how often the expensive full-table scan runs) to one recompute per
+// window per read burst.
+const LEADERBOARD_CACHE_SIZE = 200;
+const LEADERBOARD_CACHE_TTL_MS = 60_000;
+
 // ISO 8601 'now' for SQLite comparators against ISO-stored timestamp columns
 // (e.g. classifieds.expires_at). Default datetime('now') returns
 // 'YYYY-MM-DD HH:MM:SS' (no T, no Z), and a same-day lex compare puts 'T'
@@ -5369,7 +5376,7 @@ export class NewsDO extends DurableObject<Env> {
       // doesn't break the correspondents endpoint (preserves old .catch(() => []) behavior)
       let leaderboard: Array<Record<string, unknown>> = [];
       try {
-        leaderboard = this.queryLeaderboard(200);
+        leaderboard = this.getLeaderboardCached(200);
       } catch (e) {
         console.error("Leaderboard query failed in correspondents bundle:", e);
       }
@@ -5500,7 +5507,7 @@ export class NewsDO extends DurableObject<Env> {
       // Leaderboard — wrapped in try/catch to preserve partial results on failure
       let leaderboard: Array<Record<string, unknown>> = [];
       try {
-        leaderboard = this.queryLeaderboard(200);
+        leaderboard = this.getLeaderboardCached(200);
       } catch (e) {
         console.error("Leaderboard query failed in init bundle:", e);
       }
@@ -5552,7 +5559,7 @@ export class NewsDO extends DurableObject<Env> {
 
     // GET /leaderboard — weighted scores across all roles
     this.router.get("/leaderboard", (c) => {
-      const rows = this.queryLeaderboard(200);
+      const rows = this.getLeaderboardCached(200);
       return c.json({ ok: true, data: rows } satisfies DOResult<unknown[]>);
     });
 
@@ -5716,6 +5723,11 @@ export class NewsDO extends DurableObject<Env> {
            )`
         );
 
+        // Invalidate the materialised leaderboard so post-reset reads recompute
+        // from the now-cleared scoring tables instead of serving stale scores
+        // for up to the cache TTL.
+        this.ctx.storage.sql.exec("DELETE FROM leaderboard_cache");
+
         return c.json({
           ok: true,
           data: {
@@ -5802,6 +5814,14 @@ export class NewsDO extends DurableObject<Env> {
       if (seededSignalAddresses.size > 0) {
         this.recomputeCorrespondentStatsFor([...seededSignalAddresses]);
       }
+
+      // Bulk seeding changes every leaderboard scoring input (signals,
+      // corrections, referrals, earnings, snapshots) but bypasses the normal
+      // write path, so drop the materialised leaderboard here too — same
+      // rationale as the correspondent_stats refresh above. Without this, tests
+      // that seed then read /leaderboard or /init would see a stale cached
+      // snapshot from a prior seed within the TTL window.
+      this.ctx.storage.sql.exec("DELETE FROM leaderboard_cache");
 
       // Seed signal_tags
       if (Array.isArray(body.signal_tags)) {
@@ -6330,6 +6350,63 @@ export class NewsDO extends DurableObject<Env> {
         limit
       )
       .toArray();
+  }
+
+  /**
+   * Read-through cache in front of queryLeaderboard().
+   *
+   * queryLeaderboard() scans the ~30k-row signals table several times per call
+   * (a DISTINCT-since-epoch scan plus two 30-day GROUP BY re-scans). It ran on
+   * every /init, /leaderboard, and /correspondents-bundle request — the single
+   * largest driver of the DO's rows-read usage. This materialises the top-N into
+   * `leaderboard_cache` (one row) and serves reads from it, recomputing at most
+   * once per LEADERBOARD_CACHE_TTL_MS.
+   *
+   * Staleness is bounded by the TTL — acceptable for a leaderboard already served
+   * to clients with minute-scale s-maxage. Callers that need exact, unbounded
+   * results (weekly payouts, per-address verify, reset snapshots) keep calling
+   * queryLeaderboard() directly. `/leaderboard/reset` clears this cache so a
+   * post-reset read never serves pre-reset scores.
+   *
+   * Best-effort: any cache read/parse/write failure falls back to a live query,
+   * so the leaderboard can never break on a cache blip.
+   */
+  private getLeaderboardCached(limit: number): Array<Record<string, unknown>> {
+    // The cache only holds the top LEADERBOARD_CACHE_SIZE; larger asks go live.
+    if (limit > LEADERBOARD_CACHE_SIZE) return this.queryLeaderboard(limit);
+
+    const now = Date.now();
+    try {
+      const rows = this.ctx.storage.sql
+        .exec("SELECT computed_at, entries FROM leaderboard_cache WHERE id = 1")
+        .toArray();
+      if (rows.length > 0) {
+        const row = rows[0] as { computed_at: string; entries: string };
+        const age = now - Date.parse(row.computed_at);
+        if (age >= 0 && age < LEADERBOARD_CACHE_TTL_MS) {
+          const entries = JSON.parse(row.entries) as Array<Record<string, unknown>>;
+          return entries.slice(0, limit);
+        }
+      }
+    } catch (e) {
+      console.error("[leaderboard cache] read failed, recomputing:", e);
+    }
+
+    const fresh = this.queryLeaderboard(LEADERBOARD_CACHE_SIZE);
+    try {
+      this.ctx.storage.sql.exec(
+        `INSERT INTO leaderboard_cache (id, computed_at, entries)
+         VALUES (1, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET
+           computed_at = excluded.computed_at,
+           entries = excluded.entries`,
+        new Date(now).toISOString(),
+        JSON.stringify(fresh)
+      );
+    } catch (e) {
+      console.error("[leaderboard cache] write failed:", e);
+    }
+    return fresh.slice(0, limit);
   }
 
   /**

--- a/src/objects/schema.ts
+++ b/src/objects/schema.ts
@@ -172,6 +172,18 @@ CREATE INDEX IF NOT EXISTS idx_referral_scout           ON referral_credits(scou
 CREATE INDEX IF NOT EXISTS idx_referral_recruit         ON referral_credits(recruit_address);
 CREATE INDEX IF NOT EXISTS idx_payment_staging_status   ON payment_staging(stage_status);
 CREATE INDEX IF NOT EXISTS idx_payment_staging_status_created ON payment_staging(stage_status, created_at);
+
+-- Materialised top-N leaderboard snapshot (single row, id = 1). Pure cache:
+-- queryLeaderboard() scans the signals table several times per call, so the hot
+-- read paths (/init, /leaderboard, /correspondents-bundle) read this one row
+-- instead of recomputing. Holds no durable data — if lost, the next read simply
+-- recomputes and repopulates it. Kept in the always-re-applied base schema so it
+-- self-heals on every cold start (no migration versioning needed).
+CREATE TABLE IF NOT EXISTS leaderboard_cache (
+  id          INTEGER PRIMARY KEY CHECK (id = 1),
+  computed_at TEXT NOT NULL,
+  entries     TEXT NOT NULL
+);
 `;
 
 /**


### PR DESCRIPTION
Follow-up to #853 (fix #2 of the DO rows-read reduction). Independent of #853 — that PR caches the worker→DO `/init` call; this one cuts the cost *inside* the DO.

## Problem

`queryLeaderboard()` scans the ~30k-row `signals` table **several times per call** — a `DISTINCT btc_address` scan since the scoring epoch, plus two 30-day `GROUP BY btc_address` re-scans (signal count + distinct active days), joined against brief_signals/corrections/referrals/earnings. Indexes can't eliminate these aggregate scans.

It ran on **every** `/init`, `/leaderboard`, and `/correspondents-bundle` request — the single largest contributor to the `news-singleton` DO's ~18.7B rows read/month (~75% of the shared 25B/month included tier).

## Fix

A read-through cache (`getLeaderboardCached`) backed by a single-row `leaderboard_cache` table:

- The three hot **top-200** read paths serve from the materialised snapshot; the expensive scan runs **at most once per 60s** instead of per request.
- Callers needing exact, unbounded results — weekly payouts, `/leaderboard/verify/:address`, reset snapshots (all `limit = 10_000`) — keep calling `queryLeaderboard()` directly (`limit > CACHE_SIZE` bypasses the cache).
- **Staleness bounded by the 60s TTL** — acceptable for a leaderboard already served to clients with minute-scale `s-maxage`.
- **Best-effort** — any cache read/parse/write failure falls back to a live query, so the leaderboard can never break on a cache blip.
- `leaderboard_cache` lives in the always-re-applied base schema (pure cache, no durable data) so it **self-heals on cold start** — no migration bump.

## Invalidation

- `/leaderboard/reset` clears the cache so a post-reset read never serves pre-reset scores.
- `/test-seed` clears it too — bulk seeding bypasses the normal write path, mirroring the existing `recomputeCorrespondentStatsFor` refresh right beside it. Everyday mutations rely on the TTL (bounded 60s staleness by design).

## Impact

| | Before | After |
|---|---|---|
| Rows read per hot leaderboard read | ~30–50k (3× signals scans) | ~1 cached row (fresh hit) |
| Leaderboard recompute frequency | every `/init` · `/leaderboard` · `/correspondents-bundle` | ≤ 1 / 60s |

Combined with #853 (fewer `/init` recomputes) this takes the worker's DO rows read from ~75% of the 25B/mo included tier to comfortably inside it, with years of headroom.

## Verification

- `npm run typecheck` ✅
- `biome lint` on changed files — clean (no new warnings) ✅
- `npm test` — **427/427 pass** ✅, including `scoring-math` and `home-page`, which exercise `/leaderboard` and `/init` through the real DO (miniflare) via the new cached path
- `wrangler deploy --dry-run` — bundles ✅

Note: scoring-math tests initially failed on stale cross-test cache reads; resolved correctly by the `/test-seed` invalidation (the seed path is responsible for refreshing materialised views, as it already does for `correspondent_stats`).