### PR TITLE
perf(beats): drop member fan-out in beat-activity queries

### DIFF
--- a/src/__tests__/status-query-efficiency.test.ts
+++ b/src/__tests__/status-query-efficiency.test.ts
@@ -141,4 +141,89 @@ describe("/status beat-activity query efficiency", () => {
     // signal fan-out is gone.
     expect(result.newRows).toBeLessThan(result.signals / 10);
   });
+
+  // Same fan-out lived in the "all beats" list query used by /beats,
+  // /correspondents-bundle and the /init beats block. This guards that rewrite.
+  it("all-beats list reads O(beats), not O(members × signals)", async () => {
+    const id = testEnv.NEWS_DO.idFromName("news-singleton");
+    const stub = testEnv.NEWS_DO.get(id);
+
+    const result = (await runInDurableObject(stub, (_instance, state) => {
+      const sql = state.storage.sql;
+      const now = new Date().toISOString();
+      const BEATS = 4;
+      const MEMBERS = 60;
+      const PER = 8;
+
+      for (let b = 0; b < BEATS; b++) {
+        const beat = `list-beat-${b}`;
+        sql.exec(
+          "INSERT OR IGNORE INTO beats (slug, name, created_by, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+          beat,
+          `List Beat ${b}`,
+          "creator",
+          now,
+          now
+        );
+        for (let m = 0; m < MEMBERS; m++) {
+          const addr = `bc1qlist${b}member${String(m).padStart(28, "0")}`;
+          sql.exec(
+            "INSERT OR IGNORE INTO beat_claims (beat_slug, btc_address, claimed_at, status) VALUES (?, ?, ?, 'active')",
+            beat,
+            addr,
+            now
+          );
+          for (let s = 0; s < PER; s++) {
+            sql.exec(
+              `INSERT OR IGNORE INTO signals
+                 (id, beat_slug, btc_address, headline, sources, created_at, updated_at, status, correction_of)
+               VALUES (?, ?, ?, ?, '[]', ?, ?, 'approved', NULL)`,
+              `lsig-${b}-${m}-${s}`,
+              beat,
+              addr,
+              `h ${b}-${m}-${s}`,
+              new Date(Date.now() - (m * PER + s) * 60_000).toISOString(),
+              now
+            );
+          }
+        }
+      }
+      sql.exec("ANALYZE");
+
+      const oldCursor = sql.exec(
+        `SELECT b.*, MAX(s.created_at) as last_signal_at
+         FROM beats b
+         LEFT JOIN beat_claims bc ON b.slug = bc.beat_slug AND bc.status = 'active'
+         LEFT JOIN signals s ON bc.btc_address = s.btc_address
+           AND s.beat_slug = b.slug
+           AND s.correction_of IS NULL
+         GROUP BY b.slug
+         ORDER BY b.name`
+      );
+      oldCursor.toArray();
+      const oldRows = oldCursor.rowsRead;
+
+      const newCursor = sql.exec(
+        `SELECT b.*, (
+           SELECT MAX(s.created_at)
+           FROM signals s
+           WHERE s.beat_slug = b.slug
+             AND s.correction_of IS NULL
+         ) AS last_signal_at
+         FROM beats b
+         ORDER BY b.name`
+      );
+      newCursor.toArray();
+      const newRows = newCursor.rowsRead;
+
+      return { oldRows, newRows, signals: BEATS * MEMBERS * PER };
+    })) as { oldRows: number; newRows: number; signals: number };
+
+    console.log(
+      `[beats list] seeded ${result.signals} signals → OLD rowsRead=${result.oldRows}, NEW rowsRead=${result.newRows}`
+    );
+    expect(result.newRows).toBeLessThan(result.oldRows / 5);
+    // Cost must not scale with signal count.
+    expect(result.newRows).toBeLessThan(result.signals / 10);
+  });
 });

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -1999,13 +1999,17 @@ export class NewsDO extends DurableObject<Env> {
     this.router.get("/beats", (c) => {
       const rows = this.ctx.storage.sql
         .exec(
-          `SELECT b.*, MAX(s.created_at) as last_signal_at
+          `SELECT b.*, (
+             -- Per-beat last activity via idx_signals_beat_created (beat_slug,
+             -- created_at DESC). Replaces a beats x active-members x signals
+             -- fan-out that read O(members x signals) rows just to derive one MAX
+             -- per beat; see the /status rewrite. Same beat-level semantic.
+             SELECT MAX(s.created_at)
+             FROM signals s
+             WHERE s.beat_slug = b.slug
+               AND s.correction_of IS NULL
+           ) AS last_signal_at
            FROM beats b
-           LEFT JOIN beat_claims bc ON b.slug = bc.beat_slug AND bc.status = 'active'
-           LEFT JOIN signals s ON bc.btc_address = s.btc_address
-             AND s.beat_slug = b.slug
-             AND s.correction_of IS NULL
-           GROUP BY b.slug
            ORDER BY b.name`
         )
         .toArray();
@@ -2127,14 +2131,16 @@ export class NewsDO extends DurableObject<Env> {
       const slug = c.req.param("slug");
       const rows = this.ctx.storage.sql
         .exec(
-          `SELECT b.*, MAX(s.created_at) as last_signal_at
+          `SELECT b.*, (
+             -- Per-beat last activity via idx_signals_beat_created; replaces a
+             -- member fan-out join (see the /status rewrite). Beat-level semantic.
+             SELECT MAX(s.created_at)
+             FROM signals s
+             WHERE s.beat_slug = b.slug
+               AND s.correction_of IS NULL
+           ) AS last_signal_at
            FROM beats b
-           LEFT JOIN beat_claims bc ON b.slug = bc.beat_slug AND bc.status = 'active'
-           LEFT JOIN signals s ON bc.btc_address = s.btc_address
-             AND s.beat_slug = b.slug
-             AND s.correction_of IS NULL
-           WHERE b.slug = ?
-           GROUP BY b.slug`,
+           WHERE b.slug = ?`,
           slug
         )
         .toArray();
@@ -2252,14 +2258,16 @@ export class NewsDO extends DurableObject<Env> {
       // Check for existing beat — allow join if active, reclaim if inactive
       const existing = this.ctx.storage.sql
         .exec(
-          `SELECT b.*, MAX(s.created_at) as last_signal_at
+          `SELECT b.*, (
+             -- Per-beat last activity via idx_signals_beat_created; replaces a
+             -- member fan-out join (see the /status rewrite). Beat-level semantic.
+             SELECT MAX(s.created_at)
+             FROM signals s
+             WHERE s.beat_slug = b.slug
+               AND s.correction_of IS NULL
+           ) AS last_signal_at
            FROM beats b
-           LEFT JOIN beat_claims bc ON b.slug = bc.beat_slug AND bc.status = 'active'
-           LEFT JOIN signals s ON bc.btc_address = s.btc_address
-             AND s.beat_slug = b.slug
-             AND s.correction_of IS NULL
-           WHERE b.slug = ?
-           GROUP BY b.slug`,
+           WHERE b.slug = ?`,
           slug as string
         )
         .toArray();
@@ -5390,13 +5398,17 @@ export class NewsDO extends DurableObject<Env> {
 
       const beats = this.ctx.storage.sql
         .exec(
-          `SELECT b.*, MAX(s.created_at) as last_signal_at
+          `SELECT b.*, (
+             -- Per-beat last activity via idx_signals_beat_created (beat_slug,
+             -- created_at DESC). Replaces a beats x active-members x signals
+             -- fan-out that read O(members x signals) rows just to derive one MAX
+             -- per beat; see the /status rewrite. Same beat-level semantic.
+             SELECT MAX(s.created_at)
+             FROM signals s
+             WHERE s.beat_slug = b.slug
+               AND s.correction_of IS NULL
+           ) AS last_signal_at
            FROM beats b
-           LEFT JOIN beat_claims bc ON b.slug = bc.beat_slug AND bc.status = 'active'
-           LEFT JOIN signals s ON bc.btc_address = s.btc_address
-             AND s.beat_slug = b.slug
-             AND s.correction_of IS NULL
-           GROUP BY b.slug
            ORDER BY b.name`
         )
         .toArray();
@@ -5441,13 +5453,17 @@ export class NewsDO extends DurableObject<Env> {
       // Beats (with status computation via beat_claims)
       const beatRows = this.ctx.storage.sql
         .exec(
-          `SELECT b.*, MAX(s.created_at) as last_signal_at
+          `SELECT b.*, (
+             -- Per-beat last activity via idx_signals_beat_created (beat_slug,
+             -- created_at DESC). Replaces a beats x active-members x signals
+             -- fan-out that read O(members x signals) rows just to derive one MAX
+             -- per beat; see the /status rewrite. Same beat-level semantic.
+             SELECT MAX(s.created_at)
+             FROM signals s
+             WHERE s.beat_slug = b.slug
+               AND s.correction_of IS NULL
+           ) AS last_signal_at
            FROM beats b
-           LEFT JOIN beat_claims bc ON b.slug = bc.beat_slug AND bc.status = 'active'
-           LEFT JOIN signals s ON bc.btc_address = s.btc_address
-             AND s.beat_slug = b.slug
-             AND s.correction_of IS NULL
-           GROUP BY b.slug
            ORDER BY b.name`
         )
         .toArray();


### PR DESCRIPTION
Follow-up to #857. That PR fixed the `/status` beat-activity fan-out; this removes the **same copy-pasted pattern** from every other place it lived.

## The pattern

Each beat-activity read computed "last signal in each beat" by joining **all active members of the beat to their signals** just to derive one `MAX(created_at)` per beat — O(members × signals) rows (~250 members/beat, ~31k signals). Sites:

| Handler | Hot? | Cache |
|---|---|---|
| `/beats` (list) | yes | per-colo edge only |
| `/correspondents-bundle` | medium | per-colo SWR (heaviest single call, ~181 CPU) |
| `/beats/:slug` | medium | per-colo edge |
| `/init` beats block | — | global KV (already off the DB most of the time) |
| `POST /beats` (reclaim check) | rare | write path |

## Fix

Per-beat correlated `MAX` backed by the existing `idx_signals_beat_created (beat_slug, created_at DESC)` — ~1 row per beat. Removing the joins also drops the now-unnecessary `GROUP BY`. Identical transform to #857.

**Consistency bonus:** all beat-activity reads (including `/status`) now share one beat-level "last signal in the beat" definition, so the homepage, `/beats`, and `/status` can no longer report different activity/expiry for the same beat.

## Measured (regression test, actual `rowsRead`)

| query | before | after |
|---|---|---|
| all-beats list (4 beats / 1,920 signals) | **4,989** | **41** (~120×) |
| `/status` shape (unchanged, still guarded) | 4,803 | 5 |

Both tests assert the cost does **not** scale with signal count.

## Semantic note
`last_signal_at` is now "last signal in the beat" (any author) rather than "last signal by a still-active member" — same as #857. Signals carry `beat_slug`, so these agree for activity/expiry except when the most-recent signal in a beat is from a since-departed member, where counting it is at least as correct. This now matches `/status`, removing a latent cross-page inconsistency.

## Verification
- `npm test` — **429/429** (2 efficiency tests) ✅
- `biome lint` — clean ✅
- `wrangler deploy --dry-run` — bundles ✅
- Post-deploy: re-rank DO endpoints by CPU via tail to confirm `/beats` + `/correspondents-bundle` drop.

## Remaining follow-ups (from the audit, not in this PR)
- `/classifieds/rotation` `ORDER BY RANDOM()` (uncached, most-frequent endpoint — latent hog once ad volume grows)
- `/report` full-table scans (serve from materialized `correspondent_stats`)