### PR TITLE
perf(leaderboard): invalidate cache on writes, not just on TTL

### DIFF
--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -1405,6 +1405,25 @@ export class NewsDO extends DurableObject<Env> {
     // Internal Hono router for DO-internal routing
     this.router = new Hono();
 
+    // Invalidate the materialised leaderboard after any successful mutating
+    // request. queryLeaderboard()'s scoring inputs — signals, brief_signals,
+    // corrections, referral_credits, earnings, streaks — are all written by
+    // non-GET routes, so one post-dispatch hook keeps the cache fresh on writes
+    // instead of waiting out LEADERBOARD_CACHE_TTL_MS. Gating on HTTP method
+    // (rather than an explicit route list) means new mutating routes are covered
+    // automatically and no scoring write can be missed; the only cost is an
+    // occasional redundant invalidation from a non-scoring write (e.g. /config),
+    // which merely triggers one extra recompute on the next read. The TTL remains
+    // the backstop for the one write path that is not a router request — the
+    // alarm's payment-finalize sweep, which invalidates explicitly (see alarm()).
+    this.router.use("*", async (c, next) => {
+      await next();
+      const method = c.req.method;
+      if (method !== "GET" && method !== "HEAD" && c.res.status < 400) {
+        this.invalidateLeaderboardCache();
+      }
+    });
+
     this.router.get("/health", (c) => {
       return c.json({ ok: true, migrated: true });
     });
@@ -5723,10 +5742,9 @@ export class NewsDO extends DurableObject<Env> {
            )`
         );
 
-        // Invalidate the materialised leaderboard so post-reset reads recompute
-        // from the now-cleared scoring tables instead of serving stale scores
-        // for up to the cache TTL.
-        this.ctx.storage.sql.exec("DELETE FROM leaderboard_cache");
+        // Note: the materialised leaderboard is invalidated by the router's
+        // post-dispatch mutation hook once this handler returns, so post-reset
+        // reads recompute from the now-cleared scoring tables.
 
         return c.json({
           ok: true,
@@ -5815,13 +5833,10 @@ export class NewsDO extends DurableObject<Env> {
         this.recomputeCorrespondentStatsFor([...seededSignalAddresses]);
       }
 
-      // Bulk seeding changes every leaderboard scoring input (signals,
-      // corrections, referrals, earnings, snapshots) but bypasses the normal
-      // write path, so drop the materialised leaderboard here too — same
-      // rationale as the correspondent_stats refresh above. Without this, tests
-      // that seed then read /leaderboard or /init would see a stale cached
+      // Note: the router's post-dispatch mutation hook drops the materialised
+      // leaderboard once this seed request returns, so a subsequent /leaderboard
+      // or /init read recomputes from the freshly seeded rows rather than a stale
       // snapshot from a prior seed within the TTL window.
-      this.ctx.storage.sql.exec("DELETE FROM leaderboard_cache");
 
       // Seed signal_tags
       if (Array.isArray(body.signal_tags)) {
@@ -6410,6 +6425,22 @@ export class NewsDO extends DurableObject<Env> {
   }
 
   /**
+   * Drop the materialised leaderboard so the next read recomputes from live
+   * tables. Single-row delete — cheap — and best-effort: a failure just leaves
+   * the LEADERBOARD_CACHE_TTL_MS window to expire the entry instead. Invoked by
+   * the post-dispatch mutation hook (see the router `use` middleware) and the
+   * alarm's payment-finalize path so writes reflect on the leaderboard without
+   * waiting out the TTL.
+   */
+  private invalidateLeaderboardCache(): void {
+    try {
+      this.ctx.storage.sql.exec("DELETE FROM leaderboard_cache");
+    } catch (e) {
+      console.error("[leaderboard cache] invalidate failed:", e);
+    }
+  }
+
+  /**
    * Reconcile staged x402 payments whose client never polled /api/payment-status.
    * Picks up to `limit` rows in 'staged' older than `graceMs`, queries the relay,
    * and applies terminal outcomes via reconcileStageRow. Returns the number of
@@ -6441,7 +6472,12 @@ export class NewsDO extends DurableObject<Env> {
    */
   async alarm(): Promise<void> {
     try {
-      await this.sweepStagedPayments();
+      // Finalising staged signals bumps scoring inputs (correspondent_stats,
+      // streaks, referral credits), so drop the leaderboard cache when the sweep
+      // actually reconciled rows. This is the one scoring write path that does
+      // not flow through the router's post-dispatch invalidation hook.
+      const reconciled = await this.sweepStagedPayments();
+      if (reconciled > 0) this.invalidateLeaderboardCache();
     } catch (err) {
       console.error("[alarm] sweepStagedPayments threw:", err);
     }


### PR DESCRIPTION
**Stacked on #854** — base is `perf/materialize-leaderboard`, so this diff shows only the invalidation changes. Merge #854 first; GitHub will retarget this to `main` automatically.

## Why

#854 gave the leaderboard a read-through cache with a 60s TTL — so a filed signal, approved correction, or recorded payout could take up to 60s to show on the leaderboard. This tightens that: a write is reflected on the **next read**, while the TTL stays as the backstop.

## How

`queryLeaderboard()`'s scoring inputs — `signals`, `brief_signals`, `corrections`, `referral_credits`, `earnings`, `streaks` — are all mutated by non-GET routes. So instead of threading an invalidation call through a dozen handlers (easy to miss one), a single **post-dispatch Hono middleware** drops `leaderboard_cache` after any successful mutating request:

```js
this.router.use("*", async (c, next) => {
  await next();
  const method = c.req.method;
  if (method !== "GET" && method !== "HEAD" && c.res.status < 400) {
    this.invalidateLeaderboardCache();
  }
});
```

- **Method-gated, not route-listed** — new mutating routes are covered automatically; no scoring write can be missed.
- **Cost of that robustness**: an occasional redundant invalidation from a non-scoring write (e.g. `/config`, `/classifieds`), which just triggers one extra recompute on the next read. Write volume is low (mutating rate limit 20/min) and each invalidation is a single-row delete, so this is negligible and bounded.
- **The one non-router path** — the alarm's payment-finalize sweep (`finalizeSignalSubmission` bumps streaks/stats/referrals) — invalidates explicitly, and only when it actually reconciled rows.
- **Backstop unchanged** — anything not covered still expires via the 60s TTL.

The explicit cache deletes #854 added to `/leaderboard/reset` and `/test-seed` are both router mutations, so they now collapse into the single middleware mechanism (removed, replaced by an explanatory note).

## Net staleness

| Trigger | #854 (TTL only) | This PR |
|---|---|---|
| Signal filed / approved, correction, payout, referral, reset | ≤ 60s | next read |
| Cache entry with no writes | ≤ 60s | ≤ 60s (backstop) |

Rows-read impact stays in the same low band as #854: recompute frequency is now driven by write rate (≤ ~20/min, capped) rather than falling to zero between reads — still orders of magnitude below the pre-cache ~18.7B/month.

## Verification

- `npm run typecheck` ✅
- `biome lint` on changed file — clean (no new warnings) ✅
- `npm test` — **427/427 pass** ✅ — the `scoring-math` suite is itself the proof: every test does `seed()` (a POST) then reads `/leaderboard` and asserts fresh scores, which only passes because the middleware invalidates on the seed write. The reset-epoch test confirms post-reset invalidation.
- `wrangler deploy --dry-run` — bundles ✅