### PR TITLE
perf(correspondents): cut cold-rebuild latency — decouple leaderboard, widen name negative-cache

### DIFF
--- a/src/__tests__/correspondent-stats.test.ts
+++ b/src/__tests__/correspondent-stats.test.ts
@@ -318,3 +318,68 @@ describe("correspondent_stats — recon detects and repairs drift", () => {
     expect(repaired?.daysActive).toBe(1);
   });
 });
+
+describe("correspondents bundle — leaderboard read decoupled from recompute (#690 cold-rebuild)", () => {
+  // Fix 1: /correspondents-bundle reads leaderboard_cache stale-or-empty instead
+  // of running a live queryLeaderboard() on every cold rebuild. The endpoint must
+  // still serve correspondents when the cache is empty (degrading to zero scores)
+  // and source its scores from the materialised cache once it is populated — the
+  // recompute only ever happens via /leaderboard or /init, never here.
+  async function fetchWithScores(): Promise<
+    Array<{ address: string; signalCount: number; score: number }>
+  > {
+    const res = await SELF.fetch("http://example.com/api/correspondents");
+    expect(res.status).toBe(200);
+    const body = await res.json<{
+      correspondents: Array<{ address: string; signalCount: number; score: number }>;
+    }>();
+    return body.correspondents;
+  }
+
+  it("serves zero scores when the leaderboard cache is empty, then agrees with the cache once populated", async () => {
+    const addr = "bc1q-corr-lb-decouple-001";
+
+    // Seeding is a POST, so the DO's post-dispatch mutation hook drops
+    // leaderboard_cache. The next correspondents read therefore exercises the
+    // empty-cache branch of getLeaderboardStaleOrEmpty().
+    await seed({
+      signals: [
+        {
+          id: "cs-lb-001-a",
+          beat_slug: "agent-social",
+          btc_address: addr,
+          headline: "decouple",
+          sources: "[]",
+          created_at: "2026-04-15T10:00:00.000Z",
+          status: "submitted",
+        },
+      ],
+    });
+
+    // Empty-cache branch: the agent is still returned (correct signalCount) and
+    // its score degrades to 0 rather than the endpoint blocking on a recompute.
+    let correspondents = await fetchWithScores();
+    let me = correspondents.find((c) => c.address === addr);
+    expect(me).toBeDefined();
+    expect(me?.signalCount).toBe(1);
+    expect(me?.score).toBe(0);
+
+    // A /leaderboard read is the only remaining path that recomputes and
+    // repopulates leaderboard_cache.
+    const lbRes = await SELF.fetch("http://example.com/api/leaderboard");
+    expect(lbRes.status).toBe(200);
+    const lbBody = await lbRes.json<{
+      leaderboard: Array<{ address: string; score: number }>;
+    }>();
+    const lbScore =
+      lbBody.leaderboard.find((e) => e.address === addr)?.score ?? 0;
+
+    // Populated-cache branch: correspondents now sources its score from the same
+    // materialised cache the leaderboard wrote — the two agree, and the read
+    // itself never triggered a recompute.
+    correspondents = await fetchWithScores();
+    me = correspondents.find((c) => c.address === addr);
+    expect(me?.signalCount).toBe(1);
+    expect(me?.score).toBe(lbScore);
+  });
+});

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -5508,13 +5508,22 @@ export class NewsDO extends DurableObject<Env> {
         )
         .toArray();
 
-      // Leaderboard — wrapped in try/catch so a leaderboard failure
-      // doesn't break the correspondents endpoint (preserves old .catch(() => []) behavior)
+      // Leaderboard — read the materialised cache stale-or-empty rather than
+      // recomputing. The correspondents route only needs the leaderboard for
+      // score/earnings/unpaid maps, yet getLeaderboardCached() would run a live
+      // queryLeaderboard() (a ~3x scan of the full signals table) whenever the
+      // 60s cache is cold — which it almost always is on a correspondents rebuild
+      // (~25 min cadence, and the cache is invalidated on every write). Reading
+      // cache-or-empty removes that scan from the cold-rebuild path; the high-
+      // traffic /init and /leaderboard endpoints keep the cache warm, so scores
+      // are present-but-slightly-stale in the common case and briefly absent only
+      // right after a write with no intervening recompute. Still wrapped in
+      // try/catch so a cache blip can never break the correspondents endpoint.
       let leaderboard: Array<Record<string, unknown>> = [];
       try {
-        leaderboard = this.getLeaderboardCached(200);
+        leaderboard = this.getLeaderboardStaleOrEmpty(200);
       } catch (e) {
-        console.error("Leaderboard query failed in correspondents bundle:", e);
+        console.error("Leaderboard cache read failed in correspondents bundle:", e);
       }
 
       return c.json({
@@ -6543,6 +6552,37 @@ export class NewsDO extends DurableObject<Env> {
       console.error("[leaderboard cache] write failed:", e);
     }
     return fresh.slice(0, limit);
+  }
+
+  /**
+   * Read the materialised leaderboard without ever recomputing it.
+   *
+   * Returns the cached top-N regardless of age (stale is acceptable), or an
+   * empty array if the cache row is absent (e.g. just invalidated by a write and
+   * not yet recomputed by an /init or /leaderboard read). Used by the
+   * correspondents bundle, whose cold rebuild must not inherit queryLeaderboard's
+   * full-table scan — see the call site in /correspondents-bundle. Callers that
+   * need a guaranteed-fresh result use getLeaderboardCached()/queryLeaderboard().
+   *
+   * Best-effort: any read/parse failure returns [] so it can never break the
+   * caller. When the result is empty the correspondents route simply renders
+   * without scores rather than blocking on a recompute.
+   */
+  private getLeaderboardStaleOrEmpty(limit: number): Array<Record<string, unknown>> {
+    try {
+      const rows = this.ctx.storage.sql
+        .exec("SELECT entries FROM leaderboard_cache WHERE id = 1")
+        .toArray();
+      if (rows.length > 0) {
+        const entries = JSON.parse(
+          (rows[0] as { entries: string }).entries
+        ) as Array<Record<string, unknown>>;
+        return entries.slice(0, limit);
+      }
+    } catch (e) {
+      console.error("[leaderboard cache] stale read failed:", e);
+    }
+    return [];
   }
 
   /**

--- a/src/routes/correspondents.ts
+++ b/src/routes/correspondents.ts
@@ -88,12 +88,16 @@ async function buildCorrespondentsResponse(c: AppContext): Promise<Response> {
     };
   });
 
-  // Sort by score descending, then streak, then address to mirror
-  // leaderboard tie-breaking when signal_count order diverges after a reset.
+  // Sort by score descending, then streak, then signal count, then address to
+  // mirror leaderboard tie-breaking when signal_count order diverges after a
+  // reset. The signalCount tiebreak also keeps the ranking activity-ordered in
+  // the degraded case where the leaderboard cache was momentarily empty and every
+  // score is 0 (see getLeaderboardStaleOrEmpty in the DO).
   correspondents.sort(
     (a, b) =>
       b.score - a.score ||
       b.streak - a.streak ||
+      b.signalCount - a.signalCount ||
       a.address.localeCompare(b.address),
   );
 

--- a/src/services/agent-resolver.ts
+++ b/src/services/agent-resolver.ts
@@ -10,7 +10,14 @@
  */
 
 const CACHE_TTL_SECONDS = 86400; // 24 hours
-const NEGATIVE_CACHE_TTL_SECONDS = 300; // 5 minutes for unresolved names
+// Negative cache (address resolved to "no name") TTL. Held for 30 minutes so an
+// unregistered correspondent does not re-trigger a full `fetchBulkAgents()`
+// registry pull on every cache rebuild — the correspondents/init SWR windows
+// rebuild on a ~25 min cadence, so a 5 min TTL expired between every rebuild and
+// made the bulk fetch a fixed cost of each cold rebuild. A newly-registered
+// agent's name now surfaces up to 30 min later, which is cosmetic; the positive
+// cache stays at 24h.
+const NEGATIVE_CACHE_TTL_SECONDS = 1800; // 30 minutes for unresolved names
 const CACHE_KEY_PREFIX = "agent-name:";
 const AGENT_API_BASE = "https://aibtc.com/api/agents";
 const BULK_PAGE_SIZE = 100; // max allowed by aibtc.com


### PR DESCRIPTION
Follow-up to the residual note on #690. After #706 (edge/SWR envelope) and #731 (materialised `correspondent_stats`) resolved the sustained `/api/correspondents` SWR-rebuild timeouts, one cost remained on a **true cache MISS** (edge entry evicted after 30 min of no traffic — SWR hides it on stale hits, so this is quiet-endpoint tail latency, not steady-state). A cold probe measured ~7s, under the 10s DO guard but with little margin. Traced to two contributors, both hit only on a miss:

## Fix 1 — decouple the correspondents bundle from the leaderboard recompute
`/correspondents-bundle` called `getLeaderboardCached(200)`, which recomputes `queryLeaderboard()` (a ~3× scan of the full `signals` table) whenever the 60s `leaderboard_cache` is cold. It almost always is on a correspondents rebuild — ~25 min cadence, and the cache is `DELETE`d on **every** mutating request — so the correspondents cold path inherited the leaderboard's heaviest scan.

- New `getLeaderboardStaleOrEmpty()` reads the materialised cache regardless of age, returns `[]` if absent, and **never recomputes**. The bundle uses it instead.
- The high-traffic `/init` and `/leaderboard` reads keep the cache warm, so scores are present-but-slightly-stale in the common case and briefly absent only right after a write with no intervening recompute.
- The route degrades to zero scores rather than blocking; a `signalCount` tiebreaker keeps that degraded ordering activity-ranked.

## Fix 2 — widen the agent-name negative-cache TTL
The negative cache was 5 min, far below the ~25 min rebuild cadence, so every unregistered correspondent expired between rebuilds and re-triggered a full `fetchBulkAgents()` registry pull against aibtc.com on each cold rebuild.

- `NEGATIVE_CACHE_TTL_SECONDS` 300 → 1800. Trade-off: a newly-registered name surfaces up to 30 min later (cosmetic; positive cache stays 24h).

## Tests / validation
- New regression test in `correspondent-stats.test.ts`: the bundle serves zero scores when `leaderboard_cache` is empty, then agrees with the cache once a `/leaderboard` read repopulates it.
- `npm run typecheck` ✅
- Full suite: **445 passed / 44 files** ✅
- Biome: no new warnings.

## Caveat
The win is **inferred from code analysis, not yet measured end-to-end**. #706's cache-key canonicalization means an edge MISS can't be forced from outside on demand, so there's no before/after production timing here — the latency delta will only be observable post-deploy. Suggested post-deploy check: watch for absence of `SWR rebuild failed` WARNs for `/api/correspondents` and confirm cold-MISS timing on a quiet window.

Relates to #690.
