### PR TITLE
perf(status): drop member fan-out in /status beat-activity query

### DIFF
--- a/src/__tests__/status-query-efficiency.test.ts
+++ b/src/__tests__/status-query-efficiency.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Regression guard for the /status/:address beat-activity query.
+ *
+ * The beats-membership query computes each beat's last-activity timestamp. The
+ * original form joined every active member of every beat to their signals purely
+ * to derive one MAX per beat, so it read O(members × signals) rows per call — at
+ * ~25 uncached /status calls/min this was the single largest driver of the DO's
+ * SQLite rows-read bill. The current form uses a per-beat correlated MAX backed
+ * by idx_signals_beat_created, reading ~O(beats) rows.
+ *
+ * This test seeds a realistically large beat and asserts the live query reads a
+ * bounded number of rows regardless of how many members/signals the beat has.
+ */
+import { env, runInDurableObject } from "cloudflare:test";
+import { describe, it, expect } from "vitest";
+import type { NewsDO } from "../objects/news-do";
+
+describe("/status beat-activity query efficiency", () => {
+  it("reads O(beats) rows, not O(members × signals)", async () => {
+    const id = env.NEWS_DO.idFromName("news-singleton");
+    const stub = env.NEWS_DO.get(id);
+
+    const result = await runInDurableObject(stub, (_instance: NewsDO, state) => {
+      const sql = state.storage.sql;
+      const now = new Date().toISOString();
+      const beat = "measure-beat";
+      const me = "bc1qme000000000000000000000000000000000000";
+      const MEMBERS = 150;
+      const PER = 15; // signals per member
+
+      sql.exec(
+        "INSERT OR IGNORE INTO beats (slug, name, created_by, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+        beat,
+        "Measure Beat",
+        "creator",
+        now,
+        now
+      );
+
+      for (let m = 0; m < MEMBERS; m++) {
+        const addr = m === 0 ? me : `bc1qmember${String(m).padStart(31, "0")}`;
+        sql.exec(
+          "INSERT OR IGNORE INTO beat_claims (beat_slug, btc_address, claimed_at, status) VALUES (?, ?, ?, 'active')",
+          beat,
+          addr,
+          now
+        );
+        for (let s = 0; s < PER; s++) {
+          sql.exec(
+            `INSERT OR IGNORE INTO signals
+               (id, beat_slug, btc_address, headline, sources, created_at, updated_at, status, correction_of)
+             VALUES (?, ?, ?, ?, '[]', ?, ?, 'approved', NULL)`,
+            `sig-${m}-${s}`,
+            beat,
+            addr,
+            `headline ${m}-${s}`,
+            new Date(Date.now() - (m * PER + s) * 60_000).toISOString(),
+            now
+          );
+        }
+      }
+
+      // Mirror production's planner: with table stats present, the outer
+      // `beat_claims WHERE btc_address = ?` uses idx_beat_claims_address (a point
+      // lookup) rather than scanning the tiny seeded table.
+      sql.exec("ANALYZE");
+
+      // OLD form — member fan-out (kept here only to quantify the contrast).
+      const oldCursor = sql.exec(
+        `SELECT b.*, MAX(s.created_at) as last_signal_at
+         FROM beat_claims bc
+         JOIN beats b ON bc.beat_slug = b.slug
+         LEFT JOIN beat_claims bc_all ON b.slug = bc_all.beat_slug AND bc_all.status = 'active'
+         LEFT JOIN signals s ON bc_all.btc_address = s.btc_address
+           AND s.beat_slug = b.slug
+           AND s.correction_of IS NULL
+         WHERE bc.btc_address = ? AND bc.status = 'active'
+         GROUP BY b.slug
+         ORDER BY bc.claimed_at`,
+        me
+      );
+      const oldRowsData = oldCursor.toArray();
+      const oldRows = oldCursor.rowsRead;
+
+      // NEW form — per-beat correlated MAX (what /status now runs).
+      const newCursor = sql.exec(
+        `SELECT b.*, (
+           SELECT MAX(s.created_at)
+           FROM signals s
+           WHERE s.beat_slug = b.slug
+             AND s.correction_of IS NULL
+         ) AS last_signal_at
+         FROM beat_claims bc
+         JOIN beats b ON bc.beat_slug = b.slug
+         WHERE bc.btc_address = ? AND bc.status = 'active'
+         ORDER BY bc.claimed_at`,
+        me
+      );
+      const newRowsData = newCursor.toArray();
+      const newRows = newCursor.rowsRead;
+
+      return {
+        oldRows,
+        newRows,
+        members: MEMBERS,
+        signals: MEMBERS * PER,
+        // Both forms must return the same beat with the same last-activity value.
+        sameLastSignal:
+          (oldRowsData[0] as { last_signal_at: string }).last_signal_at ===
+          (newRowsData[0] as { last_signal_at: string }).last_signal_at,
+        beatCount: newRowsData.length,
+      };
+    });
+
+    console.log(
+      `[status query] members=${result.members} signals=${result.signals} → OLD rowsRead=${result.oldRows}, NEW rowsRead=${result.newRows}`
+    );
+
+    // The agent belongs to exactly one seeded beat.
+    expect(result.beatCount).toBe(1);
+    // Equivalent result (last activity in the beat is unchanged).
+    expect(result.sameLastSignal).toBe(true);
+    // The new form must read dramatically fewer rows than the fan-out...
+    expect(result.newRows).toBeLessThan(result.oldRows / 5);
+    // ...and its cost must NOT scale with the number of signals in the beat —
+    // the whole point of the rewrite. With 2,250 signals seeded, reading well
+    // under that (bounded by the agent's beat membership) proves the per-beat
+    // signal fan-out is gone.
+    expect(result.newRows).toBeLessThan(result.signals / 10);
+  });
+});

--- a/src/__tests__/status-query-efficiency.test.ts
+++ b/src/__tests__/status-query-efficiency.test.ts
@@ -13,14 +13,27 @@
  */
 import { env, runInDurableObject } from "cloudflare:test";
 import { describe, it, expect } from "vitest";
-import type { NewsDO } from "../objects/news-do";
+import type { Env } from "../lib/types";
+
+// `env` from cloudflare:test isn't typed with this worker's bindings; the app
+// Env carries NEWS_DO (present at runtime via wrangler config).
+const testEnv = env as unknown as Env;
+
+interface Measurement {
+  oldRows: number;
+  newRows: number;
+  members: number;
+  signals: number;
+  sameLastSignal: boolean;
+  beatCount: number;
+}
 
 describe("/status beat-activity query efficiency", () => {
   it("reads O(beats) rows, not O(members × signals)", async () => {
-    const id = env.NEWS_DO.idFromName("news-singleton");
-    const stub = env.NEWS_DO.get(id);
+    const id = testEnv.NEWS_DO.idFromName("news-singleton");
+    const stub = testEnv.NEWS_DO.get(id);
 
-    const result = await runInDurableObject(stub, (_instance: NewsDO, state) => {
+    const result = (await runInDurableObject(stub, (_instance, state) => {
       const sql = state.storage.sql;
       const now = new Date().toISOString();
       const beat = "measure-beat";
@@ -110,7 +123,7 @@ describe("/status beat-activity query efficiency", () => {
           (newRowsData[0] as { last_signal_at: string }).last_signal_at,
         beatCount: newRowsData.length,
       };
-    });
+    })) as Measurement;
 
     console.log(
       `[status query] members=${result.members} signals=${result.signals} → OLD rowsRead=${result.oldRows}, NEW rowsRead=${result.newRows}`

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -3931,18 +3931,35 @@ export class NewsDO extends DurableObject<Env> {
       const today = getUTCDate(now);
       const todayUTCStart = getUTCDayStart(today);
 
-      // Find all beats this agent is a member of (via beat_claims)
+      // Find all beats this agent is a member of (via beat_claims), each with the
+      // beat's last-activity timestamp.
+      //
+      // `last_signal_at` is a per-beat correlated MAX rather than a member fan-out
+      // join. The previous form joined every active member of every beat to their
+      // signals (beats × ~250 members × signals) purely to compute one MAX per
+      // beat — reading thousands of rows per /status call, which (at ~25 calls/min,
+      // uncached) was the single largest driver of the DO's rows-read bill. The
+      // correlated subquery uses idx_signals_beat_created (beat_slug, created_at
+      // DESC) to read ~1 row per beat instead.
+      //
+      // Semantic note: this is "last signal in the beat" (any author) rather than
+      // "last signal by a still-active member". Signals carry beat_slug, so for
+      // beat-activity/expiry purposes these agree except in the rare case where the
+      // single most-recent signal in a beat is from a since-departed member — in
+      // which case counting it as recent activity is at least as correct. The
+      // equivalent joins in /beats and the /init beats block still use the old
+      // member-fan-out form and should get the same rewrite for consistency.
       const beatRows = this.ctx.storage.sql
         .exec(
-          `SELECT b.*, MAX(s.created_at) as last_signal_at
+          `SELECT b.*, (
+             SELECT MAX(s.created_at)
+             FROM signals s
+             WHERE s.beat_slug = b.slug
+               AND s.correction_of IS NULL
+           ) AS last_signal_at
            FROM beat_claims bc
            JOIN beats b ON bc.beat_slug = b.slug
-           LEFT JOIN beat_claims bc_all ON b.slug = bc_all.beat_slug AND bc_all.status = 'active'
-           LEFT JOIN signals s ON bc_all.btc_address = s.btc_address
-             AND s.beat_slug = b.slug
-             AND s.correction_of IS NULL
            WHERE bc.btc_address = ? AND bc.status = 'active'
-           GROUP BY b.slug
            ORDER BY bc.claimed_at`,
           address
         )


### PR DESCRIPTION
The real DO rows-read hog, found by ranking **live production** DO endpoints by CPU (via `wrangler tail`): **`/status/:address`** — ~25 calls/min, uncached, dominating total CPU. (The earlier leaderboard PRs #853/#854/#856 were verified working — `/init` no longer hits the DO, `/leaderboard` is ~1 CPU/call — but the leaderboard was not the live hot path.)

## Root cause

`/status/:address` computed each of the agent's beats' last-activity timestamp with a member fan-out:

```sql
SELECT b.*, MAX(s.created_at) as last_signal_at
FROM beat_claims bc
JOIN beats b ON bc.beat_slug = b.slug
LEFT JOIN beat_claims bc_all ON b.slug = bc_all.beat_slug AND bc_all.status = 'active'
LEFT JOIN signals s ON bc_all.btc_address = s.btc_address AND s.beat_slug = b.slug ...
WHERE bc.btc_address = ? ... GROUP BY b.slug
```

It joined **every active member of every beat** (~250/beat across 13 beats) to their signals just to derive one MAX per beat — O(members × signals) rows per call. Uncached at ~25/min, this was the dominant read.

## Fix

Per-beat correlated MAX backed by the existing `idx_signals_beat_created (beat_slug, created_at DESC)` — ~1 row per beat:

```sql
SELECT b.*, (
  SELECT MAX(s.created_at) FROM signals s
  WHERE s.beat_slug = b.slug AND s.correction_of IS NULL
) AS last_signal_at
FROM beat_claims bc JOIN beats b ON bc.beat_slug = b.slug
WHERE bc.btc_address = ? AND bc.status = 'active' ORDER BY bc.claimed_at
```

## Measured reduction (not modelled)

New regression test seeds a 150-member / 2,250-signal beat and reads actual `cursor.rowsRead` for both forms, with `ANALYZE` so the planner matches production:

| | rows read |
|---|---|
| old (member fan-out) | **4,803** |
| new (per-beat MAX) | **5** |

~960× fewer rows for this query. The test asserts the new form's cost does **not** scale with signal count (guards against regression).

## Semantic note

`last_signal_at` is now "last signal in the beat" (any author) rather than "last signal by a still-active member". Signals carry `beat_slug`, so for beat activity/expiry these agree except when the single most-recent signal in a beat is from a since-departed member — where counting it as recent activity is at least as correct. Same-result assertion is in the test.

## Follow-ups (same pattern, not in this PR)

`/beats` and the `/init` beats block use the identical member-fan-out MAX and should get the same rewrite for consistency and further savings. `/status` has no worker-layer cache, which is why it dominated — worth considering a short KV cache there too.

## Verification
- `npm test` — **428/428** (new test included) ✅
- `biome lint` on changed files — clean ✅
- `wrangler deploy --dry-run` — bundles ✅
- Post-deploy: I'll re-rank DO endpoints by CPU via tail to confirm `/status` drops.