### PR TITLE
fix(staging): self-heal beat_editors/beat_claims, seed beats table

### DIFF
--- a/fixtures/seed-staging.json
+++ b/fixtures/seed-staging.json
@@ -1,4 +1,69 @@
 {
+  "beats": [
+    {
+      "slug": "bitcoin-macro",
+      "name": "Bitcoin Macro",
+      "description": "Broader Bitcoin macroeconomic news: price milestones, ETF flows, institutional adoption, regulatory developments, and macro events relevant to the Bitcoin-native AI economy.",
+      "color": "#F9A825",
+      "created_by": "system",
+      "created_at": "2026-01-01T00:00:00Z",
+      "updated_at": "2026-01-01T00:00:00Z"
+    },
+    {
+      "slug": "quantum",
+      "name": "Quantum",
+      "description": "Quantum computing and its potential impacts on Bitcoin: hardware and algorithm advances, threats to ECDSA and SHA-256, post-quantum cryptography proposals and BIPs, timeline and risk assessments, and quantum-resistant signature schemes.",
+      "color": "#00BFA5",
+      "created_by": "system",
+      "created_at": "2026-01-01T00:00:00Z",
+      "updated_at": "2026-01-01T00:00:00Z"
+    },
+    {
+      "slug": "agent-economy",
+      "name": "Agent Economy",
+      "description": "Payments, bounties, x402 flows, sBTC transfers between agents, service marketplaces, and agent registration/reputation events.",
+      "color": "#FF8F00",
+      "created_by": "system",
+      "created_at": "2026-01-01T00:00:00Z",
+      "updated_at": "2026-01-01T00:00:00Z"
+    },
+    {
+      "slug": "agent-skills",
+      "name": "Agent Skills",
+      "description": "Skills built by agents, PRs, adoption metrics, capability milestones, and tool registrations.",
+      "color": "#00897B",
+      "created_by": "system",
+      "created_at": "2026-01-01T00:00:00Z",
+      "updated_at": "2026-01-01T00:00:00Z"
+    },
+    {
+      "slug": "governance",
+      "name": "Governance",
+      "description": "Multisig operations, elections, sBTC staking, DAO proposals, voting outcomes, and signer/council activity.",
+      "color": "#7C4DFF",
+      "created_by": "system",
+      "created_at": "2026-01-01T00:00:00Z",
+      "updated_at": "2026-01-01T00:00:00Z"
+    },
+    {
+      "slug": "infrastructure",
+      "name": "Infrastructure",
+      "description": "MCP server updates, relay health, API changes, protocol releases, and tooling that agents and builders depend on.",
+      "color": "#546E7A",
+      "created_by": "system",
+      "created_at": "2026-01-01T00:00:00Z",
+      "updated_at": "2026-01-01T00:00:00Z"
+    },
+    {
+      "slug": "security",
+      "name": "Security",
+      "description": "Vulnerabilities affecting aibtc agents and wallets, contract audit findings, agent-targeted threats, and network security events.",
+      "color": "#E53935",
+      "created_by": "system",
+      "created_at": "2026-01-01T00:00:00Z",
+      "updated_at": "2026-01-01T00:00:00Z"
+    }
+  ],
   "signals": [
     {
       "id": "seed-sig-001",

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -5861,6 +5861,7 @@ export class NewsDO extends DurableObject<Env> {
       }
 
       const inserted: Record<string, number> = {
+        beats: 0,
         signals: 0,
         signal_tags: 0,
         brief_signals: 0,
@@ -5870,6 +5871,31 @@ export class NewsDO extends DurableObject<Env> {
         leaderboard_snapshots: 0,
         classifieds: 0,
       };
+
+      // Seed beats — signals reference beat_slug (see below), so beats must
+      // land first or /api/beats and beat-lookup 404 even when signals seed
+      // fine (sqlite doesn't enforce the beats(slug) FK by default). See #805.
+      if (Array.isArray(body.beats)) {
+        for (const row of body.beats as Array<Record<string, unknown>>) {
+          try {
+            this.ctx.storage.sql.exec(
+              `INSERT OR IGNORE INTO beats
+               (slug, name, description, color, created_by, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?)`,
+              row.slug as string,
+              row.name as string,
+              (row.description as string | null) ?? null,
+              (row.color as string | null) ?? null,
+              (row.created_by as string) ?? "system",
+              (row.created_at as string) ?? new Date().toISOString(),
+              (row.updated_at as string) ?? new Date().toISOString()
+            );
+            inserted.beats++;
+          } catch {
+            // Skip invalid rows silently
+          }
+        }
+      }
 
       // Seed signals
       const seededSignalAddresses = new Set<string>();

--- a/src/objects/schema.ts
+++ b/src/objects/schema.ts
@@ -184,6 +184,36 @@ CREATE TABLE IF NOT EXISTS leaderboard_cache (
   computed_at TEXT NOT NULL,
   entries     TEXT NOT NULL
 );
+
+-- beat_claims and beat_editors are otherwise created by versioned migrations
+-- #13 and #17 (MIGRATION_BEAT_CLAIMS_SQL / MIGRATION_BEAT_EDITORS_SQL below).
+-- If migration_version was ever written >= 17 without the tables actually
+-- landing (partial storage reset, a migration that failed silently), the
+-- version counter never retries them and GET /api/beats 500s forever on
+-- "no such table: beat_editors" (#805). Declaring them here too means they
+-- self-heal on every cold start, same as leaderboard_cache above — safe
+-- because both CREATE TABLE and the indexes are already idempotent.
+CREATE TABLE IF NOT EXISTS beat_claims (
+  beat_slug    TEXT NOT NULL REFERENCES beats(slug),
+  btc_address  TEXT NOT NULL,
+  claimed_at   TEXT NOT NULL,
+  status       TEXT NOT NULL DEFAULT 'active',
+  PRIMARY KEY (beat_slug, btc_address)
+);
+CREATE INDEX IF NOT EXISTS idx_beat_claims_address ON beat_claims(btc_address);
+CREATE INDEX IF NOT EXISTS idx_beat_claims_status ON beat_claims(status);
+
+CREATE TABLE IF NOT EXISTS beat_editors (
+  beat_slug      TEXT NOT NULL REFERENCES beats(slug),
+  btc_address    TEXT NOT NULL,
+  status         TEXT NOT NULL DEFAULT 'active',
+  registered_at  TEXT NOT NULL,
+  registered_by  TEXT NOT NULL,
+  deactivated_at TEXT,
+  PRIMARY KEY (beat_slug, btc_address)
+);
+CREATE INDEX IF NOT EXISTS idx_beat_editors_address ON beat_editors(btc_address);
+CREATE INDEX IF NOT EXISTS idx_beat_editors_status ON beat_editors(status);
 `;
 
 /**


### PR DESCRIPTION
## Summary
- `beat_claims` and `beat_editors` are added to the always-re-applied `SCHEMA_SQL` (same self-heal pattern already used for `leaderboard_cache`), so a DO whose `migration_version` was bumped past #13/#17 without those tables actually landing recovers on next cold start instead of 500ing `GET /api/beats` forever on "no such table: beat_editors".
- `POST /api/internal/seed` (`/test-seed` DO route) now accepts a `beats` array and inserts it before signals — previously only `signals`/`signal_tags`/etc. were seeded, so signals referenced beat slugs that never existed as rows, and every `GET /api/beats/:slug` 404'd.
- `fixtures/seed-staging.json` now includes the 7 beats its seed signals actually reference (`bitcoin-macro`, `quantum`, `agent-economy`, `agent-skills`, `governance`, `infrastructure`, `security`), matching the canonical name/description/color from the migrations that created them.

## Context

Closes #805. Root cause was confirmed in the issue thread — this PR implements the two-part fix proposed there (structural self-heal + seed-endpoint fix).

## Test plan
- [ ] `tsc --noEmit` passes (verified locally, no new errors from these files)
- [ ] Preview deploy: `GET /api/beats` returns 200 with 7 seeded beats
- [ ] Preview deploy: `GET /api/beats/bitcoin-macro` (and the other 6 slugs) resolve instead of 404
- [ ] Re-run the x402 signal-payment smoke test steps 2,3,4,5,6,7,8,10b that #805 said were blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)