### PR TITLE
fix(identity-gate): negative-cache fail-closed result to stop timeout storms (#826)

### DIFF
--- a/src/__tests__/identity-gate.test.ts
+++ b/src/__tests__/identity-gate.test.ts
@@ -169,33 +169,43 @@ describe("checkAgentIdentity — fail closed on API errors", () => {
     expect(result.level).toBe(2);
   });
 
-  it("does not cache the result on API failure", async () => {
-    const kv = makeKV();
-    // Both attempts fail — fail-closed result must NOT be cached
+  it("negative-caches the block briefly so an outage doesn't storm the API (#826)", async () => {
+    const store = new Map<string, string>();
+    const putArgs: Array<{ key: string; options?: { expirationTtl?: number } }> = [];
+    const kv = {
+      async get(key: string) {
+        return store.get(key) ?? null;
+      },
+      async put(key: string, value: string, options?: { expirationTtl?: number }) {
+        store.set(key, value);
+        putArgs.push({ key, options });
+      },
+    } as unknown as KVNamespace;
+
+    // Both attempts fail — fail-closed result must be cached with a short TTL
     const firstSpy = vi
       .spyOn(globalThis, "fetch")
       .mockRejectedValueOnce(new Error("timeout"))
       .mockRejectedValueOnce(new Error("timeout"));
 
-    await checkAgentIdentity(kv, "bc1qnocache");
+    const blocked = await checkAgentIdentity(kv, "bc1qstorm");
+    expect(blocked.shouldBlock).toBe(true);
+    expect(firstSpy).toHaveBeenCalledTimes(2);
+
+    // The block was written with a short (60s) TTL, not the 1h happy-path TTL
+    expect(putArgs).toHaveLength(1);
+    expect(putArgs[0].options?.expirationTtl).toBe(60);
 
     // Restore the first spy before creating a new one — stacking vi.spyOn causes double-counting
     firstSpy.mockRestore();
 
-    // Second call should hit the API again (not cached) and recover
-    const fetchSpy = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ found: true, level: 2, levelName: "Genesis" }), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        })
-      );
-
-    const result = await checkAgentIdentity(kv, "bc1qnocache");
-    expect(fetchSpy).toHaveBeenCalledOnce();
-    expect(result.level).toBe(2);
-    expect(result.shouldBlock).toBe(false);
+    // A follow-up request within the window hits the cached block and does NOT
+    // re-storm the API — this is the storm the negative cache exists to prevent.
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const second = await checkAgentIdentity(kv, "bc1qstorm");
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(second.shouldBlock).toBe(true);
+    expect(second.apiReachable).toBe(false);
   });
 });
 

--- a/src/services/identity-gate.ts
+++ b/src/services/identity-gate.ts
@@ -11,6 +11,11 @@
  */
 
 const CACHE_TTL_SECONDS = 3600; // 1 hour
+// Fail-closed (shouldBlock) results are cached briefly so a sustained outage
+// doesn't turn every incoming request into a fresh 2×timeout storm against the
+// identity API (see #826). Kept short so submissions unblock quickly once the
+// API recovers; 60s is Cloudflare KV's minimum allowed expirationTtl.
+const BLOCK_CACHE_TTL_SECONDS = 60;
 const CACHE_KEY_PREFIX = "agent-level:";
 const AGENT_API_BASE = "https://aibtc.com/api/agents";
 
@@ -113,11 +118,22 @@ export async function checkAgentIdentity(
 
   // Both attempts failed. Fail-closed: do not allow unverified submissions.
   // Callers should return 503 so agents know to retry after the service recovers.
-  return {
+  const blocked: IdentityCheckResult = {
     registered: false,
     level: null,
     levelName: null,
     apiReachable: false,
     shouldBlock: true,
   };
+
+  // Negative-cache the block for a short window. Without this, every request
+  // during an outage re-runs the full initial+retry fetch (up to 6s of hung
+  // sockets each), which is the timeout storm reported in #826. A 60s TTL
+  // collapses the storm to at most one probe per address per minute while still
+  // unblocking submissions within a minute of the API recovering.
+  await kv.put(cacheKey, JSON.stringify(blocked), {
+    expirationTtl: BLOCK_CACHE_TTL_SECONDS,
+  });
+
+  return blocked;
 }


### PR DESCRIPTION
Closes #826.

## Problem
`checkAgentIdentity` fails closed (`shouldBlock=true`) when the identity API is unreachable, but did **not cache** that result. During a sustained outage every incoming request re-ran the full initial+retry fetch (up to ~6s of hung sockets each), producing the repeated timeout storms reported in #826.

## Fix
Negative-cache the block for a short window (60s — Cloudflare KV's minimum `expirationTtl`). This collapses the storm to at most one probe per address per minute while submissions still unblock within a minute of the API recovering. Happy-path and 404 caching are unchanged.

## Verification
- Rewrote the stale "does not cache on failure" unit test to assert the new negative-cache behavior (block is cached with a 60s TTL; a follow-up request within the window hits cache instead of re-storming).
- Full suite green (433 tests); `tsc --noEmit` clean.

## Notes
- 60s is the floor KV allows; shorter TTLs are rejected at runtime.
- Confirmed live in code before fixing: the fail-closed branch returned without any `kv.put`.