### PR TITLE
fix(brief): expose flat inscription_id/inscribed_txid on brief endpoints (#870)

### DIFF
--- a/src/__tests__/brief-inscription-fields.test.ts
+++ b/src/__tests__/brief-inscription-fields.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { SELF, env } from "cloudflare:test";
+import { saveBrief, updateBrief } from "../lib/do-client";
+import type { Env } from "../lib/types";
+
+// `cloudflare:test` types env as Cloudflare.Env; the do-client helpers want the
+// app's own Env. Same cast the other DO-touching suites use.
+const testEnv = env as unknown as Env;
+
+/**
+ * /api/brief and /api/brief/:date must expose flat, snake_case inscription_id /
+ * inscribed_txid fields read straight from the DB column — the same shape the
+ * /api/brief/:date/inscription endpoint returns.
+ *
+ * Before this, inscription state on the brief endpoints was only reachable at
+ * the nested camelCase `.inscription.inscriptionId` path, while the compile-time
+ * `json_data` blob carried no flat field at all. A client polling
+ * `.inscription_id` therefore got a *permanent* undefined — not a value that
+ * lagged and cleared, but one that never existed. That was misread as a
+ * 5-minute edge-cache staleness (#870 investigation), when in fact
+ * /api/brief/:date is not edge-cached at all and the data was always fresh.
+ */
+async function seedBrief(date: string, updates?: { inscription_id: string; inscribed_txid: string }) {
+  const saved = await saveBrief(testEnv, {
+    date,
+    text: "brief body",
+    json_data: JSON.stringify({ sections: [], summary: { beats: 0, signals: 0, correspondents: 0 } }),
+    compiled_at: `${date}T01:00:00.000Z`,
+  });
+  expect(saved.ok).toBe(true);
+  if (updates) {
+    const updated = await updateBrief(testEnv, date, updates);
+    expect(updated.ok).toBe(true);
+  }
+}
+
+describe("/api/brief/:date — flat inscription fields", () => {
+  it("mirrors the DB column into flat inscription_id/inscribed_txid after inscription", async () => {
+    const date = "2026-06-10";
+    const inscriptionId = `${"a".repeat(64)}i0`;
+    const inscribedTxid = "b".repeat(64);
+    await seedBrief(date, { inscription_id: inscriptionId, inscribed_txid: inscribedTxid });
+
+    const res = await SELF.fetch(`http://example.com/api/brief/${date}`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+
+    // Flat fields — the canonical shape agents poll (matches /inscription).
+    expect(body.inscription_id).toBe(inscriptionId);
+    expect(body.inscribed_txid).toBe(inscribedTxid);
+    // Nested object kept for backward-compat with the frontend.
+    expect(body.inscription).toMatchObject({ inscriptionId, inscribedTxid });
+  });
+
+  it("emits flat inscription fields as null (present, never undefined) before inscription", async () => {
+    const date = "2026-06-11";
+    await seedBrief(date);
+
+    const res = await SELF.fetch(`http://example.com/api/brief/${date}`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+
+    // The keys must exist so a client polling `.inscription_id` reads a real
+    // null, not undefined — the false-negative that started #870.
+    expect(body).toHaveProperty("inscription_id");
+    expect(body.inscription_id).toBeNull();
+    expect(body).toHaveProperty("inscribed_txid");
+    expect(body.inscribed_txid).toBeNull();
+  });
+});

--- a/src/routes/brief.ts
+++ b/src/routes/brief.ts
@@ -9,6 +9,20 @@ import { buildLocalPaymentStatusUrl, buildPaymentRequired, verifyPayment, mapVer
 
 const briefRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>();
 
+// Flat, snake_case inscription fields read straight from the DB column — the
+// same shape /api/brief/:date/inscription returns. Kept flat (not just the
+// nested camelCase `.inscription` object) so a client can poll one canonical
+// field across every brief surface, and always present (null before inscription)
+// so that poll never hits an undefined path. Callers spread this AFTER
+// `...jsonData` so the authoritative column wins over any stale inscription
+// baked into the compile-time json_data blob (#870).
+function flatInscriptionFields(brief: { inscription_id?: string | null; inscribed_txid?: string | null } | null) {
+  return {
+    inscription_id: brief?.inscription_id ?? null,
+    inscribed_txid: brief?.inscribed_txid ?? null,
+  };
+}
+
 // GET /api/brief — get today's compiled brief, or today's date with empty content if not yet compiled.
 // Always returns today's UTC date so the frontend can show today's signal feed before the
 // brief is compiled, rather than falling back to yesterday's stale brief.
@@ -59,6 +73,7 @@ briefRouter.get("/api/brief", async (c) => {
       latest: true,
       archive,
       inscription: null,
+      ...flatInscriptionFields(null),
     });
   }
 
@@ -90,6 +105,7 @@ briefRouter.get("/api/brief", async (c) => {
     price: { amount: BRIEF_PRICE_SATS, asset: "sBTC (sats)", protocol: "x402" },
     ...jsonData,
     text: todaysBrief.text,
+    ...flatInscriptionFields(todaysBrief),
   });
 });
 
@@ -279,6 +295,7 @@ briefRouter.get("/api/brief/:date", async (c) => {
     inscription,
     ...jsonData,
     text: brief.text,
+    ...flatInscriptionFields(brief),
   });
 });
 


### PR DESCRIPTION
Follow-up from the #870 / #884 investigation. **Not a cache fix** — a response-shape fix. Splitting it out of #884 (which is scoped to the `/api/init` purge) so each PR does one thing.

## What the investigation found

secret-mars reported that `GET /api/brief/{date}.inscription_id` returned `null` right after a successful inscribe, and attributed it to ~5-min `s-maxage` edge staleness. I probed the live endpoints:

- `/api/brief/{date}` returns **no** `cf-cache-status`, **no** `age`, **no** `x-edge-cache` even on back-to-back requests → it is **not edge-cached at all** (no Cloudflare Cache Rule; `brief.ts` never calls `edgeCachePut`). So caching could not have been the cause, and the data was always fresh.
- The real cause: inscription state was only exposed at the nested camelCase `.inscription.inscriptionId`. There is **no top-level `inscription_id` key** — the response spreads the compile-time `json_data` blob, which never carried one. A client polling `.inscription_id` reads a *permanent* undefined, not a lagging value.

Concretely, days after inscription, `/api/brief/2026-07-15` still shows top-level `inscription_id: null` while `.inscription.inscriptionId` and `/api/brief/2026-07-15/inscription` both return the real id. Three endpoints, three shapes for the same DB-backed fact.

## Fix

Add flat, snake_case `inscription_id` / `inscribed_txid` (read straight from the DB column) to `/api/brief` and `/api/brief/:date`, matching what `/api/brief/:date/inscription` already returns. Also added to the pre-compile empty branch as `null`, so the key is **always present** — a client polling it gets a real `null`, never `undefined`.

- Placed **after** `...jsonData` so the authoritative column value always wins over any stale inscription baked into `json_data`.
- The nested `inscription` object is untouched (frontend backward-compat).

## Test / verify

- New `src/__tests__/brief-inscription-fields.test.ts` — route-level, seeds a brief via `saveBrief`/`updateBrief` and asserts the flat fields both post-inscription and pre-inscription (present-as-null).
- Full suite green: **467/467**. `typecheck` + `biome lint` clean.

## Note

This supersedes the "secret-mars `/api/brief/{date}` sibling" rationale that #884 originally cited for purging brief URLs — that purge was dropped in review precisely because those endpoints aren't in the Workers cache. This PR fixes the actual root cause.