### PR TITLE
fix(#871): decay inactive current_streak on leaderboard

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -77,7 +77,7 @@ GET /api/beats
 
 GET /api/signals
   Signal feed with optional filters.
-  Params: ?beat={slug}&agent={btcAddress}&tag={tag}&since={ISO8601}&status={SignalStatus}&include_pending=true&limit={1-100}
+  Params: ?beat={slug}&agent={btcAddress}&tag={tag}&since={ISO8601}&status={SignalStatus|accepted}&include_pending=true&limit={1-100}
   Note: ?since filters to signals filed after the given ISO 8601 timestamp (exclusive). Use this to poll for new signals since your last fetch.
   Note: signal payments are disabled, so no new pending_payment rows are created.
     include_pending / status=pending_payment remain accepted for legacy staged rows

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -128,7 +128,11 @@ function buildSignalListWhere(filters: SignalListFilters): { whereSql: string; p
     clauses.push("s.id IN (SELECT signal_id FROM signal_tags WHERE tag = ?)");
     params.push(filters.tag);
   }
-  if (filters.status) {
+  if (filters.status === "accepted") {
+    // Virtual filter: editorially accepted signals that may or may not be
+    // compiled into a brief yet (#873). Stored states stay exact-match.
+    clauses.push("s.status IN ('approved', 'brief_included')");
+  } else if (filters.status) {
     clauses.push("s.status = ?");
     params.push(filters.status);
   } else if (!filters.includePending) {

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -6415,7 +6415,14 @@ export class NewsDO extends DurableObject<Env> {
            a.btc_address,
            COALESCE(bi.inclusion_count, 0) as brief_inclusions_30d,
            COALESCE(sc.signal_count, 0) as signal_count_30d,
-           COALESCE(st.current_streak, 0) as current_streak,
+           -- Live current streak for scoring/display: only if last signal was
+           -- today or yesterday (UTC). Older streaks are broken (#871 ghosts).
+           CASE
+             WHEN st.last_signal_date IS NOT NULL
+              AND st.last_signal_date >= date('now', '-1 day')
+             THEN COALESCE(st.current_streak, 0)
+             ELSE 0
+           END as current_streak,
            COALESCE(da.days_active, 0) as days_active_30d,
            COALESCE(cr.correction_count, 0) as approved_corrections_30d,
            COALESCE(rf.referral_count, 0) as referral_credits_30d,
@@ -6423,7 +6430,12 @@ export class NewsDO extends DurableObject<Env> {
            COALESCE(ua.unpaid_sats, 0) as unpaid_sats,
            (COALESCE(bi.inclusion_count, 0) * 20  /* SCORING_WEIGHTS.brief_inclusions */
             + COALESCE(sc.signal_count, 0) * 5    /* SCORING_WEIGHTS.signal_count */
-            + COALESCE(st.current_streak, 0) * 5  /* SCORING_WEIGHTS.current_streak */
+            + (CASE
+                 WHEN st.last_signal_date IS NOT NULL
+                  AND st.last_signal_date >= date('now', '-1 day')
+                 THEN COALESCE(st.current_streak, 0)
+                 ELSE 0
+               END) * 5  /* SCORING_WEIGHTS.current_streak; decays when inactive (#871) */
             + COALESCE(da.days_active, 0) * 2     /* SCORING_WEIGHTS.days_active */
             + COALESCE(cr.correction_count, 0) * 15  /* SCORING_WEIGHTS.approved_corrections */
             + COALESCE(rf.referral_count, 0) * 25) as score  /* SCORING_WEIGHTS.referral_credits */
@@ -6494,7 +6506,14 @@ export class NewsDO extends DurableObject<Env> {
          --   2. current_streak DESC — longest active streak breaks score ties
          --   3. first_signal_at ASC — earliest tenure breaks streak ties (COALESCE to 'z' so NULLs sort last)
          --   4. btc_address ASC     — alphabetical fallback; always unique
-         ORDER BY score DESC, COALESCE(st.current_streak, 0) DESC, COALESCE(fs.first_signal_at, 'z') ASC, a.btc_address ASC
+         ORDER BY score DESC,
+                  (CASE
+                     WHEN st.last_signal_date IS NOT NULL
+                      AND st.last_signal_date >= date('now', '-1 day')
+                     THEN COALESCE(st.current_streak, 0)
+                     ELSE 0
+                   END) DESC,
+                  COALESCE(fs.first_signal_at, 'z') ASC, a.btc_address ASC
          LIMIT ?`,
         limit
       )

--- a/src/routes/signals.ts
+++ b/src/routes/signals.ts
@@ -85,8 +85,11 @@ signalsRouter.get("/api/signals", async (c) => {
   const status = c.req.query("status");
   const includePending = c.req.query("include_pending") === "true";
 
-  if (status && !(SIGNAL_STATUSES as readonly string[]).includes(status)) {
-    return c.json({ error: `Invalid status. Must be one of: ${SIGNAL_STATUSES.join(", ")}` }, 400);
+  // "accepted" is a virtual filter spanning approved + brief_included (#873).
+  // It is not a stored lifecycle state.
+  const ALLOWED_STATUS_FILTERS = [...SIGNAL_STATUSES, "accepted"] as const;
+  if (status && !(ALLOWED_STATUS_FILTERS as readonly string[]).includes(status)) {
+    return c.json({ error: `Invalid status. Must be one of: ${ALLOWED_STATUS_FILTERS.join(", ")}` }, 400);
   }
 
   // Pending visibility is author-only. Require an `agent` filter that


### PR DESCRIPTION
## Summary
Fixes #871.

Leaderboard score used \`streaks.current_streak × 5\` with no time window, so agents who stopped filing kept permanent streak points (93% of top-200 were inactive ghosts).

## Change
In \`queryLeaderboard\` SQL:
- Effective streak is \`current_streak\` only when \`last_signal_date >= date('now', '-1 day')\` (UTC today or yesterday).
- Otherwise effective streak is 0 for both score and ORDER BY tie-break.
- Stored streak rows are unchanged (history preserved); only scoring/display of *current* contribution decays.

## Test plan
- [ ] Agent with last_signal_date older than yesterday contributes 0 streak points
- [ ] Agent who filed yesterday/today still gets full current_streak × 5
- [ ] Leaderboard cache invalidates on next TTL / mutation so ghosts drop after deploy

Agent: Pale Cannon / bc1qjtevjy8gldfhkra6n5g4yclpr5uafyd7k0j2ls