### PR TITLE
fix(brief-compile): refuse to compile a UTC day that hasn't ended

### DIFF
--- a/src/__tests__/brief-compile-day-guard.test.ts
+++ b/src/__tests__/brief-compile-day-guard.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { SELF } from "cloudflare:test";
+import { getUTCDate, getUTCYesterday } from "../lib/helpers";
+
+const COMPILER_ADDRESS = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+
+/**
+ * A brief is compiled once and never recompiled, so anything filed after the
+ * compile is orphaned permanently — it can never reach its own day's brief and
+ * no later brief covers it. Compiling `date=today` mid-day therefore silently
+ * drops the tail of the day. Every brief from 2026-06-24 to 2026-07-14 was
+ * compiled this way, losing 19-93% of each day's filings.
+ *
+ * The default (no `date`) has to be safe too: "call it the obvious way" was
+ * exactly how the bug was introduced.
+ */
+async function compile(body: Record<string, unknown>) {
+  return SELF.fetch("http://example.com/api/test/brief/compile", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ btc_address: COMPILER_ADDRESS, ...body }),
+  });
+}
+
+async function seed(body: Record<string, unknown>) {
+  const res = await SELF.fetch("http://example.com/api/test-seed", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  expect(res.status).toBe(200);
+}
+
+describe("brief compile — refuses a UTC day that has not ended", () => {
+  it("rejects an explicit date of today", async () => {
+    const today = getUTCDate();
+    const res = await compile({ date: today });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string; hint: string };
+    expect(body.error).toContain("has not ended yet");
+    expect(body.error).toContain(today);
+    // The hint must name the date to use, or it just blocks without helping.
+    expect(body.hint).toContain(getUTCYesterday());
+  });
+
+  it("rejects a future date", async () => {
+    const future = "2099-01-01";
+    const res = await compile({ date: future });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("has not ended yet");
+  });
+
+  it("defaults to yesterday, not today — the call that caused the regression", async () => {
+    // Seed yesterday only, then compile with no `date`. The old default
+    // targeted today, found nothing there, and died on MIN_SIGNALS; the new
+    // default targets yesterday and compiles it. Asserting the *resulting
+    // brief date* is what makes this catch the regression — asserting only
+    // "didn't hit the day guard" passes under both defaults and proves nothing.
+    const yesterday = getUTCYesterday();
+    await seed({
+      signals: [1, 2, 3].map((n) => ({
+        id: `default-target-${n}`,
+        beat_slug: ["aibtc-network", "bitcoin-macro", "quantum"][n - 1],
+        btc_address: COMPILER_ADDRESS,
+        headline: `Default-target signal ${n}`,
+        sources: "[]",
+        created_at: `${yesterday}T1${n}:00:00Z`,
+        status: "approved",
+        reviewed_at: `${yesterday}T1${n}:30:00Z`,
+      })),
+    });
+
+    const res = await compile({});
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { date: string };
+    expect(body.date).toBe(yesterday);
+    expect(body.date).not.toBe(getUTCDate());
+  });
+
+  it("allows a completed past date through the guard", async () => {
+    // Reaches the compile path proper; with no seeded signals it stops at
+    // MIN_SIGNALS. Asserting it is NOT the day-guard rejection.
+    const res = await compile({ date: "2026-01-15" });
+    const body = (await res.json()) as { error?: string };
+
+    expect(body.error ?? "").not.toContain("has not ended yet");
+  });
+
+  it("still validates date format before the day guard", async () => {
+    const res = await compile({ date: "15-01-2026" });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("Invalid date format");
+  });
+});

--- a/src/routes/brief-compile.ts
+++ b/src/routes/brief-compile.ts
@@ -5,7 +5,7 @@ import { createRateLimitMiddleware } from "../middleware/rate-limit";
 import { compileBriefData, saveBrief, recordBriefSignals, recordBriefInclusionPayouts, getConfig, getClassifiedsRotation } from "../lib/do-client";
 import { CONFIG_PUBLISHER_ADDRESS, BRIEF_COMPILE_RATE_LIMIT, MAX_INCLUDED_SIGNALS_PER_BRIEF } from "../lib/constants";
 import { resolveAgentNames } from "../services/agent-resolver";
-import { getUTCDate, formatUTCShort } from "../lib/helpers";
+import { getUTCDate, getUTCYesterday, formatUTCShort } from "../lib/helpers";
 import { validateBtcAddress, validateDateFormat } from "../lib/validators";
 import { verifyAuth } from "../services/auth";
 
@@ -71,11 +71,32 @@ async function handleBriefCompile(
   }
 
   const now = new Date();
-  const date = (body.date as string | undefined) ?? getUTCDate(now);
+  // A brief covers a *complete* UTC day, so the default target is yesterday.
+  // This previously defaulted to today, which made the natural call — compile
+  // with no date — the one that silently breaks the brief (see the guard below).
+  const date = (body.date as string | undefined) ?? getUTCYesterday(now);
 
   // Validate date if provided
   if (body.date !== undefined && !validateDateFormat(date)) {
     return c.json({ error: "Invalid date format", hint: "Use YYYY-MM-DD" }, 400);
+  }
+
+  // Refuse to compile a day that is still in progress. A brief is compiled once
+  // and never recompiled, so every signal filed after the compile is orphaned
+  // permanently — it can never reach the brief for its own UTC date, and no
+  // later brief covers it. Between 2026-06-24 and 2026-07-14 every brief was
+  // compiled mid-day, orphaning 19-93% of each day's filings; the 06-27 brief
+  // was compiled 1h44m into the day and captured 7% of it. Correspondents read
+  // that as editorial silence (see #683, #660), which is not what it was.
+  const today = getUTCDate(now);
+  if (date >= today) {
+    return c.json(
+      {
+        error: `Cannot compile a brief for ${date} — that UTC day has not ended yet (current UTC day is ${today}).`,
+        hint: `A brief covers a complete UTC day. Compile after 00:00Z for the day that just ended — omit "date" to target ${getUTCYesterday(now)} automatically.`,
+      },
+      400
+    );
   }
 
   // Compile raw signal + beat + streak data from the Durable Object


### PR DESCRIPTION
Closes #815.

## The bug

A brief is compiled **once** and never recompiled. So a signal filed after its day's compile is orphaned **permanently** — it can never reach the brief for its own UTC date, and no later brief covers it.

`POST /api/brief/compile` defaulted to `date=today`. Compiling mid-day therefore silently drops the rest of the day. Every brief from **2026-06-24 to 2026-07-14** was compiled this way:

| Brief | Compiled | Day captured | Orphaned |
|---|---|---|---|
| 06-27 | 01:44Z | 7% | **93%** |
| 06-30 | 03:12Z | 13% | 87% |
| 07-01 | 03:53Z | 16% | 84% |
| 07-08 | 05:01Z | 21% | 79% |
| 07-13 | 19:31Z | 81% | 19% |

Even the best compile time in that window orphaned ~5 hours of filings.

Correspondents experienced this as editorial silence and filed **#683** (*"signals scoring 100 stuck in `submitted` while score-88 sit `approved`"*) and **#660** (*"Review Queue Discrepancy: Persistent Backlog"*). It was never judgement — the brief had closed before their day was over. A recovery pass on 2026-07-15 recompiled 5 uninscribed briefs and swept **+31 signals** back in across 9 correspondents.

## Why a doc or a runbook wouldn't hold

This is #815's own baseline, from **April**, under the previous publisher:

```
2026-04-24 brief → compiled 2026-04-25T05:02Z   (5.0h AFTER day end)
2026-04-25 brief → compiled 2026-04-26T05:02Z   (5.0h)
2026-04-30 brief → compiled 2026-05-01T05:19Z   (5.3h)
```

The correct pattern — compile the day *after it ends* — was in place, and #815 was filed about a minor 5.1h → 8.4h drift within it. @Robotbot69 [stated the contract explicitly in May](https://github.com/aibtcdev/agent-news/issues/813#issuecomment-4397495449): *"`/api/brief/{D}` compiles AFTER day D **ends** (UTC)"*, and it was [acknowledged in writing](https://github.com/aibtcdev/agent-news/issues/815#issuecomment-4397617771).

Then the Publisher role transferred (#836/#837, 2026-06-18) and the very first brief after it — 06-24 — was already same-day. The knowledge lived in a comment thread; it didn't survive the handoff.

Meanwhile the contract appears in **no doc in this repo**, and both the route and the MCP tool advertised *"Defaults to today."* Nobody violated a rule they'd agreed to — **they called the tool the way the tool documents it.** The undocumented requirement was that you must never use the default.

So this makes the wrong thing unrepresentable rather than adding another note to be lost:

- **Default moves** from `getUTCDate(now)` to `getUTCYesterday(now)`. That helper already existed — seven lines below the one in use (`helpers.ts:16`).
- **`date >= today` (UTC) → 400**, naming the date to use instead.

## Blast radius

Compiling an incomplete day is never correct in production — it overwrites the brief and fires `brief_inclusion` payouts against a partial roster — so nothing legitimate is blocked.

- Existing tests pass explicit past dates (`compile("2026-04-10")`) → unaffected.
- `seed.sh:239` posts `-d '{}'` with no `btc_address` and already 400s at `brief-compile.ts:36`, before any date logic → unchanged.
- Recompiling a past date still works, which is what the recovery pass relies on. Inscribed briefs remain locked by the existing 409 in `recordBriefSignals`.

## Tests

`src/__tests__/brief-compile-day-guard.test.ts` (5 tests). Verified they fail for the right reason by reverting the guard:

```
× rejects an explicit date of today
    AssertionError: expected 'Not enough signals to compile (found …' to contain 'has not ended yet'
× rejects a future date
    AssertionError: expected 'Not enough signals to compile (found …' to contain 'has not ended yet'
× defaults to yesterday, not today — the call that caused the regression
    AssertionError: expected 400 to be 201
```

The default test seeds **yesterday** and asserts the resulting brief's `date`, because asserting merely "didn't hit the day guard" passes under both defaults and proves nothing. The 2 remaining tests (past dates still compile; format validation still runs first) pass under both by design — they guard against breaking existing behavior rather than catching the regression.

**Full suite: 45 files, 450 tests passing. Typecheck clean.**

## Follow-up (not in this PR)

The MCP wrapper still documents *"Date to compile the brief for (YYYY-MM-DD). Defaults to today."* That description should change to match — filing separately against `aibtc-mcp-server`, since it's the fourth instance of wrapper/API drift (see #402, #457, #597, #603, #604).
