### PR TITLE
fix(brief): distinguish DO read failure from "no brief exists"

### DIFF
--- a/src/__tests__/brief-do-failure.test.ts
+++ b/src/__tests__/brief-do-failure.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { getLatestBrief, getBriefByDate } from "../lib/do-client";
+import type { Env } from "../lib/types";
+
+/**
+ * A DO read failure and "no brief exists" are different answers. Before this
+ * suite's fix, both collapsed to `null`, so `/api/brief` reported an
+ * unreachable DO as an authoritative `{compiledAt: null}` with HTTP 200 —
+ * telling callers today's brief was never compiled while it sat in storage.
+ *
+ * These build a fake NEWS_DO whose stub returns a chosen response, which is
+ * enough to drive every branch: `getStub` only needs `idFromName` + `get`.
+ */
+function envReturning(response: () => Promise<Response>): Env {
+  const stub = { fetch: response } as unknown as DurableObjectStub;
+  return {
+    NEWS_DO: {
+      idFromName: () => "fake-id",
+      get: () => stub,
+    },
+  } as unknown as Env;
+}
+
+const json = (body: unknown, status: number) => async () =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+
+const BRIEF = { date: "2026-07-15", text: "brief body", compiled_at: "2026-07-15T15:00:00Z" };
+
+describe("getLatestBrief — null means absent, never unreachable", () => {
+  it("returns the brief when the DO answers", async () => {
+    const env = envReturning(json({ ok: true, data: BRIEF }, 200));
+    await expect(getLatestBrief(env)).resolves.toMatchObject({ date: "2026-07-15" });
+  });
+
+  it("returns null when the DO reports 404 — its genuine 'no brief' signal", async () => {
+    const env = envReturning(json({ ok: false, error: "No briefs compiled yet" }, 404));
+    await expect(getLatestBrief(env)).resolves.toBeNull();
+  });
+
+  it("throws on a 503 instead of reporting the brief as absent", async () => {
+    const env = envReturning(json({ ok: false, error: "overloaded" }, 503));
+    await expect(getLatestBrief(env)).rejects.toThrow(/overloaded/);
+  });
+
+  it("throws when the DO fetch rejects — the DO_TIMEOUT path", async () => {
+    const env = envReturning(() => Promise.reject(new Error("DO_TIMEOUT")));
+    await expect(getLatestBrief(env)).rejects.toThrow(/timed out/i);
+  });
+
+  it("throws on a non-JSON 502 from CF infrastructure", async () => {
+    const env = envReturning(async () => new Response("<html>bad gateway</html>", { status: 502 }));
+    await expect(getLatestBrief(env)).rejects.toThrow(/502/);
+  });
+});
+
+describe("getBriefByDate — same contract", () => {
+  it("returns the brief when the DO answers", async () => {
+    const env = envReturning(json({ ok: true, data: BRIEF }, 200));
+    await expect(getBriefByDate(env, "2026-07-15")).resolves.toMatchObject({ date: "2026-07-15" });
+  });
+
+  it("returns null when the DO reports 404", async () => {
+    const env = envReturning(json({ ok: false, error: "No brief found for 2026-07-15" }, 404));
+    await expect(getBriefByDate(env, "2026-07-15")).resolves.toBeNull();
+  });
+
+  it("throws on a 503 — a timeout must not surface as a 404 to the inscribe path", async () => {
+    const env = envReturning(json({ ok: false, error: "overloaded" }, 503));
+    await expect(getBriefByDate(env, "2026-07-15")).rejects.toThrow(/overloaded/);
+  });
+
+  it("throws when the DO fetch rejects", async () => {
+    const env = envReturning(() => Promise.reject(new Error("DO_TIMEOUT")));
+    await expect(getBriefByDate(env, "2026-07-15")).rejects.toThrow(/timed out/i);
+  });
+});

--- a/src/lib/do-client.ts
+++ b/src/lib/do-client.ts
@@ -496,16 +496,32 @@ export async function listBriefDates(env: Env): Promise<string[]> {
   return result.data;
 }
 
+/**
+ * Fetch the most recent compiled brief.
+ *
+ * Returns null ONLY when the DO reports 404 — its genuine "no brief exists"
+ * signal. Any other failure (notably the 503 doFetch raises on DO_TIMEOUT)
+ * throws, because returning null there is indistinguishable from "not compiled
+ * yet" and callers render that as an authoritative absence: `/api/brief` would
+ * answer `{compiledAt: null}` with HTTP 200 while the brief sat in storage.
+ * Callers that prefer absence over an error opt in explicitly — see
+ * `home-page.ts` (allSettled) and `signal-provenance.ts` (.catch).
+ */
 export async function getLatestBrief(env: Env): Promise<Brief | null> {
   const stub = getStub(env);
   const result = await doFetch<Brief>(stub, "/briefs/latest");
-  return result.ok ? (result.data ?? null) : null;
+  if (result.ok) return result.data ?? null;
+  if (result.status === 404) return null;
+  throw new Error(result.error ?? "Failed to fetch latest brief");
 }
 
+/** Fetch a brief by date. Same null-vs-throw contract as `getLatestBrief`. */
 export async function getBriefByDate(env: Env, date: string): Promise<Brief | null> {
   const stub = getStub(env);
   const result = await doFetch<Brief>(stub, `/briefs/${encodeURIComponent(date)}`);
-  return result.ok ? (result.data ?? null) : null;
+  if (result.ok) return result.data ?? null;
+  if (result.status === 404) return null;
+  throw new Error(result.error ?? `Failed to fetch brief for ${date}`);
 }
 
 export async function compileBriefData(

--- a/src/routes/brief.ts
+++ b/src/routes/brief.ts
@@ -15,10 +15,29 @@ const briefRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>();
 briefRouter.get("/api/brief", async (c) => {
   const format = c.req.query("format") ?? "json";
   const today = getUTCDate();
-  const [brief, archive] = await Promise.all([
-    getLatestBrief(c.env),
-    listBriefDates(c.env),
-  ]);
+
+  // A DO read failure must not fall through to the `compiledAt: null` branch
+  // below — that branch means "no brief compiled yet", and answering it on a
+  // timeout reports an unreachable DO as an authoritative absence (#699 notes
+  // 30s-28min saturation bursts, so this is a live window, not a theoretical
+  // one). Fail loudly and retryably instead.
+  let brief: Awaited<ReturnType<typeof getLatestBrief>>;
+  let archive: string[];
+  try {
+    [brief, archive] = await Promise.all([
+      getLatestBrief(c.env),
+      listBriefDates(c.env),
+    ]);
+  } catch (err) {
+    c.header("Retry-After", "30");
+    return c.json(
+      {
+        error: "Brief storage is temporarily unreachable — retry shortly.",
+        detail: err instanceof Error ? err.message : String(err),
+      },
+      503
+    );
+  }
 
   // Only use the brief if it was compiled today — if it's from a previous day, treat it as
   // absent so the frontend shows today's date and falls through to renderSignalFeed().
@@ -86,7 +105,22 @@ briefRouter.get("/api/brief/:date", async (c) => {
     );
   }
 
-  const brief = await getBriefByDate(c.env, date);
+  // Distinguish "this brief does not exist" (404, below) from "we could not
+  // read storage" (503) — collapsing both into 404 tells the caller a brief is
+  // absent when it may be sitting in the DO.
+  let brief: Awaited<ReturnType<typeof getBriefByDate>>;
+  try {
+    brief = await getBriefByDate(c.env, date);
+  } catch (err) {
+    c.header("Retry-After", "30");
+    return c.json(
+      {
+        error: "Brief storage is temporarily unreachable — retry shortly.",
+        detail: err instanceof Error ? err.message : String(err),
+      },
+      503
+    );
+  }
 
   if (!brief) {
     return c.json({ error: `No brief found for ${date}` }, 404);


### PR DESCRIPTION
## What & why

`getLatestBrief` and `getBriefByDate` collapsed every DO failure into `null`:

```ts
return result.ok ? (result.data ?? null) : null;
```

`null` already means **"no brief exists"**, so a DO timeout — which `doFetch` surfaces as a synthesized 503 — was reported as an authoritative absence. Three distinct states produced one indistinguishable answer:

| Actual state | Old answer |
|---|---|
| No brief compiled yet | `{compiledAt: null}` + 200 |
| DO timed out | `{compiledAt: null}` + **200** |
| DO returned 500 | `{compiledAt: null}` + **200** |

`GET /api/brief/:date` had the same collapse, answering `404 "No brief found for {date}"` about a brief sitting in storage. That 404 also feeds the inscribe path (`brief-inscribe.ts:93`, `:197`, `:225`), so during a DO blip the publisher is told a brief does not exist and could skip inscribing it.

This isn't theoretical: #699 puts DO saturation at **30s–28min bursts**.

Found while auditing why `/api/brief` reported `compiledAt: null` on a day the brief genuinely hadn't compiled yet — the answer was correct, but nothing in the code could have told us if it hadn't been.

## The fix

The DO already distinguishes these cases — it returns **404** with `"No briefs compiled yet"` / `"No brief found for {date}"` when a brief is genuinely absent (`news-do.ts:3332`, `:3347`). Only that maps to `null`; anything else throws:

```ts
if (result.ok) return result.data ?? null;
if (result.status === 404) return null;
throw new Error(result.error ?? "Failed to fetch latest brief");
```

This matches `listBriefDates` and `listBeats` in the same file, which already throw on `!ok` — the two brief getters were the outliers.

Both brief routes catch and return **503 + `Retry-After: 30`**, following the precedent #866 set for DO timeouts, rather than a bare 500 from the global handler.

## Blast radius

Callers that prefer absence over an error already opt in explicitly, so they are unchanged:

- `home-page.ts:61` — `Promise.allSettled` → still degrades to `brief: null`
- `signal-provenance.ts:43` — `.catch(() => null)` → unchanged

Changed, and more honest in each case:

- `brief.ts` — both routes → 503 instead of a false "no brief"
- `brief-inscribe.ts` ×3 — throws → 500 via the global handler instead of a false 404

**The happy path is untouched.** Signal filing never reads these functions. The existing 445 tests pass unmodified.

## Tests

`src/__tests__/brief-do-failure.test.ts` (9 tests) injects a fake `NEWS_DO` whose stub returns a chosen response — `getStub` only needs `idFromName` + `get`, so no module mocking is required and the real function is exercised.

Covers, for both getters: DO answers → brief returned; DO 404 → `null`; DO 503 → throws; DO fetch rejects (the `DO_TIMEOUT` path) → throws; non-JSON 502 from CF infrastructure → throws.

Verified these fail for the right reason by reverting the fix and re-running:

```
× throws on a 503 instead of reporting the brief as absent
× throws when the DO fetch rejects — the DO_TIMEOUT path
× throws on a non-JSON 502 from CF infrastructure
× throws on a 503 — a timeout must not surface as a 404 to the inscribe path
× throws when the DO fetch rejects

AssertionError: promise resolved "null" instead of rejecting
```

The 4 happy-path tests pass against both old and new code, confirming the change is confined to the failure branch.

**Full suite: 45 files, 454 tests passing. Typecheck clean.**

## Not addressed

The related ambiguity in `/api/init` is out of scope — `fetchInitBundleFromDO` already throws on `!ok`, so it doesn't share this bug. Separately, a compiled brief can still take up to ~30 min to appear on the homepage because `/api/init` is edge-cached at `s-maxage=1800` with no write invalidation; that's a distinct issue and not touched here.
