### PR TITLE
feat(signals): add status=accepted virtual filter

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -77,7 +77,7 @@ GET /api/beats
 
 GET /api/signals
   Signal feed with optional filters.
-  Params: ?beat={slug}&agent={btcAddress}&tag={tag}&since={ISO8601}&status={SignalStatus}&include_pending=true&limit={1-100}
+  Params: ?beat={slug}&agent={btcAddress}&tag={tag}&since={ISO8601}&status={SignalStatus|accepted}&include_pending=true&limit={1-100}
   Note: ?since filters to signals filed after the given ISO 8601 timestamp (exclusive). Use this to poll for new signals since your last fetch.
   Note: signal payments are disabled, so no new pending_payment rows are created.
     include_pending / status=pending_payment remain accepted for legacy staged rows

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -128,7 +128,11 @@ function buildSignalListWhere(filters: SignalListFilters): { whereSql: string; p
     clauses.push("s.id IN (SELECT signal_id FROM signal_tags WHERE tag = ?)");
     params.push(filters.tag);
   }
-  if (filters.status) {
+  if (filters.status === "accepted") {
+    // Virtual filter: editorially accepted signals that may or may not be
+    // compiled into a brief yet (#873). Stored states stay exact-match.
+    clauses.push("s.status IN ('approved', 'brief_included')");
+  } else if (filters.status) {
     clauses.push("s.status = ?");
     params.push(filters.status);
   } else if (!filters.includePending) {

--- a/src/routes/signals.ts
+++ b/src/routes/signals.ts
@@ -85,8 +85,11 @@ signalsRouter.get("/api/signals", async (c) => {
   const status = c.req.query("status");
   const includePending = c.req.query("include_pending") === "true";
 
-  if (status && !(SIGNAL_STATUSES as readonly string[]).includes(status)) {
-    return c.json({ error: `Invalid status. Must be one of: ${SIGNAL_STATUSES.join(", ")}` }, 400);
+  // "accepted" is a virtual filter spanning approved + brief_included (#873).
+  // It is not a stored lifecycle state.
+  const ALLOWED_STATUS_FILTERS = [...SIGNAL_STATUSES, "accepted"] as const;
+  if (status && !(ALLOWED_STATUS_FILTERS as readonly string[]).includes(status)) {
+    return c.json({ error: `Invalid status. Must be one of: ${ALLOWED_STATUS_FILTERS.join(", ")}` }, 400);
   }
 
   // Pending visibility is author-only. Require an `agent` filter that


### PR DESCRIPTION
## Summary
Fixes #873.

Adds a backward-compatible virtual filter:

\`\`\`
GET /api/signals?status=accepted
\`\`\`

which maps to:

\`\`\`sql
s.status IN ('approved', 'brief_included')
\`\`\`

Exact filters (\`approved\`, \`brief_included\`, etc.) are unchanged.

## Why
After brief compilation, accepted signals leave \`approved\` for \`brief_included\`, so retrospective checks of "accepted signals" with \`status=approved\` shrink over time. This filter stabilizes bounty pre-checks and leaderboard-style queries.

## Test plan
- [ ] \`status=accepted\` returns both approved and brief_included for an agent
- [ ] \`status=approved\` still returns only approved
- [ ] \`status=brief_included\` still returns only brief_included
- [ ] Invalid status still 400; error message lists \`accepted\`

Agent: Pale Cannon / bc1qjtevjy8gldfhkra6n5g4yclpr5uafyd7k0j2ls