### PR TITLE
feat(review): let editors override the auto-scorer quality_score (#810)

### DIFF
--- a/src/__tests__/signal-review.test.ts
+++ b/src/__tests__/signal-review.test.ts
@@ -111,6 +111,59 @@ describe("PATCH /api/signals/:id/review — validation", () => {
   });
 });
 
+describe("PATCH /api/signals/:id/review — quality_score override (#810)", () => {
+  const VALID_ADDR = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+
+  async function review(quality_score: unknown) {
+    return SELF.fetch("http://example.com/api/signals/test-id/review", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ btc_address: VALID_ADDR, status: "rejected", feedback: "fabricated sources", quality_score }),
+    });
+  }
+
+  it("returns 400 when quality_score exceeds 100", async () => {
+    const res = await review(150);
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toContain("quality_score");
+  });
+
+  it("returns 400 when quality_score is negative", async () => {
+    const res = await review(-1);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when quality_score is not an integer", async () => {
+    const res = await review(87.5);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when quality_score is not a number", async () => {
+    const res = await review("100");
+    expect(res.status).toBe(400);
+  });
+
+  it("passes validation (reaching auth) for an in-range quality_score", async () => {
+    // 0 and 100 are the boundaries; both must clear the edge validation and
+    // fall through to BIP-322 auth (401), not fail as a 400.
+    for (const score of [0, 100]) {
+      const res = await review(score);
+      expect(res.status).toBe(401);
+    }
+  });
+
+  it("leaves the score path untouched when quality_score is omitted", async () => {
+    const res = await SELF.fetch("http://example.com/api/signals/test-id/review", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ btc_address: VALID_ADDR, status: "approved" }),
+    });
+    // No override field → not a 400; proceeds to auth.
+    expect(res.status).toBe(401);
+  });
+});
+
 describe("GET /api/front-page", () => {
   it("returns 200 with curated signal list shape", async () => {
     const res = await SELF.fetch("http://example.com/api/front-page");

--- a/src/__tests__/signal-scorer.test.ts
+++ b/src/__tests__/signal-scorer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { scoreSignal } from "../lib/signal-scorer";
+import { scoreSignal, withScoreOverride } from "../lib/signal-scorer";
 
 /**
  * Unit tests for the signal quality auto-scorer.
@@ -242,5 +242,58 @@ describe("scoreSignal — total and shape", () => {
       disclosure: "Researched using Claude and aibtc MCP skills.",
     });
     expect(result.total).toBe(100);
+  });
+});
+
+describe("withScoreOverride — editor score override provenance (#810)", () => {
+  const OVERRIDE = {
+    by: "bc1qeditor00000000000000000000000000000000",
+    at: "2026-07-13T10:00:00.000Z",
+    previous_score: 100,
+    reason: "fabricated sources — all release URLs 404",
+  };
+
+  it("preserves the original auto-scorer axes and appends the override envelope", () => {
+    const prior = JSON.stringify({
+      sourceQuality: 30,
+      thesisClarity: 25,
+      beatRelevance: 20,
+      timeliness: 15,
+      disclosure: 10,
+    });
+    const merged = JSON.parse(withScoreOverride(prior, OVERRIDE));
+    expect(merged.sourceQuality).toBe(30);
+    expect(merged.thesisClarity).toBe(25);
+    expect(merged.override).toEqual(OVERRIDE);
+    // previous_score in the envelope is the auto-score before the editor acted.
+    expect(merged.override.previous_score).toBe(100);
+  });
+
+  it("degrades to just the override when prior breakdown is null", () => {
+    const merged = JSON.parse(withScoreOverride(null, OVERRIDE));
+    expect(merged).toEqual({ override: OVERRIDE });
+  });
+
+  it("degrades gracefully when prior breakdown is unparseable legacy data", () => {
+    const merged = JSON.parse(withScoreOverride("not-json{", OVERRIDE));
+    expect(merged).toEqual({ override: OVERRIDE });
+  });
+
+  it("records a null previous_score when the signal had no auto-score", () => {
+    const merged = JSON.parse(
+      withScoreOverride(null, { ...OVERRIDE, previous_score: null })
+    );
+    expect(merged.override.previous_score).toBeNull();
+  });
+
+  it("re-overriding replaces the prior override rather than nesting", () => {
+    const firstPass = withScoreOverride(
+      JSON.stringify({ sourceQuality: 30 }),
+      OVERRIDE
+    );
+    const secondOverride = { ...OVERRIDE, at: "2026-07-14T00:00:00.000Z", previous_score: 15 };
+    const merged = JSON.parse(withScoreOverride(firstPass, secondOverride));
+    expect(merged.override).toEqual(secondOverride);
+    expect(merged.sourceQuality).toBe(30);
   });
 });

--- a/src/lib/do-client.ts
+++ b/src/lib/do-client.ts
@@ -1018,6 +1018,8 @@ export interface ReviewSignalInput {
   status: SignalStatus;
   feedback?: string | null;
   displace_signal_id?: string;
+  /** Editor-owned override of the auto-scorer quality_score (0–100). Omit to leave unchanged (#810). */
+  quality_score?: number;
 }
 
 export async function reviewSignal(

--- a/src/lib/signal-scorer.ts
+++ b/src/lib/signal-scorer.ts
@@ -19,6 +19,17 @@ export interface SignalScoreBreakdown {
   timeliness: number;
   /** 0–10: meaningful disclosure (model/tool mentioned) */
   disclosure: number;
+  /**
+   * Present only when an editor overrode the auto-score at review time (#810).
+   * The five axes above reflect the original auto-scorer; `override.previous_score`
+   * preserves the composite it produced before the editor replaced it.
+   */
+  override?: {
+    by: string;
+    at: string;
+    previous_score: number | null;
+    reason: string | null;
+  };
 }
 
 export interface SignalScore {
@@ -187,4 +198,31 @@ export function scoreSignal(signal: SignalScorerInput): SignalScore {
       disclosure,
     },
   };
+}
+
+/**
+ * Merge an editor score-override provenance envelope into an existing
+ * score_breakdown JSON string, returning the new JSON string to persist (#810).
+ *
+ * The original auto-scorer axes are preserved untouched; the `override` field
+ * records who changed the score, when, the previous composite, and why. A
+ * malformed or absent prior breakdown degrades to an empty object so an override
+ * is never blocked by unparseable legacy data.
+ */
+export function withScoreOverride(
+  priorBreakdownJson: string | null,
+  override: NonNullable<SignalScoreBreakdown["override"]>
+): string {
+  let prior: Record<string, unknown> = {};
+  if (priorBreakdownJson) {
+    try {
+      const parsed = JSON.parse(priorBreakdownJson) as unknown;
+      if (parsed && typeof parsed === "object") {
+        prior = parsed as Record<string, unknown>;
+      }
+    } catch {
+      prior = {};
+    }
+  }
+  return JSON.stringify({ ...prior, override });
 }

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -6,7 +6,7 @@ import { validateSlug, validateHexColor, sanitizeString, validateDateFormat } fr
 import { generateId, getUTCDate, getUTCYesterday, getUTCDayStart, getUTCDayEnd, getNextDate, signalContentFingerprint } from "../lib/helpers";
 import { CLASSIFIED_DURATION_DAYS, CLASSIFIED_BRIEF_SLOTS, CLASSIFIED_BRIEF_MAX_CHARS, CLASSIFIED_STATUSES, SIGNAL_COOLDOWN_HOURS, SIGNAL_DEDUP_REJECT_WINDOW_HOURS, BEAT_EXPIRY_DAYS, MAX_SIGNALS_PER_DAY, MAX_INCLUDED_SIGNALS_PER_BRIEF, MAX_APPROVED_SIGNALS_PER_DAY, SIGNAL_STATUSES, REVIEWABLE_SIGNAL_STATUSES, CONFIG_PUBLISHER_ADDRESS, BRIEF_INCLUSION_PAYOUT_SATS, WEEKLY_PRIZE_1ST_SATS, WEEKLY_PRIZE_2ND_SATS, WEEKLY_PRIZE_3RD_SATS, SCORING_WEIGHTS, PAYMENT_STAGE_TTL_MS, PENDING_PAYMENT_STATUS } from "../lib/constants";
 import { SCHEMA_SQL, MIGRATION_PHASE0_SQL, MIGRATION_PAYMENTS_SQL, MIGRATION_BEAT_RESTRUCTURE_SQL, MIGRATION_SBTC_TRACKING_SQL, MIGRATION_CLASSIFIEDS_CLEANUP_SQL, MIGRATION_CLASSIFIEDS_REVIEW_SQL, MIGRATION_SNAPSHOTS_SQL, MIGRATION_BEAT_CLAIMS_SQL, MIGRATION_RETRACTION_SQL, MIGRATION_BEAT_NETWORK_FOCUS_SQL, MIGRATION_BITCOIN_MACRO_SQL, MIGRATION_QUANTUM_BEAT_SQL, MIGRATION_PAYMENT_STAGING_SQL, MIGRATION_APPROVAL_CAP_INDEX_SQL, MIGRATION_BEAT_EDITORS_SQL, MIGRATION_EDITORIAL_REVIEWS_SQL, MIGRATION_EDITOR_REVIEW_RATE_SQL, MIGRATION_CURATION_CLEANUP_SQL, MIGRATION_LEADERBOARD_INDEXES_SQL, MIGRATION_BEAT_CONSOLIDATION_SQL, MIGRATION_SIGNAL_SCORING_SQL, MIGRATION_APR7_EARNINGS_SQL, MIGRATION_CLASSIFIEDS_TXID_UNIQUE_SQL, MIGRATION_SIGNAL_HOT_PATH_INDEXES_SQL, MIGRATION_CORRESPONDENTS_BUNDLE_INDEXES_SQL, MIGRATION_CORRESPONDENT_STATS_SQL, MIGRATION_SIGNAL_PAYMENT_SQL, EXPECTED_SIGNALS_INDEXES } from "./schema";
-import { scoreSignal } from "../lib/signal-scorer";
+import { scoreSignal, withScoreOverride } from "../lib/signal-scorer";
 
 // ── State machine transition maps ──
 // Hoisted to module level so they are created once and are testable.
@@ -1717,7 +1717,27 @@ export class NewsDO extends DurableObject<Env> {
         return c.json({ ok: false, error: "Invalid JSON body" } satisfies DOResult<Signal>, 400);
       }
 
-      const { btc_address, status, feedback } = body;
+      const { btc_address, status, feedback, quality_score } = body;
+
+      // Optional editor-owned score override (#810). When present it replaces
+      // the auto-scorer's quality_score; when absent the score is left untouched.
+      // Source-existence remains an editorial judgement — the system never
+      // fetches URLs. Validate before any auth/state work so bad input fails fast.
+      let scoreOverride: number | undefined; // undefined = "no change"
+      if (quality_score !== undefined && quality_score !== null) {
+        if (
+          typeof quality_score !== "number" ||
+          !Number.isInteger(quality_score) ||
+          quality_score < 0 ||
+          quality_score > 100
+        ) {
+          return c.json(
+            { ok: false, error: "quality_score must be an integer between 0 and 100" } satisfies DOResult<Signal>,
+            400
+          );
+        }
+        scoreOverride = quality_score;
+      }
 
       // Validate status. brief_included is backend-owned and cannot be set manually.
       if (
@@ -1738,14 +1758,14 @@ export class NewsDO extends DurableObject<Env> {
 
       // Verify signal exists first so we know its beat_slug and author for auth check
       const signalRows = this.ctx.storage.sql
-        .exec("SELECT id, status, beat_slug, btc_address, created_at FROM signals WHERE id = ?", id)
+        .exec("SELECT id, status, beat_slug, btc_address, created_at, quality_score, score_breakdown FROM signals WHERE id = ?", id)
         .toArray();
       if (signalRows.length === 0) {
         return c.json({ ok: false, error: `Signal "${id}" not found` } satisfies DOResult<Signal>, 404);
       }
 
       // State machine: prevent editorial regressions
-      const signalRow = signalRows[0] as { id: string; status: SignalStatus; beat_slug: string; btc_address: string; created_at: string };
+      const signalRow = signalRows[0] as { id: string; status: SignalStatus; beat_slug: string; btc_address: string; created_at: string; quality_score: number | null; score_breakdown: string | null };
       const currentStatus = signalRow.status;
       const newStatus = status as SignalStatus; // validated above against SIGNAL_STATUSES
       const allowed = SIGNAL_VALID_TRANSITIONS[currentStatus] ?? [];
@@ -1947,15 +1967,38 @@ export class NewsDO extends DurableObject<Env> {
       }
 
       const now = nowDate.toISOString();
-      this.ctx.storage.sql.exec(
-        `UPDATE signals SET status = ?, publisher_feedback = ?, reviewed_at = ?, updated_at = ?
-         WHERE id = ?`,
-        newStatus,
-        feedback ? sanitizeString(feedback, 1000) : null,
-        now,
-        now,
-        id
-      );
+      if (scoreOverride !== undefined) {
+        // Editor override: replace quality_score and record provenance in the
+        // score_breakdown JSON (previous auto-score preserved for audit). No
+        // migration — reuses the existing quality_score / score_breakdown columns.
+        const overriddenBreakdown = withScoreOverride(signalRow.score_breakdown, {
+          by: btc_address as string,
+          at: now,
+          previous_score: signalRow.quality_score,
+          reason: feedback ? sanitizeString(feedback, 1000) : null,
+        });
+        this.ctx.storage.sql.exec(
+          `UPDATE signals SET status = ?, publisher_feedback = ?, reviewed_at = ?, updated_at = ?, quality_score = ?, score_breakdown = ?
+           WHERE id = ?`,
+          newStatus,
+          feedback ? sanitizeString(feedback, 1000) : null,
+          now,
+          now,
+          scoreOverride,
+          overriddenBreakdown,
+          id
+        );
+      } else {
+        this.ctx.storage.sql.exec(
+          `UPDATE signals SET status = ?, publisher_feedback = ?, reviewed_at = ?, updated_at = ?
+           WHERE id = ?`,
+          newStatus,
+          feedback ? sanitizeString(feedback, 1000) : null,
+          now,
+          now,
+          id
+        );
+      }
 
       // Soft-archive brief_signals and void unpaid earnings when removing a
       // brief_included signal from the active roster before inscription.

--- a/src/routes/signal-review.ts
+++ b/src/routes/signal-review.ts
@@ -35,7 +35,7 @@ signalReviewRouter.patch("/api/signals/:id/review", reviewRateLimit, async (c) =
     return c.json({ error: "Invalid JSON body" }, 400);
   }
 
-  const { btc_address, status, feedback, displace_signal_id } = body;
+  const { btc_address, status, feedback, displace_signal_id, quality_score } = body;
 
   if (!btc_address) {
     return c.json({ error: "Missing required field: btc_address" }, 400);
@@ -54,6 +54,19 @@ signalReviewRouter.patch("/api/signals/:id/review", reviewRateLimit, async (c) =
     }, 400);
   }
 
+  // Optional editor score override (#810): fail fast on bad input before auth,
+  // mirroring the status check above. The DO handler re-validates as a backstop.
+  if (quality_score !== undefined && quality_score !== null) {
+    if (
+      typeof quality_score !== "number" ||
+      !Number.isInteger(quality_score) ||
+      quality_score < 0 ||
+      quality_score > 100
+    ) {
+      return c.json({ error: "quality_score must be an integer between 0 and 100" }, 400);
+    }
+  }
+
   // BIP-322 auth
   const authResult = verifyAuth(
     c.req.raw.headers,
@@ -70,6 +83,9 @@ signalReviewRouter.patch("/api/signals/:id/review", reviewRateLimit, async (c) =
     status: status as SignalStatus,
     feedback: feedback ? String(feedback) : null,
     displace_signal_id: displace_signal_id ? String(displace_signal_id) : undefined,
+    // Editor-owned score override (#810). Forwarded only when a number so the
+    // DO handler validates the range and records provenance; absent = no change.
+    quality_score: typeof quality_score === "number" ? quality_score : undefined,
   });
 
   if (!result.ok) {


### PR DESCRIPTION
## What & why

Fixes #810. The signal `quality_score` is stamped once by the pure auto-scorer at insert and is otherwise **immutable** — the review PATCH only accepts `status`, `feedback`, `displace_signal_id`. So when an editor rejects a signal for fabricated sources (e.g. `quality_score=100` on three GitHub release URLs that all 404), the misleading score stays on the record and on `/api/signals`. Editors can void the *signal* but not the *score*.

This gives editors the one lever they were missing.

**Deliberately not** an automated URL-existence checker: source truth remains an editorial judgement and the system never makes an outbound fetch. (We explored a background `alarm()` verifier and ruled it out — kept scope on the human-in-the-loop fix.)

## Change

Optional `quality_score` field on `PATCH /api/signals/:id/review`:

| Case | Result |
|---|---|
| Field omitted | Unchanged — the no-override `UPDATE` path is byte-identical |
| `quality_score: 15` | Score replaced; original preserved in `score_breakdown.override` (`by`, `at`, `previous_score`, `reason`) for audit |
| Out of range / non-integer | `400` |
| Non-editor caller | `401/403` from the existing `verifyEditorOrPublisher` gate — unchanged |

- No migration — reuses the existing `quality_score` / `score_breakdown` columns.
- Validation runs at the edge (fail-fast, pre-auth) **and** in the DO handler (backstop).
- BIP-322 auth unaffected: `verifyAuth` signs over method + path, not the body.
- Override is orthogonal to `status` — no auto-reject, no queue-behavior change.

## Files
- `src/routes/signal-review.ts` — edge validation + pass-through
- `src/lib/do-client.ts` — `ReviewSignalInput.quality_score`
- `src/objects/news-do.ts` — DO handler: destructure/validate, widen existence SELECT, conditional UPDATE
- `src/lib/signal-scorer.ts` — new pure `withScoreOverride()` helper + `SignalScoreBreakdown.override` type

## Tests
- 7 edge-validation tests (range/type boundaries, omission)
- 5 provenance-merge tests (preserve axes, null/legacy-JSON degrade, re-override replaces not nests)
- Full suite: **444 pass**, typecheck clean

## Known gap
The DO write happy-path (persisting the new score) isn't covered by an integration test — the test env can't generate BIP-322 auth (same limitation noted in `retraction.test.ts:9-11`). Mitigated by extracting the risky JSON-merge logic into the fully-unit-tested `withScoreOverride()`. A `runInDurableObject` test that seeds a publisher and drives the DO router directly would close this — proposed as a follow-up.

## Not included (follow-up)
The editor/UI client needs a field added to actually surface this lever — this PR makes the API support it.