### PR TITLE
fix(read-path): degrade classifieds + front-page gracefully on DO timeout (#699)

### DIFF
--- a/src/routes/classifieds.ts
+++ b/src/routes/classifieds.ts
@@ -7,7 +7,7 @@
  */
 
 import { Hono } from "hono";
-import type { Env, AppVariables, Classified } from "../lib/types";
+import type { Env, AppVariables, Classified, AppContext } from "../lib/types";
 import {
   CLASSIFIED_PRICE_SATS,
   CLASSIFIED_CATEGORIES,
@@ -27,7 +27,7 @@ import {
 import { logPaymentEvent } from "../lib/payment-logging";
 import { buildLocalPaymentStatusUrl, buildPaymentRequired, verifyPayment, mapVerificationError } from "../services/x402";
 import { resolveNamesWithTimeout, generateId } from "../lib/helpers";
-import { edgeCacheMatch, edgeCachePut } from "../lib/edge-cache";
+import { edgeCacheMatchSWR, edgeCachePut, triggerSWRRefresh } from "../lib/edge-cache";
 
 /** Transform a Classified row to the camelCase API response shape. */
 export function transformClassified(cl: Classified) {
@@ -82,21 +82,23 @@ classifiedsRouter.get("/api/classifieds/rotation", async (c) => {
 // primary consumer of this view and likely needs immediate freshness on their
 // own submissions. The endpoint is already public (no auth gate today), so
 // skipping the cache changes nothing about visibility — just about staleness.
-classifiedsRouter.get("/api/classifieds", async (c) => {
-  const category = c.req.query("category");
-  const agent = c.req.query("agent");
-  const limitParam = c.req.query("limit");
-  const limit = limitParam
-    ? Math.min(Math.max(1, parseInt(limitParam, 10) || 50), 1000)
-    : undefined;
+// Inner freshness window for the SWR cache. Within this, a hit is served as a
+// plain HIT; past it (but still within the s-maxage=300 edge TTL) the stale copy
+// is served immediately and a background rebuild fires. This keeps the Durable
+// Object off the synchronous request path once warm — and, critically, means a
+// transient DO timeout serves stale instead of a 500 (#699).
+const CLASSIFIEDS_FRESH_SECONDS = 60;
 
-  const cacheable = !agent;
-  if (cacheable) {
-    const cached = await edgeCacheMatch(c);
-    if (cached) return cached;
-  }
-
-  const classifieds = await listClassifieds(c.env, { category, agent, limit });
+/** Build the classifieds list response (DO fetch + name resolution + cache put). */
+async function buildClassifiedsListResponse(
+  c: AppContext,
+  opts: { category?: string; agent?: string; limit?: number; cacheable: boolean }
+): Promise<Response> {
+  const classifieds = await listClassifieds(c.env, {
+    category: opts.category,
+    agent: opts.agent,
+    limit: opts.limit,
+  });
 
   const transformed = classifieds.map(transformClassified);
 
@@ -117,15 +119,55 @@ classifiedsRouter.get("/api/classifieds", async (c) => {
     };
   });
 
+  const response = c.json({ classifieds: withNames, total: withNames.length });
   // Per-agent views aren't cached (see above); send a private,no-store
   // header so downstream caches don't independently snapshot them either.
-  c.header(
+  response.headers.set(
     "Cache-Control",
-    cacheable ? "public, max-age=60, s-maxage=300" : "private, no-store"
+    opts.cacheable ? "public, max-age=60, s-maxage=300" : "private, no-store"
   );
-  const response = c.json({ classifieds: withNames, total: withNames.length });
-  if (cacheable) edgeCachePut(c, response);
+  if (opts.cacheable) edgeCachePut(c, response);
   return response;
+}
+
+classifiedsRouter.get("/api/classifieds", async (c) => {
+  const category = c.req.query("category");
+  const agent = c.req.query("agent");
+  const limitParam = c.req.query("limit");
+  const limit = limitParam
+    ? Math.min(Math.max(1, parseInt(limitParam, 10) || 50), 1000)
+    : undefined;
+
+  const cacheable = !agent;
+  const opts = { category, agent, limit, cacheable };
+
+  if (cacheable) {
+    const hit = await edgeCacheMatchSWR(c, { freshSeconds: CLASSIFIEDS_FRESH_SECONDS });
+    if (hit && !hit.stale) return hit.response;
+    if (hit?.stale) {
+      // Serve stale immediately; rebuild in the background (guarded by a KV lock).
+      triggerSWRRefresh(c, "classifieds", () => buildClassifiedsListResponse(c, opts));
+      return hit.response;
+    }
+  }
+
+  try {
+    return await buildClassifiedsListResponse(c, opts);
+  } catch (err) {
+    // Transient DO saturation makes listClassifieds() throw (10s doFetch guard).
+    // With no cached copy to fall back on, degrade to a retryable 503 rather than
+    // a bare 500 so probes get an honest, retry-able signal (#699).
+    const logger = c.get("logger");
+    logger.warn("classifieds list unavailable", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    const res = c.json(
+      { error: "Classifieds are temporarily unavailable. Please retry shortly.", code: "CLASSIFIEDS_UNAVAILABLE" },
+      503
+    );
+    res.headers.set("Retry-After", "30");
+    return res;
+  }
 });
 
 // GET /api/classifieds/:id — get a single classified ad

--- a/src/routes/signal-review.ts
+++ b/src/routes/signal-review.ts
@@ -6,14 +6,14 @@
  */
 
 import { Hono } from "hono";
-import type { Env, AppVariables, SignalStatus } from "../lib/types";
+import type { Env, AppVariables, SignalStatus, AppContext } from "../lib/types";
 import { createRateLimitMiddleware } from "../middleware/rate-limit";
 import { reviewSignal, listFrontPagePage, listFrontPage } from "../lib/do-client";
 import { validateDateFormat } from "../lib/validators";
 import { validateBtcAddress } from "../lib/validators";
 import { verifyAuth } from "../services/auth";
 import { REVIEW_RATE_LIMIT, REVIEWABLE_SIGNAL_STATUSES } from "../lib/constants";
-import { edgeCacheMatch, edgeCachePut } from "../lib/edge-cache";
+import { edgeCacheMatchSWR, edgeCachePut, triggerSWRRefresh } from "../lib/edge-cache";
 
 const signalReviewRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>();
 
@@ -136,26 +136,20 @@ signalReviewRouter.patch("/api/signals/:id/review", reviewRateLimit, async (c) =
 // Edge-cached for both modes — paginated mode in particular benefits because
 // the URL is stable per day, so the same page served to every infinite-scroll
 // reader after the first hit is served from edge.
-signalReviewRouter.get("/api/front-page", async (c) => {
-  const cached = await edgeCacheMatch(c);
-  if (cached) return cached;
+// Inner freshness window for the SWR cache (see /api/correspondents for the
+// same pattern). Serving stale past this window keeps the Durable Object off
+// the synchronous path once warm — so a transient DO timeout serves stale
+// instead of a hard 500 (#699).
+const FRONT_PAGE_FRESH_SECONDS = 60;
 
-  const before = c.req.query("before") ?? null;
-  const limitParam = c.req.query("limit");
-  const limit = limitParam ? Math.min(Math.max(1, parseInt(limitParam, 10) || 50), 200) : 50;
-
+/** Build the front-page response for the given mode (paginated vs default). */
+async function buildFrontPageResponse(
+  c: AppContext,
+  opts: { before: string | null; limit: number }
+): Promise<Response> {
   // Paginated mode: infinite scroll request
-  if (before !== null) {
-    if (!validateDateFormat(before)) {
-      return c.json({ error: "Invalid 'before' param (YYYY-MM-DD required)" }, 400);
-    }
-    // Validate it parses to a real date (rejects e.g. 2026-99-99)
-    const parsed = new Date(`${before}T12:00:00Z`);
-    if (Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== before) {
-      return c.json({ error: "Invalid 'before' param (not a real date)" }, 400);
-    }
-
-    const result = await listFrontPagePage(c.env, before, limit);
+  if (opts.before !== null) {
+    const result = await listFrontPagePage(c.env, opts.before, opts.limit);
     const transformed = result.signals.map((s) => ({
       id: s.id,
       btcAddress: s.btc_address,
@@ -171,20 +165,19 @@ signalReviewRouter.get("/api/front-page", async (c) => {
       correction_of: s.correction_of,
     }));
 
-    c.header("Cache-Control", "public, max-age=60, s-maxage=300");
     const response = c.json({
       signals: transformed,
       date: result.date,
       hasMore: result.hasMore,
       curated: true,
     });
+    response.headers.set("Cache-Control", "public, max-age=60, s-maxage=300");
     edgeCachePut(c, response);
     return response;
   }
 
   // Default mode: single DO query for all approved + brief_included signals
   const all = await listFrontPage(c.env);
-
   const transformed = all.map((s) => ({
     id: s.id,
     btcAddress: s.btc_address,
@@ -200,14 +193,59 @@ signalReviewRouter.get("/api/front-page", async (c) => {
     correction_of: s.correction_of,
   }));
 
-  c.header("Cache-Control", "public, max-age=60, s-maxage=300");
   const response = c.json({
     signals: transformed,
     total: transformed.length,
     curated: true,
   });
+  response.headers.set("Cache-Control", "public, max-age=60, s-maxage=300");
   edgeCachePut(c, response);
   return response;
+}
+
+signalReviewRouter.get("/api/front-page", async (c) => {
+  const before = c.req.query("before") ?? null;
+  const limitParam = c.req.query("limit");
+  const limit = limitParam ? Math.min(Math.max(1, parseInt(limitParam, 10) || 50), 200) : 50;
+
+  // Validate the paginated param before touching the cache or DO — invalid
+  // dates are a 400 regardless of cache state.
+  if (before !== null) {
+    if (!validateDateFormat(before)) {
+      return c.json({ error: "Invalid 'before' param (YYYY-MM-DD required)" }, 400);
+    }
+    // Validate it parses to a real date (rejects e.g. 2026-99-99)
+    const parsed = new Date(`${before}T12:00:00Z`);
+    if (Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== before) {
+      return c.json({ error: "Invalid 'before' param (not a real date)" }, 400);
+    }
+  }
+
+  const hit = await edgeCacheMatchSWR(c, { freshSeconds: FRONT_PAGE_FRESH_SECONDS });
+  if (hit && !hit.stale) return hit.response;
+  if (hit?.stale) {
+    // Serve stale immediately; rebuild in the background (guarded by a KV lock).
+    triggerSWRRefresh(c, "front-page", () => buildFrontPageResponse(c, { before, limit }));
+    return hit.response;
+  }
+
+  try {
+    return await buildFrontPageResponse(c, { before, limit });
+  } catch (err) {
+    // Transient DO saturation makes listFrontPage() throw (10s doFetch guard).
+    // With no cached copy to fall back on, degrade to a retryable 503 rather
+    // than a bare 500 so probes get an honest, retry-able signal (#699).
+    const logger = c.get("logger");
+    logger.warn("front-page unavailable", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    const res = c.json(
+      { error: "The front page is temporarily unavailable. Please retry shortly.", code: "FRONT_PAGE_UNAVAILABLE" },
+      503
+    );
+    res.headers.set("Retry-After", "30");
+    return res;
+  }
 });
 
 export { signalReviewRouter };


### PR DESCRIPTION
## What & why

Fixes #699. `secret-mars` documented a recurring 5xx flap: `/api/classifieds` and `/api/front-page` return **500 together** in 30s–28min bursts, several times a day, while `/api/health` and unrelated reads stay 200.

**Root cause** (traced in code): both endpoints fetch from the news-singleton Durable Object via do-client helpers that **throw** on a `doFetch` timeout (the 10s guard from #519). The handlers had **no try/catch**, so a transient DO-saturation window became a bare 500. That's the flap — the DO recovers seconds/minutes later and the endpoint works again.

## Fix

Adopt the SWR read-path already proven on `/api/correspondents`:

- **`edgeCacheMatchSWR` + `triggerSWRRefresh`** — once warm, the DO is off the synchronous request path. A stale copy is served immediately and rebuilt in the background, so a transient DO timeout never reaches the client.
- **`try/catch` → `503` + `Retry-After: 30`** on a true cache miss where the DO fetch throws — a retryable, honest signal (with a structured `warn` log) instead of a raw 500. Mirrors the identity-gate #353 degradation shape.

Refactor extracts `buildClassifiedsListResponse` / `buildFrontPageResponse` so one builder feeds both the synchronous path and the background refresh.

### Behavior
| Path | Before | After |
|---|---|---|
| Happy path | 200 | 200 (unchanged) |
| DO slow, warm cache | 500 | **200 stale** + background rebuild |
| DO slow, cold cache | 500 | **503 + Retry-After: 30** |
| `?agent=` view | live, 500 on DO fail | live, **503** on DO fail |

## Scope / not addressed here
- The underlying **DO saturation** (same family as #690) — the real perf root cause, separate effort.
- `/api/classifieds/{id}` returns a transient **404** on DO failure (`getClassified` swallows the fetch error into `null`) rather than 5xx — a milder, separate degradation mode; noted, not expanded into here.

## Tests
- Full suite **444 pass**, typecheck clean, `wrangler deploy --dry-run` clean.
- The 503 degradation path requires injecting a DO fetch failure, which the integration test env can't do (same limitation as the identity-gate/retraction tests) — the SWR/cache helpers no-op in test, so happy-path coverage is unchanged and green.

## Files
- `src/routes/classifieds.ts` — SWR + try/catch on the list handler; extract builder
- `src/routes/signal-review.ts` — same for `/api/front-page` (both paginated + default modes)