### PR TITLE
perf(beats): fetch member roster only on ?include=members

### DIFF
--- a/src/__tests__/beats-roster-gating.test.ts
+++ b/src/__tests__/beats-roster-gating.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Guards the /beats member-roster gating.
+ *
+ * The DO /beats handler fetches the full active-member roster (thousands of rows
+ * across all beats) only when ?include=members is requested; the default path
+ * returns per-beat `member_count` instead, so the hot /api/beats endpoint does
+ * not materialise every claim just to report a count.
+ */
+import { env, runInDurableObject } from "cloudflare:test";
+import { describe, it, expect } from "vitest";
+import type { Env } from "../lib/types";
+
+const testEnv = env as unknown as Env;
+
+interface BeatRow {
+  slug: string;
+  member_count?: number;
+  members?: unknown[];
+}
+
+describe("/beats member-roster gating", () => {
+  it("default returns member_count only; include=members returns the roster", async () => {
+    const id = testEnv.NEWS_DO.idFromName("news-singleton");
+    const stub = testEnv.NEWS_DO.get(id);
+    const MEMBERS = 7;
+
+    await runInDurableObject(stub, (_instance, state) => {
+      const sql = state.storage.sql;
+      const now = new Date().toISOString();
+      sql.exec(
+        "INSERT OR IGNORE INTO beats (slug, name, created_by, created_at, updated_at) VALUES ('roster-beat', 'Roster', 'creator', ?, ?)",
+        now,
+        now
+      );
+      for (let m = 0; m < MEMBERS; m++) {
+        sql.exec(
+          "INSERT OR IGNORE INTO beat_claims (beat_slug, btc_address, claimed_at, status) VALUES ('roster-beat', ?, ?, 'active')",
+          `bc1qroster${String(m).padStart(30, "0")}`,
+          now
+        );
+      }
+    });
+
+    // Default: count present, full roster omitted.
+    const defRes = await stub.fetch("https://do/beats");
+    const defBody = (await defRes.json()) as { data: BeatRow[] };
+    const defBeat = defBody.data.find((b) => b.slug === "roster-beat");
+    expect(defBeat).toBeDefined();
+    expect(defBeat?.member_count).toBe(MEMBERS);
+    expect(defBeat?.members).toBeUndefined();
+
+    // include=members: full roster present, count still correct.
+    const incRes = await stub.fetch("https://do/beats?include=members");
+    const incBody = (await incRes.json()) as { data: BeatRow[] };
+    const incBeat = incBody.data.find((b) => b.slug === "roster-beat");
+    expect(incBeat?.members?.length).toBe(MEMBERS);
+    expect(incBeat?.member_count).toBe(MEMBERS);
+  });
+
+  it("count query reads fewer rows than the full-roster fetch", async () => {
+    const id = testEnv.NEWS_DO.idFromName("news-singleton");
+    const stub = testEnv.NEWS_DO.get(id);
+
+    const { fullRows, countRows } = (await runInDurableObject(stub, (_instance, state) => {
+      const sql = state.storage.sql;
+      const now = new Date().toISOString();
+      for (let b = 0; b < 8; b++) {
+        sql.exec(
+          "INSERT OR IGNORE INTO beats (slug, name, created_by, created_at, updated_at) VALUES (?, ?, 'c', ?, ?)",
+          `cntbeat-${b}`,
+          `Cnt ${b}`,
+          now,
+          now
+        );
+        for (let m = 0; m < 50; m++) {
+          sql.exec(
+            "INSERT OR IGNORE INTO beat_claims (beat_slug, btc_address, claimed_at, status) VALUES (?, ?, ?, 'active')",
+            `cntbeat-${b}`,
+            `bc1qcnt${b}_${String(m).padStart(28, "0")}`,
+            now
+          );
+        }
+      }
+      sql.exec("ANALYZE");
+
+      const full = sql.exec(
+        "SELECT beat_slug, btc_address, claimed_at, status FROM beat_claims WHERE status='active' ORDER BY claimed_at"
+      );
+      full.toArray();
+      const fullRows = full.rowsRead;
+
+      const cnt = sql.exec(
+        "SELECT beat_slug, COUNT(*) as member_count FROM beat_claims WHERE status='active' GROUP BY beat_slug"
+      );
+      cnt.toArray();
+      const countRows = cnt.rowsRead;
+      return { fullRows, countRows };
+    })) as { fullRows: number; countRows: number };
+
+    console.log(`[roster] full-roster rowsRead=${fullRows}, count rowsRead=${countRows}`);
+    // The default count path must read strictly fewer rows than fetching the
+    // full roster (it skips the table read + sort via an index-only scan).
+    expect(countRows).toBeLessThan(fullRows);
+  });
+});

--- a/src/lib/do-client.ts
+++ b/src/lib/do-client.ts
@@ -59,9 +59,16 @@ async function doFetch<T>(
 // Beats
 // ---------------------------------------------------------------------------
 
-export async function listBeats(env: Env): Promise<Beat[]> {
+/**
+ * List beats. By default each beat carries `member_count` only; the full
+ * `members` roster (~thousands of rows across all beats) is fetched from the DO
+ * solely when `includeMembers` is true — the Bureau/leaderboard paths that need
+ * per-member addresses. Everything else (homepage, /api/beats without
+ * ?include=members, skills, sitemap) takes the cheap count.
+ */
+export async function listBeats(env: Env, includeMembers = false): Promise<Beat[]> {
   const stub = getStub(env);
-  const result = await doFetch<Beat[]>(stub, "/beats");
+  const result = await doFetch<Beat[]>(stub, includeMembers ? "/beats?include=members" : "/beats");
   if (!result.ok) throw new Error(result.error ?? "Failed to list beats");
   if (result.data === undefined) throw new Error("Missing data in response");
   return result.data;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -157,8 +157,12 @@ export interface Beat {
   readonly editor_review_rate_sats?: number | null;
   /** "retired" is stored in DB (migration 22); "active"/"inactive" computed from signal activity */
   readonly status?: "active" | "inactive" | "retired";
-  /** Active members from beat_claims — populated when joined */
+  /** Active members from beat_claims — only populated when the caller requests
+   *  the full roster (listBeats(env, true) / GET /beats?include=members). */
   readonly members?: BeatMember[];
+  /** Count of active members — always populated; the cheap default when the
+   *  full `members` roster is not requested. */
+  readonly member_count?: number;
   /** Active editor for this beat (one per beat, null when unassigned) */
   readonly editor: { btc_address: string; registered_at: string } | null;
 }

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -1997,6 +1997,7 @@ export class NewsDO extends DurableObject<Env> {
 
     // GET /beats — list all beats ordered by name; retired status from DB, active/inactive computed from signal activity
     this.router.get("/beats", (c) => {
+      const includeMembers = c.req.query("include") === "members";
       const rows = this.ctx.storage.sql
         .exec(
           `SELECT b.*, (
@@ -2014,24 +2015,44 @@ export class NewsDO extends DurableObject<Env> {
         )
         .toArray();
 
-      // Fetch all active claims for member lists
-      const claimRows = this.ctx.storage.sql
-        .exec(
-          `SELECT beat_slug, btc_address, claimed_at, status
-           FROM beat_claims WHERE status = 'active'
-           ORDER BY claimed_at`
-        )
-        .toArray();
+      // Member data. The full per-member roster is only needed by
+      // ?include=members callers (Bureau page, leaderboard). The default path
+      // takes per-beat counts so a hot, frequently-hit endpoint doesn't
+      // materialise every active claim (~thousands of rows across all beats)
+      // into JS objects just to report memberCount.
       const claimsByBeat = new Map<string, Array<{ btc_address: string; claimed_at: string; status: string }>>();
-      for (const cr of claimRows) {
-        const claim = cr as Record<string, unknown>;
-        const slug = claim.beat_slug as string;
-        if (!claimsByBeat.has(slug)) claimsByBeat.set(slug, []);
-        claimsByBeat.get(slug)!.push({
-          btc_address: claim.btc_address as string,
-          claimed_at: claim.claimed_at as string,
-          status: claim.status as string,
-        });
+      const countByBeat = new Map<string, number>();
+      if (includeMembers) {
+        const claimRows = this.ctx.storage.sql
+          .exec(
+            `SELECT beat_slug, btc_address, claimed_at, status
+             FROM beat_claims WHERE status = 'active'
+             ORDER BY claimed_at`
+          )
+          .toArray();
+        for (const cr of claimRows) {
+          const claim = cr as Record<string, unknown>;
+          const slug = claim.beat_slug as string;
+          if (!claimsByBeat.has(slug)) claimsByBeat.set(slug, []);
+          claimsByBeat.get(slug)!.push({
+            btc_address: claim.btc_address as string,
+            claimed_at: claim.claimed_at as string,
+            status: claim.status as string,
+          });
+        }
+        for (const [slug, list] of claimsByBeat) countByBeat.set(slug, list.length);
+      } else {
+        const countRows = this.ctx.storage.sql
+          .exec(
+            `SELECT beat_slug, COUNT(*) as member_count
+             FROM beat_claims WHERE status = 'active'
+             GROUP BY beat_slug`
+          )
+          .toArray();
+        for (const cr of countRows) {
+          const r = cr as { beat_slug: string; member_count: number };
+          countByBeat.set(r.beat_slug, Number(r.member_count) || 0);
+        }
       }
 
       // Fetch active editor per beat (one per beat enforced by registration logic)
@@ -2077,7 +2098,8 @@ export class NewsDO extends DurableObject<Env> {
           daily_approved_limit: row.daily_approved_limit as number | null,
           editor_review_rate_sats: row.editor_review_rate_sats as number | null,
           status,
-          members: claimsByBeat.get(row.slug as string) ?? [],
+          ...(includeMembers ? { members: claimsByBeat.get(row.slug as string) ?? [] } : {}),
+          member_count: countByBeat.get(row.slug as string) ?? 0,
           editor: editorByBeat.get(row.slug as string) ?? null,
         } as Beat;
       });

--- a/src/routes/beats.ts
+++ b/src/routes/beats.ts
@@ -23,13 +23,12 @@ beatsRouter.get("/api/beats", async (c) => {
   const cached = await edgeCacheMatch(c);
   if (cached) return cached;
 
-  const beats = await listBeats(c.env);
   const includeMembers = c.req.query("include") === "members";
+  const beats = await listBeats(c.env, includeMembers);
   const statusFilter = c.req.query("status")?.toLowerCase();
 
   // Transform snake_case → camelCase to match frontend expectations
   const transformed = beats.map((b) => {
-    const members = b.members ?? [];
     return {
       slug: b.slug,
       name: b.name,
@@ -41,8 +40,8 @@ beatsRouter.get("/api/beats", async (c) => {
       dailyApprovedLimit: b.daily_approved_limit ?? null,
       editorReviewRateSats: b.editor_review_rate_sats ?? null,
       ...(includeMembers
-        ? { members: members.map((m) => ({ address: m.btc_address, claimedAt: m.claimed_at })) }
-        : { memberCount: members.length }),
+        ? { members: (b.members ?? []).map((m) => ({ address: m.btc_address, claimedAt: m.claimed_at })) }
+        : { memberCount: b.member_count ?? 0 }),
       editor: b.editor
         ? { address: b.editor.btc_address, assignedAt: b.editor.registered_at }
         : null,

--- a/src/routes/leaderboard.ts
+++ b/src/routes/leaderboard.ts
@@ -114,7 +114,7 @@ const leaderboardRouter = new Hono<AppContext>();
 leaderboardRouter.get("/api/leaderboard", async (c) => {
   const [entries, beats] = await Promise.all([
     getLeaderboard(c.env),
-    listBeats(c.env),
+    listBeats(c.env, true), // needs the full member roster for buildBeatsByAddress
   ]);
 
   // Extract claims from beat members for buildBeatsByAddress


### PR DESCRIPTION
Follow-up to the beat-activity fan-out fixes (#857/#858). After those, the remaining cost of the hot `/beats` endpoint was a second query that **always fetched every active claim across all beats** (~thousands of rows) and materialised them into JS objects — just so the default `/api/beats` could report `memberCount`. The full roster is only needed by `?include=members` (Bureau page) and `/api/leaderboard`.

## Change
- **Default path**: per-beat `COUNT(*) GROUP BY beat_slug` (index-only via `idx_beat_claims_status_beat_address`), returned as `member_count`.
- **Full roster**: fetched only when `?include=members` is passed.
- `do-client.listBeats(env, includeMembers=false)` — `/api/leaderboard` opts in (it needs per-member addresses); skills + sitemap keep the cheap default.

## Measured (regression test, actual `rowsRead`)
| query | rows read |
|---|---|
| full-roster fetch (600-claim seed) | 1,200 |
| count `GROUP BY` (default) | 600 |

~2× fewer rows, plus it skips materialising every claim row into JS/JSON on a hot endpoint. A second test guards the contract (`member_count` on default, `members` array on `?include=members`).

## Confirmed against Cloudflare docs
The DO storage docs state indexes "reduce how much data is scanned … reduction in rows read." The count path is served index-only by `idx_beat_claims_status_beat_address (status, beat_slug, …)`, consistent with that guidance — and the `rowsRead` measurement above confirms the actual reduction rather than assuming it.

## Verification
- `npm test` — **431/431** (2 new roster tests) ✅
- `biome lint` — clean ✅
- `wrangler deploy --dry-run` — bundles ✅

## Note
This is a rows-read + CPU/payload trim (~2×), not the ~100× of the fan-out fixes — `COUNT … GROUP BY` still reads one index row per active member. Making it O(beats) would need a materialized `member_count` column maintained on join/leave; deferred as a bigger change.