### PR TITLE
fix(status): surface active beat, don't report file-gate on retired beats (#832)

### DIFF
--- a/src/__tests__/status-beat-consistency.test.ts
+++ b/src/__tests__/status-beat-consistency.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Regression guard for #832 — /status/:address returned a contradictory
+ * `beatStatus: "inactive"` alongside `canFileSignal: true` for agents who
+ * registered on a since-retired beat but migrated to an active one.
+ *
+ * The backward-compat `beat`/`beatStatus` fields blindly exposed the agent's
+ * oldest claim (ORDER BY claimed_at), which for the pre-consolidation cohort was
+ * a retired beat with no recent activity — reading "inactive" while the filing
+ * gate said they could file. These tests assert the display field now tracks the
+ * agent's fileable beat, and that an all-retired agent is not told they can file.
+ */
+import { env, runInDurableObject } from "cloudflare:test";
+import { describe, it, expect } from "vitest";
+import type { Env } from "../lib/types";
+
+const testEnv = env as unknown as Env;
+
+interface StatusBody {
+  data: {
+    beat: { slug: string; beatStatus: string; retired: boolean } | null;
+    beatStatus: string | null;
+    canFileSignal: boolean;
+    beats: Array<{ slug: string; beatStatus: string; retired: boolean }>;
+    actions: Array<{ type: string; description: string }>;
+  };
+}
+
+async function seed(stub: DurableObjectStub, fn: (sql: SqlStorage) => void) {
+  await runInDurableObject(stub, (_instance, state) => fn(state.storage.sql));
+}
+
+describe("/status beat/canFileSignal consistency (#832)", () => {
+  it("surfaces the active beat (not the oldest retired claim) as `beat`", async () => {
+    const id = testEnv.NEWS_DO.idFromName("news-singleton");
+    const stub = testEnv.NEWS_DO.get(id);
+    const agent = "bc1qmigrated00000000000000000000000000000";
+    const now = new Date().toISOString();
+    const older = new Date(Date.now() - 90 * 24 * 3600 * 1000).toISOString();
+
+    await seed(stub, (sql) => {
+      // A now-retired beat the agent claimed first (no recent activity)...
+      sql.exec(
+        "INSERT OR IGNORE INTO beats (slug, name, created_by, created_at, updated_at, status) VALUES ('deal-flow-832', 'Deal Flow', 'creator', ?, ?, 'retired')",
+        older,
+        older
+      );
+      sql.exec(
+        "INSERT OR IGNORE INTO beat_claims (beat_slug, btc_address, claimed_at, status) VALUES ('deal-flow-832', ?, ?, 'active')",
+        agent,
+        older // claimed first → would be agentBeats[0] under the old code
+      );
+      // ...and an active beat they migrated to and file on.
+      sql.exec(
+        "INSERT OR IGNORE INTO beats (slug, name, created_by, created_at, updated_at) VALUES ('aibtc-network-832', 'AIBTC Network', 'creator', ?, ?)",
+        now,
+        now
+      );
+      sql.exec(
+        "INSERT OR IGNORE INTO beat_claims (beat_slug, btc_address, claimed_at, status) VALUES ('aibtc-network-832', ?, ?, 'active')",
+        agent,
+        now
+      );
+      // Recent beat activity from another author keeps the beat `active` without
+      // putting *this* agent in signal cooldown (so canFileSignal stays true).
+      sql.exec(
+        `INSERT OR IGNORE INTO signals
+           (id, beat_slug, btc_address, headline, sources, created_at, updated_at, status, correction_of)
+         VALUES ('sig-832-live', 'aibtc-network-832', 'bc1qother0000000000000000000000000000000', 'live signal', '[]', ?, ?, 'approved', NULL)`,
+        now,
+        now
+      );
+    });
+
+    const res = await stub.fetch(`https://do/status/${agent}`);
+    const { data } = (await res.json()) as StatusBody;
+
+    // The exposed beat is the active, non-retired one — no contradiction.
+    expect(data.beat?.slug).toBe("aibtc-network-832");
+    expect(data.beat?.retired).toBe(false);
+    expect(data.beatStatus).toBe("active");
+    expect(data.canFileSignal).toBe(true);
+    // Both claims still visible in the full array.
+    expect(data.beats.map((b) => b.slug).sort()).toEqual([
+      "aibtc-network-832",
+      "deal-flow-832",
+    ]);
+  });
+
+  it("does not report canFileSignal=true when every claimed beat is retired", async () => {
+    const id = testEnv.NEWS_DO.idFromName("news-singleton");
+    const stub = testEnv.NEWS_DO.get(id);
+    const agent = "bc1qretiredonly000000000000000000000000000";
+    const older = new Date(Date.now() - 90 * 24 * 3600 * 1000).toISOString();
+
+    await seed(stub, (sql) => {
+      sql.exec(
+        "INSERT OR IGNORE INTO beats (slug, name, created_by, created_at, updated_at, status) VALUES ('agent-economy-832', 'Agent Economy', 'creator', ?, ?, 'retired')",
+        older,
+        older
+      );
+      sql.exec(
+        "INSERT OR IGNORE INTO beat_claims (beat_slug, btc_address, claimed_at, status) VALUES ('agent-economy-832', ?, ?, 'active')",
+        agent,
+        older
+      );
+    });
+
+    const res = await stub.fetch(`https://do/status/${agent}`);
+    const { data } = (await res.json()) as StatusBody;
+
+    // Retired-only agent genuinely cannot file (POST rejects retired beats).
+    expect(data.canFileSignal).toBe(false);
+    expect(data.actions.some((a) => a.type === "claim-beat")).toBe(true);
+  });
+});

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -3996,10 +3996,13 @@ export class NewsDO extends DurableObject<Env> {
         .toArray();
 
       const expiryMs = BEAT_EXPIRY_DAYS * 24 * 3600 * 1000;
-      const agentBeats: Array<Record<string, unknown> & { beatStatus: "active" | "inactive" }> = [];
+      const agentBeats: Array<
+        Record<string, unknown> & { beatStatus: "active" | "inactive"; retired: boolean }
+      > = [];
       for (const r of beatRows) {
         const row = r as Record<string, unknown>;
         const lastSignalAt = row.last_signal_at as string | null;
+        const retired = row.status === "retired";
         const status: "active" | "inactive" =
           lastSignalAt && now.getTime() - new Date(lastSignalAt).getTime() < expiryMs
             ? "active"
@@ -4013,12 +4016,29 @@ export class NewsDO extends DurableObject<Env> {
           created_at: row.created_at,
           updated_at: row.updated_at,
           beatStatus: status,
+          retired,
         });
       }
 
-      // Backward compat: expose first beat as `beat` / `beatStatus`
-      const beat = agentBeats.length > 0 ? agentBeats[0] : null;
+      // Backward compat: expose a single beat as `beat` / `beatStatus`.
+      //
+      // Prefer the agent's first non-retired *active* beat, then any non-retired
+      // beat, before falling back to the oldest claim. Agents who registered on a
+      // since-retired beat (e.g. `deal-flow`) but migrated to an active one were
+      // otherwise shown that retired claim here — reading beatStatus "inactive"
+      // while canFileSignal/actions correctly said they could file, the
+      // contradiction reported in #832. Selecting an active beat aligns the
+      // display field with the filing gate instead of flapping it on cooldown.
+      const beat =
+        agentBeats.find((b) => !b.retired && b.beatStatus === "active") ??
+        agentBeats.find((b) => !b.retired) ??
+        (agentBeats.length > 0 ? agentBeats[0] : null);
       const beatStatus = beat ? beat.beatStatus : null;
+
+      // An agent whose every claimed beat is retired cannot actually file —
+      // POST /api/signals rejects retired beats. Reflect that in the gate so
+      // canFileSignal doesn't read `true` for someone who has nowhere to file.
+      const hasFileableBeat = agentBeats.some((b) => !b.retired);
 
       // Last signal time for cooldown
       const lastSignalRows = this.ctx.storage.sql
@@ -4098,6 +4118,9 @@ export class NewsDO extends DurableObject<Env> {
 
       if (agentBeats.length === 0) {
         actions.push({ type: "claim-beat", description: "Claim a news beat to start filing signals" });
+      } else if (!hasFileableBeat) {
+        canFileSignal = false;
+        actions.push({ type: "claim-beat", description: "Your beat has been retired — claim an active beat to keep filing signals" });
       } else if (signalsToday >= MAX_SIGNALS_PER_DAY) {
         canFileSignal = false;
         actions.push({ type: "daily-limit", description: `Daily limit reached (${MAX_SIGNALS_PER_DAY}/${MAX_SIGNALS_PER_DAY}). Try again tomorrow.` });


### PR DESCRIPTION
Closes #832.

## Problem
`GET /api/status/{address}` exposed the agent's **oldest** claim (`ORDER BY claimed_at`) as the singular `beat`/`beatStatus`. For the pre-consolidation cohort that oldest claim is a since-retired beat with no recent activity, so it read `beatStatus:"inactive"` while `canFileSignal:true` and the `file-signal` action were correct for the active beat they migrated to — the contradiction reported in #832 (reproduced live on `deal-flow`).

## Fix
- Prefer the agent's first non-retired **active** beat (then any non-retired beat) as the backward-compat `beat`, instead of the oldest claim. Keeps the `active|inactive` contract and avoids flapping `beatStatus` on cooldown (which sonic-mast's literal option-1 would have done).
- Set `canFileSignal=false` when **every** claimed beat is retired, matching `POST /api/signals` which rejects retired-beat filing, with a `claim-beat` action.
- Expose per-beat `retired` in the `beats` array.

## Verification
- New `status-beat-consistency.test.ts` seeds the exact reported scenario (retired beat claimed first + active beat migrated to) and asserts the exposed beat is the active one with a consistent gate; plus a retired-only agent gets `canFileSignal:false`.
- Full suite green (433 tests); `tsc --noEmit` clean.