### PR TITLE
feat(signals): status=accepted virtual filter (#873)

### DIFF
--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -129,8 +129,13 @@ function buildSignalListWhere(filters: SignalListFilters): { whereSql: string; p
     params.push(filters.tag);
   }
   if (filters.status) {
-    clauses.push("s.status = ?");
-    params.push(filters.status);
+    // Virtual filter status=accepted → editorially accepted lifecycle states (#873)
+    if (filters.status === "accepted") {
+      clauses.push("s.status IN ('approved', 'brief_included')");
+    } else {
+      clauses.push("s.status = ?");
+      params.push(filters.status);
+    }
   } else if (!filters.includePending) {
     // Default listings hide x402-staged-but-unconfirmed rows. Use an explicit
     // IN list (the non-pending statuses) so SQLite can hit

--- a/src/routes/signals.ts
+++ b/src/routes/signals.ts
@@ -85,8 +85,10 @@ signalsRouter.get("/api/signals", async (c) => {
   const status = c.req.query("status");
   const includePending = c.req.query("include_pending") === "true";
 
-  if (status && !(SIGNAL_STATUSES as readonly string[]).includes(status)) {
-    return c.json({ error: `Invalid status. Must be one of: ${SIGNAL_STATUSES.join(", ")}` }, 400);
+  // status=accepted is a virtual filter (approved + brief_included), not a lifecycle state (#873)
+  const allowedStatuses = [...SIGNAL_STATUSES, "accepted"] as readonly string[];
+  if (status && !allowedStatuses.includes(status)) {
+    return c.json({ error: `Invalid status. Must be one of: ${allowedStatuses.join(", ")}` }, 400);
   }
 
   // Pending visibility is author-only. Require an `agent` filter that


### PR DESCRIPTION
## Summary
Adds virtual filter `status=accepted` for #873 so callers can query all editorially accepted signals after brief compilation moves items from `approved` → `brief_included`.

## Behavior
| Query | Result |
|-------|--------|
| `status=approved` | unchanged (exact) |
| `status=brief_included` | unchanged (exact) |
| `status=accepted` | `status IN ('approved','brief_included')` |

## Test plan
- [ ] `GET /api/signals?status=accepted` returns both approved and brief_included
- [ ] Exact status filters unchanged

Closes #873