### PR TITLE
fix(scorer): stop capping single-word beat slugs at 10/20 on beatRelevance

### DIFF
--- a/src/__tests__/signal-scorer.test.ts
+++ b/src/__tests__/signal-scorer.test.ts
@@ -128,6 +128,40 @@ describe("scoreSignal — beatRelevance dimension", () => {
     });
     expect(result.breakdown.beatRelevance).toBe(0);
   });
+
+  it("awards full pts for a single-word beat slug whose only keyword matches", () => {
+    const result = scoreSignal({
+      ...MINIMAL_SIGNAL,
+      tags: ["quantum"],
+      beat_slug: "quantum",
+    });
+    expect(result.breakdown.beatRelevance).toBe(20);
+  });
+
+  it("still returns 0 pts for a single-word beat slug with no matching tag", () => {
+    const result = scoreSignal({
+      ...MINIMAL_SIGNAL,
+      tags: ["ordinals"],
+      beat_slug: "quantum",
+    });
+    expect(result.breakdown.beatRelevance).toBe(0);
+  });
+
+  it("lets a single-word beat reach the same composite ceiling as a multi-word beat", () => {
+    const oneWord = scoreSignal({ ...MINIMAL_SIGNAL, tags: ["quantum"], beat_slug: "quantum" });
+    const twoWord = scoreSignal({
+      ...MINIMAL_SIGNAL,
+      tags: ["agent", "economy"],
+      beat_slug: "agent-economy",
+    });
+    expect(oneWord.breakdown.beatRelevance).toBe(twoWord.breakdown.beatRelevance);
+    expect(oneWord.total).toBe(twoWord.total);
+  });
+
+  it("returns 0 pts when the slug yields no scorable keywords", () => {
+    const result = scoreSignal({ ...MINIMAL_SIGNAL, tags: ["ai"], beat_slug: "ai" });
+    expect(result.breakdown.beatRelevance).toBe(0);
+  });
 });
 
 describe("scoreSignal — timeliness dimension", () => {

--- a/src/lib/signal-scorer.ts
+++ b/src/lib/signal-scorer.ts
@@ -113,7 +113,14 @@ function scoreThesisClarity(headline: string, body?: string | null): number {
 /**
  * Score beat relevance (0–20).
  * Tags are compared against the words in the beat_slug.
- * 1+ matches = 10 pts, 2+ matches = 20 pts.
+ * All of the beat's keywords matched = 20 pts, some matched = 10 pts, none = 0.
+ *
+ * Scored as a proportion of the keywords the slug actually has rather than a
+ * flat "2+ matches" threshold: a single-word slug (e.g. `quantum`) only ever
+ * yields one keyword, so a fixed threshold of 2 capped those beats at 10/20 —
+ * a silent 10-point penalty on every signal filed to them, purely because of
+ * how the beat was named. Two-word slugs are unaffected (2 of 2 = full marks,
+ * 1 of 2 = partial), so this only lifts the beats the old rule could not score.
  */
 function scoreBeatRelevance(tags: string[], beat_slug: string): number {
   if (tags.length === 0) return 0;
@@ -136,9 +143,9 @@ function scoreBeatRelevance(tags: string[], beat_slug: string): number {
     }
   }
 
-  if (matches >= 2) return MAX_BEAT_RELEVANCE;
-  if (matches === 1) return 10;
-  return 0;
+  if (matches === 0) return 0;
+  if (matches === beatKeywords.length) return MAX_BEAT_RELEVANCE;
+  return 10;
 }
 
 /**


### PR DESCRIPTION
`quantum` signals cannot score above 90/100. `bitcoin-macro` and `aibtc-network` signals can reach 100. The difference is not quality — it is how many words are in the beat's name.

## Cause

`scoreBeatRelevance` (`src/lib/signal-scorer.ts:118`) awards full marks only at `matches >= 2`, where `matches` counts distinct beat-slug keywords hit by the signal's tags:

```js
if (matches >= 2) return MAX_BEAT_RELEVANCE;  // 20
if (matches === 1) return 10;
```

The slug is split on `[-_\s]` with sub-3-char fragments dropped, so the keyword count is bounded by the number of words in the slug. Active beats:

| beat | keywords | max beatRelevance | max composite |
|---|---|---|---|
| `aibtc-network` | 2 | 20 / 20 | 100 |
| `bitcoin-macro` | 2 | 20 / 20 | 100 |
| `quantum` | 1 | **10 / 20** | **90** |

A single-word slug can never produce 2 matches, so `quantum` is capped no matter how well-tagged the signal is.

Signals compete across beats for brief slots and leaderboard rank, so this is a standing 10-point handicap on every quantum correspondent.

## Corroboration

This independently explains the evidence table in #683, which recorded quantum's pending signals topping out at **score 90** while bitcoin-macro's sat at **100**. That was read as a score-ranking inversion; it is this cap.

## Fix

Score relevance as a proportion of the keywords the slug actually has:

```js
if (matches === 0) return 0;
if (matches === beatKeywords.length) return MAX_BEAT_RELEVANCE;
return 10;
```

- Two-word slugs unchanged: 2 of 2 = 20, 1 of 2 = 10, 0 = 0 — all four pre-existing tests pass untouched.
- Single-word slugs can now reach 20 when their keyword matches.
- A slug yielding no scorable keywords still returns 0, not a vacuous full mark.

## Scope limit

This does **not** repair existing rows. Scores are computed once at insert and persisted (`news-do.ts:3087`), so already-filed quantum signals keep their frozen 90s until scoring is recomputed on read — that is #683, deliberately not addressed here.

Related: #865 (`sourceQuality` measures `sources.length` only). Both are part of the same scorer, but each has a separate correctness argument and is worth landing separately.

## Verification

- `npm run typecheck` — clean
- `npm run lint` — exit 0
- `npm test` — **465/465** passing (5 new covering single-word slugs, the no-match case, ceiling parity with multi-word beats, and the no-scorable-keywords edge)