### PR TITLE
fix(cache): purge /api/init + brief edge cache on compile/inscribe (#870)

### DIFF
--- a/src/lib/edge-cache.ts
+++ b/src/lib/edge-cache.ts
@@ -200,6 +200,27 @@ export function edgeCacheDelete(c: AppContext, paths: string[]): void {
 }
 
 /**
+ * Evict the homepage bundle (/api/init) from the local colo's edge cache.
+ *
+ * Shared by the brief compile and inscribe success paths: both mutate brief
+ * state that /api/init embeds behind its 30-min s-maxage TTL — compile changes
+ * the brief body, inscribe changes the inscription id/txid (init.ts folds
+ * inscription state into its brief payload). Purging on write lets the writing
+ * agent's own follow-up reads go fresh within seconds instead of waiting out
+ * the TTL (#870).
+ *
+ * Only /api/init is purged. The /api/brief and /api/brief/:date read endpoints
+ * set Cache-Control but never call edgeCachePut, so they are not stored in this
+ * Workers cache — there is nothing here to evict, and listing them would imply
+ * a caching path that this codebase doesn't create. (If a Cloudflare zone Cache
+ * Rule caches them at the dashboard level, that's a separate namespace/config
+ * this Cache-API delete wouldn't reliably reach — tracked separately.)
+ */
+export function purgeHomepageBundle(c: AppContext): void {
+  edgeCacheDelete(c, ["/api/init"]);
+}
+
+/**
  * Fire a background rebuild for a stale cache entry, guarded by a short KV
  * lock so concurrent stale hits don't hammer the upstream (e.g. a cold
  * Durable Object) with duplicate rebuilds.

--- a/src/lib/edge-cache.ts
+++ b/src/lib/edge-cache.ts
@@ -166,6 +166,40 @@ export function edgeCachePut(
 }
 
 /**
+ * Purge one or more cached paths from the local colo's edge cache.
+ *
+ * Cloudflare's Cache API is colo-scoped: this evicts entries only in the data
+ * center where the current (write) request runs, not globally. That is exactly
+ * the coverage a write-side purge wants — the agent that just POSTed a compile
+ * or inscribe sits in one colo, and clearing that colo makes its own follow-up
+ * reads (and any co-located readers) see the new state within seconds instead
+ * of waiting out the s-maxage TTL. Far-colo readers still refresh on the normal
+ * TTL, which is acceptable for the glance-info the homepage bundle carries.
+ *
+ * Cost note: the delete itself is free (a colo cache op, not a DO read). The
+ * only downstream cost is that the next read in this colo is a MISS and rebuilds
+ * once — i.e. we pay one rebuild exactly when the underlying data changed, not
+ * on a timer. Cheaper than shrinking the TTL, which would rebuild on a schedule.
+ *
+ * Paths are resolved against the current request's origin and keyed by the
+ * canonical GET URL, matching how edgeCachePut() stored them. Runs via
+ * waitUntil so the write handler pays no latency for the eviction. No-op in
+ * test (a shared caches.default would cross-contaminate) and harmless for any
+ * path that was never edge-cached (delete simply resolves false).
+ */
+export function edgeCacheDelete(c: AppContext, paths: string[]): void {
+  if (isTestEnv(c)) return;
+  const origin = new URL(c.req.url).origin;
+  c.executionCtx.waitUntil(
+    Promise.all(
+      paths.map((path) =>
+        caches.default.delete(new Request(new URL(path, origin).toString(), { method: "GET" }))
+      )
+    ).then(() => undefined)
+  );
+}
+
+/**
  * Fire a background rebuild for a stale cache entry, guarded by a short KV
  * lock so concurrent stale hits don't hammer the upstream (e.g. a cold
  * Durable Object) with duplicate rebuilds.

--- a/src/routes/brief-compile.ts
+++ b/src/routes/brief-compile.ts
@@ -8,6 +8,7 @@ import { resolveAgentNames } from "../services/agent-resolver";
 import { getUTCDate, getUTCYesterday, formatUTCShort } from "../lib/helpers";
 import { validateBtcAddress, validateDateFormat } from "../lib/validators";
 import { verifyAuth } from "../services/auth";
+import { edgeCacheDelete } from "../lib/edge-cache";
 
 const briefCompileRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>();
 
@@ -345,6 +346,12 @@ async function handleBriefCompile(
       return c.json({ error: payoutResult.error ?? "Failed to reconcile brief inclusion payouts" }, 500);
     }
   }
+
+  // The compile just changed brief state that the homepage bundle (/api/init,
+  // 30-min edge TTL) and the brief read endpoints cache. Evict them so the
+  // compiling agent's own follow-up reads — and co-located homepage readers —
+  // see the new brief within seconds instead of waiting out the TTL (#870).
+  edgeCacheDelete(c, ["/api/init", "/api/brief", `/api/brief/${date}`]);
 
   return c.json(
     {

--- a/src/routes/brief-compile.ts
+++ b/src/routes/brief-compile.ts
@@ -8,7 +8,7 @@ import { resolveAgentNames } from "../services/agent-resolver";
 import { getUTCDate, getUTCYesterday, formatUTCShort } from "../lib/helpers";
 import { validateBtcAddress, validateDateFormat } from "../lib/validators";
 import { verifyAuth } from "../services/auth";
-import { edgeCacheDelete } from "../lib/edge-cache";
+import { purgeHomepageBundle } from "../lib/edge-cache";
 
 const briefCompileRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>();
 
@@ -347,11 +347,11 @@ async function handleBriefCompile(
     }
   }
 
-  // The compile just changed brief state that the homepage bundle (/api/init,
-  // 30-min edge TTL) and the brief read endpoints cache. Evict them so the
-  // compiling agent's own follow-up reads — and co-located homepage readers —
-  // see the new brief within seconds instead of waiting out the TTL (#870).
-  edgeCacheDelete(c, ["/api/init", "/api/brief", `/api/brief/${date}`]);
+  // The compile just changed brief state embedded in the homepage bundle
+  // (/api/init, 30-min edge TTL). Evict it so the compiling agent's own
+  // follow-up reads — and co-located homepage readers — see the new brief
+  // within seconds instead of waiting out the TTL (#870).
+  purgeHomepageBundle(c);
 
   return c.json(
     {

--- a/src/routes/brief-inscribe.ts
+++ b/src/routes/brief-inscribe.ts
@@ -1,13 +1,21 @@
 import { Hono } from "hono";
-import type { Env, AppVariables } from "../lib/types";
+import type { Env, AppVariables, AppContext } from "../lib/types";
 import { createRateLimitMiddleware } from "../middleware/rate-limit";
 import { BRIEF_INSCRIBE_RATE_LIMIT } from "../lib/constants";
 import { getBriefByDate, updateBrief } from "../lib/do-client";
 import { validateDateFormat } from "../lib/validators";
 import { validateBtcAddress, validateSignatureFormat } from "../lib/validators";
 import { verifyAuth } from "../services/auth";
+import { edgeCacheDelete } from "../lib/edge-cache";
 
 const briefInscribeRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>();
+
+// Brief read surfaces to evict after an inscription write so the writing agent's
+// own follow-up reads see fresh inscription state within seconds instead of
+// waiting out the edge TTL (#870, and secret-mars's /api/brief/{date} sibling).
+function purgeBriefCaches(c: AppContext, date: string): void {
+  edgeCacheDelete(c, ["/api/init", "/api/brief", `/api/brief/${date}`]);
+}
 
 const inscribeRateLimit = createRateLimitMiddleware({
   key: "brief-inscribe",
@@ -121,6 +129,7 @@ briefInscribeRouter.post(
       inscription_id: inscription_id as string,
       btc_address,
     });
+    purgeBriefCaches(c, date);
     return c.json(
       {
         ok: true,
@@ -208,6 +217,7 @@ briefInscribeRouter.patch("/api/brief/:date/inscribe", async (c) => {
     return c.json({ error: result.error ?? "Failed to update brief" }, 500);
   }
 
+  purgeBriefCaches(c, date);
   return c.json({ ok: true, date, brief: result.data });
 });
 

--- a/src/routes/brief-inscribe.ts
+++ b/src/routes/brief-inscribe.ts
@@ -1,21 +1,14 @@
 import { Hono } from "hono";
-import type { Env, AppVariables, AppContext } from "../lib/types";
+import type { Env, AppVariables } from "../lib/types";
 import { createRateLimitMiddleware } from "../middleware/rate-limit";
 import { BRIEF_INSCRIBE_RATE_LIMIT } from "../lib/constants";
 import { getBriefByDate, updateBrief } from "../lib/do-client";
 import { validateDateFormat } from "../lib/validators";
 import { validateBtcAddress, validateSignatureFormat } from "../lib/validators";
 import { verifyAuth } from "../services/auth";
-import { edgeCacheDelete } from "../lib/edge-cache";
+import { purgeHomepageBundle } from "../lib/edge-cache";
 
 const briefInscribeRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>();
-
-// Brief read surfaces to evict after an inscription write so the writing agent's
-// own follow-up reads see fresh inscription state within seconds instead of
-// waiting out the edge TTL (#870, and secret-mars's /api/brief/{date} sibling).
-function purgeBriefCaches(c: AppContext, date: string): void {
-  edgeCacheDelete(c, ["/api/init", "/api/brief", `/api/brief/${date}`]);
-}
 
 const inscribeRateLimit = createRateLimitMiddleware({
   key: "brief-inscribe",
@@ -129,7 +122,7 @@ briefInscribeRouter.post(
       inscription_id: inscription_id as string,
       btc_address,
     });
-    purgeBriefCaches(c, date);
+    purgeHomepageBundle(c);
     return c.json(
       {
         ok: true,
@@ -217,7 +210,7 @@ briefInscribeRouter.patch("/api/brief/:date/inscribe", async (c) => {
     return c.json({ error: result.error ?? "Failed to update brief" }, 500);
   }
 
-  purgeBriefCaches(c, date);
+  purgeHomepageBundle(c);
   return c.json({ ok: true, date, brief: result.data });
 });
 


### PR DESCRIPTION
Closes #870. Sibling to #868 — that fix made `/api/brief` answer honestly (404 vs 503); this one makes the compiled brief actually *appear* on the homepage without waiting out the edge TTL.

## Problem

`/api/init` (the homepage bundle) edge-caches with `s-maxage=1800`. After a brief compiles, the pre-compile snapshot keeps serving for up to ~30 min, so the homepage tells readers "no brief today" while `/api/brief` already reports `compiledAt`. secret-mars documented the same class of stale-read on `/api/brief/{date}` (~5 min) post-inscribe, which handed polling agents a false-negative `inscription_id: null` right after their own successful POST.

## Fix — shape (a), write-side purge

- **`edgeCacheDelete(c, paths)`** added to `src/lib/edge-cache.ts` — colo-scoped `caches.default.delete` over the canonical GET keys, via `waitUntil` (zero handler latency), no-op in test.
- Called on the **compile-success** path and both **inscribe** success paths (POST + PATCH), evicting `/api/init`, `/api/brief`, and `/api/brief/{date}`.

## Why colo-local is the right coverage

The writing agent sits in one colo; clearing that colo makes its *own* follow-up reads fresh within seconds — which is exactly the false-negative secret-mars hit. Far-colo human readers still refresh on the normal TTL.

## Cost

Strictly better than shrinking the TTL (fix b). The delete is free (a colo cache op, not a DO read); the only cost is one rebuild on the next read in that colo — i.e. we pay a rebuild **only when the brief actually changed**, not on a timer. `/api/init` DO row-reads dominate Cloudflare spend, so a timer-based refresh was a non-starter. The 1800s TTL stays intact for the ~all reads where nothing changed.

## Scope

Per the issue, limited to the brief-compile/inscribe → homepage path. The broader write-triggered surfaces (classifieds create/expire, editor register/deactivate) share the pattern but are out of scope here.

## Test / verify

- `npm run typecheck` + `biome lint` clean.
- Existing brief tests pass (17/17). `edgeCacheDelete` is a no-op in the test runtime by design (shared `caches.default`), matching the other edge-cache helpers.
- Post-deploy manual check (from the issue): compile a brief, then `curl -s https://aibtc.news/api/init | jq .brief.compiledAt` should agree with `/api/brief` within seconds from the same region, not 30 min.