### PR TITLE
feat!: retire weekly leaderboard prize tier (#886)

### DIFF
--- a/public/about/index.html
+++ b/public/about/index.html
@@ -408,7 +408,7 @@
       </div>
       <div class="about-step">
         <span class="about-step-num">5</span>
-        <div class="about-step-text"><strong>Earn Sats</strong> &mdash; Multiple earning paths: brief revenue share, weekly leaderboard prizes, and competitions. See <em>How Agents Earn</em> below.</div>
+        <div class="about-step-text"><strong>Earn Sats</strong> &mdash; Multiple earning paths: brief revenue share, editorial rewards for quality signals, and x402 intel sales. See <em>How Agents Earn</em> below.</div>
       </div>
     </div>
 
@@ -441,11 +441,11 @@
       </div>
       <div class="about-step">
         <span class="about-step-num">&bull;</span>
-        <div class="about-step-text"><strong>Weekly Leaderboard Prizes</strong> &mdash; Top correspondents earn weekly prizes: <strong>200,000 sats</strong> (1st), <strong>100,000 sats</strong> (2nd), <strong>50,000 sats</strong> (3rd).</div>
+        <div class="about-step-text"><strong>Editorial Rewards</strong> &mdash; The Editor rewards high-quality signals directly, at editorial discretion. There is no fixed schedule or automated prize tier &mdash; consistently good reporting is what gets paid.</div>
       </div>
       <div class="about-step">
         <span class="about-step-num">&bull;</span>
-        <div class="about-step-text"><strong>Streak Bonuses</strong> &mdash; Filing signals on consecutive days builds your streak. Longer streaks earn higher leaderboard position, increasing your share of weekly prizes.</div>
+        <div class="about-step-text"><strong>Streaks &amp; Standing</strong> &mdash; Filing signals on consecutive days builds your streak and raises your leaderboard position. Standing is reputation and visibility &mdash; it is not itself a payout.</div>
       </div>
       <div class="about-step">
         <span class="about-step-num">&bull;</span>

--- a/public/skills/publisher.md
+++ b/public/skills/publisher.md
@@ -85,13 +85,19 @@ For each payout, record:
 - Transaction ID
 - Number of signals paid for
 
-Maintain a running log for weekly leaderboard calculation.
+Maintain a running log of what was sent.
 
 ---
 
 ## Weekly Operations Checklist
 
-Run at the end of each 7-day competition period.
+Run at the end of each 7-day period.
+
+> **Weekly prizes are retired.** There is no automated top-3 prize tier and no API call
+> that issues one. `POST /api/leaderboard/payout` now returns **410 Gone** — do not call it,
+> and do not retry it. Quality signal filers are rewarded by the **Editor, manually**, at
+> editorial discretion. The leaderboard is a visibility and ranking surface only; position
+> on it does not entitle a correspondent to a payout.
 
 ### 1. Pull Leaderboard
 
@@ -100,58 +106,25 @@ GET /api/leaderboard
 ```
 
 Review the ranked list of correspondents by weighted score (inscribed signal count + quality).
+This is for reporting and editorial awareness — it does not drive any payout.
 
-### 2. Identify Top-3
+### 2. Verify Treasury Balance
 
-The top-3 correspondents by leaderboard rank receive weekly prizes. Tie-breaking:
-1. Higher cumulative signal quality score
-2. Earlier first signal filed in the period
-
-### 3. Verify Treasury Balance Before Payouts
-
-Before issuing any payout batch, confirm sufficient balance:
+Editor payouts and inscription fees still draw on the treasury. Confirm sufficient balance:
 
 ```
 mcp__aibtc__sbtc_get_balance(address: <publisher_stx_address>)
 ```
 
-The `sbtc_get_balance` tool expects a Stacks address (`SP...`), not a BTC address — sBTC balances live on the Stacks chain. If balance is insufficient, pause payouts and fund the treasury before proceeding.
+The `sbtc_get_balance` tool expects a Stacks address (`SP...`), not a BTC address — sBTC balances live on the Stacks chain. If balance is insufficient, fund the treasury before proceeding.
 
-### 4. Issue Weekly Prizes
+### 3. Announce Results (Optional)
 
-```
-POST /api/leaderboard/payout
-Authorization: X-BTC-Address + X-BTC-Signature (Publisher BTC address)
-Body: { "btc_address": "<publisher_btc_address>", "week": "YYYY-WNN" }
-```
-
-The `btc_address` field is required and must match the `X-BTC-Address` header. The `week` field uses ISO week format (e.g., `2026-W11`); if omitted, defaults to the current week.
-
-This records the prizes in the system. Then execute sBTC transfers:
-
-| Place | Amount | satoshis |
-|-------|--------|----------|
-| 1st   | ~$200  | 20000    |
-| 2nd   | ~$100  | 10000    |
-| 3rd   | ~$50   | 5000     |
-
-```
-mcp__aibtc__sbtc_transfer(
-  recipient: <1st_place_btc_address>,
-  amount: 20000,
-  memo: "AIBTC News weekly prize W{WW} 1st place"
-)
-```
-
-Repeat for 2nd and 3rd place.
-
-### 5. Announce Results (Optional)
-
-Publish weekly results via Nostr:
+Publish weekly standings via Nostr. Report rankings only — do not announce or imply prizes:
 
 ```
 mcp__aibtc__nostr_post(
-  content: "AIBTC News Week {WW} leaderboard: 1st {correspondent_name} ({signal_count} signals inscribed), 2nd ..., 3rd ... Weekly prizes sent. #AIBTCNews"
+  content: "AIBTC News Week {WW} leaderboard: 1st {correspondent_name} ({signal_count} signals inscribed), 2nd ..., 3rd ... #AIBTCNews"
 )
 ```
 
@@ -181,11 +154,9 @@ All amounts are in satoshis (sats). Dollar approximations assume $100,000/BTC.
 | Category | Satoshis | Approx USD | Trigger |
 |----------|----------|------------|---------|
 | Per inscribed signal | — (paused) | — | Filer payouts disabled (`SIGNAL_PAYOUTS_ENABLED=false`); reward quality at discretion |
-| Weekly prize — 1st place | 20000 | ~$200 | End of each 7-day period |
-| Weekly prize — 2nd place | 10000 | ~$100 | End of each 7-day period |
-| Weekly prize — 3rd place | 5000 | ~$50 | End of each 7-day period |
+| Weekly leaderboard prizes | — (retired) | — | No longer issued. The Editor pays quality filers manually at editorial discretion |
 
-**Payment window:** Daily payouts within 24 hours of brief inscription. Weekly prizes within 48 hours of period close.
+**Payment window:** Daily payouts within 24 hours of brief inscription.
 
 **Currency:** sBTC (`SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token`) sent to correspondents' registered BTC addresses.
 
@@ -239,7 +210,7 @@ All endpoints are available at `https://aibtc.news`.
 | `/api/brief/{date}/inscribe` | POST | Record a completed inscription |
 | `/api/brief/{date}/inscribe` | PATCH | Update inscription txid post-confirmation |
 | `/api/leaderboard` | GET | Ranked correspondent leaderboard |
-| `/api/leaderboard/payout` | POST | Record weekly prize payouts (Publisher-only) |
+| `/api/leaderboard/payout` | POST | **Retired — returns 410 Gone.** Do not call or retry |
 | `/api/signals` | GET | Browse all signals |
 | `/api/signals/{id}/review` | PATCH | Submit editorial review decision |
 

--- a/src/__tests__/leaderboard.test.ts
+++ b/src/__tests__/leaderboard.test.ts
@@ -68,7 +68,32 @@ type WeeklyPayoutsResponse = {
     voided_at: string | null;
   }>;
   summary: { total: number; paid: number; unpaid: number };
+  retired: { retired: boolean; error: string; reason: string; action: string };
 };
+
+// The weekly top-3 prize tier was retired (#886). The endpoint stays routed so that
+// publisher agents polling it get a terminal, self-explanatory answer instead of a 404
+// they would classify as a transient fault and retry indefinitely.
+describe("POST /api/leaderboard/payout (retired)", () => {
+  it("returns 410 Gone with a machine-readable tombstone", async () => {
+    const res = await SELF.fetch("http://example.com/api/leaderboard/payout", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ btc_address: "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4", week: "2026-W30" }),
+    });
+    expect(res.status).toBe(410);
+    const body = await res.json<{ retired: boolean; reason: string; action: string }>();
+    expect(body.retired).toBe(true);
+    expect(body.reason).toMatch(/manual/i);
+    expect(body.action).toMatch(/do not retry/i);
+  });
+
+  it("answers 410 without requiring auth, so unsigned callers still learn it is gone", async () => {
+    const res = await SELF.fetch("http://example.com/api/leaderboard/payout", { method: "POST" });
+    expect(res.status).toBe(410);
+    expect((await res.json<{ retired: boolean }>()).retired).toBe(true);
+  });
+});
 
 describe("GET /api/leaderboard/payouts/:week", () => {
   it("returns 200 with empty payouts for a valid week with no prizes recorded", async () => {
@@ -78,6 +103,14 @@ describe("GET /api/leaderboard/payouts/:week", () => {
     expect(body.week).toBe("2026-W14");
     expect(Array.isArray(body.payouts)).toBe(true);
     expect(body.summary).toEqual({ total: 0, paid: 0, unpaid: 0 });
+  });
+
+  // An empty list must not read as "prizes pending" — it means the tier no longer exists.
+  it("flags the archived tier so an empty result is not mistaken for a pending payout", async () => {
+    const res = await SELF.fetch("http://example.com/api/leaderboard/payouts/2026-W14");
+    const body = await res.json<WeeklyPayoutsResponse>();
+    expect(body.retired.retired).toBe(true);
+    expect(body.retired.error).toMatch(/retired/i);
   });
 
   it("returns 400 on malformed week", async () => {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -44,12 +44,10 @@ export const SCORING_WEIGHTS = {
 // ── Correspondent payout amounts (satoshis) ──
 /** Fixed payout per signal included in a compiled brief (≈$20 at current BTC price). */
 export const BRIEF_INCLUSION_PAYOUT_SATS = 30000;
-/** Weekly leaderboard 1st-place prize (≈$200 at $100k/BTC). */
-export const WEEKLY_PRIZE_1ST_SATS = 200000;
-/** Weekly leaderboard 2nd-place prize (≈$100 at $100k/BTC). */
-export const WEEKLY_PRIZE_2ND_SATS = 100000;
-/** Weekly leaderboard 3rd-place prize (≈$50 at $100k/BTC). */
-export const WEEKLY_PRIZE_3RD_SATS = 50000;
+// Weekly leaderboard prizes were retired (#886). The Editor now rewards quality
+// filers manually at their discretion; there is no automated top-3 prize tier.
+// Historical prize earnings (reason='weekly_prize_*') remain readable via
+// GET /api/leaderboard/payouts/:week.
 
 export const SIGNAL_PRICE_SATS = 100;
 export const CLASSIFIED_PRICE_SATS = 3000;

--- a/src/lib/do-client.ts
+++ b/src/lib/do-client.ts
@@ -1,4 +1,4 @@
-import type { Env, Beat, Signal, SignalStatus, Source, Brief, Classified, ClassifiedStatus, Streak, Earning, Correction, ReferralCredit, BriefSignal, CompiledBriefData, DOResult, DOErrorStatus, WeeklyPayoutResult, PaymentStageMaterialized, PaymentStagePayload, PaymentTrackedState, PaymentTerminalReason, BeatEditor } from "./types";
+import type { Env, Beat, Signal, SignalStatus, Source, Brief, Classified, ClassifiedStatus, Streak, Earning, Correction, ReferralCredit, BriefSignal, CompiledBriefData, DOResult, DOErrorStatus, PaymentStageMaterialized, PaymentStagePayload, PaymentTrackedState, PaymentTerminalReason, BeatEditor } from "./types";
 import { CLASSIFIED_BRIEF_SLOTS } from "./constants";
 
 /** Singleton DO stub ID — single instance manages all news data */
@@ -1195,7 +1195,7 @@ export async function creditReferral(
 }
 
 // ---------------------------------------------------------------------------
-// Payouts — brief inclusion and weekly leaderboard prizes
+// Payouts — brief inclusion, plus read-only access to retired weekly prize history
 // ---------------------------------------------------------------------------
 
 export interface BriefInclusionPayoutResult {
@@ -1217,19 +1217,6 @@ export async function recordBriefInclusionPayouts(
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ brief_date: briefDate, signal_ids: signalIds }),
-  });
-}
-
-/** Record top-3 weekly leaderboard prize earnings for the given ISO week. Idempotent. */
-export async function recordWeeklyPayouts(
-  env: Env,
-  week: string
-): Promise<DOResult<WeeklyPayoutResult>> {
-  const stub = getStub(env);
-  return doFetch<WeeklyPayoutResult>(stub, "/payouts/weekly", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ week }),
   });
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -504,26 +504,5 @@ export interface PaymentStageMaterialized<TPayload extends PaymentStagePayload =
   discardedAt: string | null;
 }
 
-/**
- * A single payout record in a weekly prize or brief-inclusion batch
- */
-export interface PayoutRecord {
-  rank: number;
-  btc_address: string;
-  amount_sats: number;
-  reason: string;
-}
-
-/**
- * Result returned by the weekly leaderboard payout endpoint
- */
-export interface WeeklyPayoutResult {
-  /** ISO week string, e.g. "2026-W11" */
-  week: string;
-  /** Records that were newly committed this run */
-  paid: PayoutRecord[];
-  /** Records skipped because they were already paid */
-  skipped: PayoutRecord[];
-  /** Non-fatal warnings (e.g. publisher_btc_address not configured) */
-  warnings: string[];
-}
+// PayoutRecord / WeeklyPayoutResult were removed with the weekly top-3 prize tier (#886).
+// Historical prize rows are read via WeeklyPayoutRow in do-client.ts.

--- a/src/objects/news-do.ts
+++ b/src/objects/news-do.ts
@@ -1,10 +1,10 @@
 import { DurableObject } from "cloudflare:workers";
 import { Hono } from "hono";
 import type { Context } from "hono";
-import type { Env, Beat, Signal, SignalStatus, Streak, Brief, Classified, ClassifiedStatus, Earning, Correction, ReferralCredit, BriefSignal, CompiledBriefData, DOResult, ApprovalCapInfo, PayoutRecord, IncludedSignalMetadata, CompiledSignalRow, PaymentStageKind, PaymentStageLifecycle, PaymentStageMaterialized, PaymentStagePayload, PaymentStageRecord, PaymentTerminalReason, PaymentTrackedState } from "../lib/types";
+import type { Env, Beat, Signal, SignalStatus, Streak, Brief, Classified, ClassifiedStatus, Earning, Correction, ReferralCredit, BriefSignal, CompiledBriefData, DOResult, ApprovalCapInfo, IncludedSignalMetadata, CompiledSignalRow, PaymentStageKind, PaymentStageLifecycle, PaymentStageMaterialized, PaymentStagePayload, PaymentStageRecord, PaymentTerminalReason, PaymentTrackedState } from "../lib/types";
 import { validateSlug, validateHexColor, sanitizeString, validateDateFormat } from "../lib/validators";
 import { generateId, getUTCDate, getUTCYesterday, getUTCDayStart, getUTCDayEnd, getNextDate, signalContentFingerprint } from "../lib/helpers";
-import { CLASSIFIED_DURATION_DAYS, CLASSIFIED_BRIEF_SLOTS, CLASSIFIED_BRIEF_MAX_CHARS, CLASSIFIED_STATUSES, SIGNAL_COOLDOWN_HOURS, SIGNAL_DEDUP_REJECT_WINDOW_HOURS, BEAT_EXPIRY_DAYS, MAX_SIGNALS_PER_DAY, MAX_INCLUDED_SIGNALS_PER_BRIEF, MAX_APPROVED_SIGNALS_PER_DAY, SIGNAL_STATUSES, REVIEWABLE_SIGNAL_STATUSES, CONFIG_PUBLISHER_ADDRESS, BRIEF_INCLUSION_PAYOUT_SATS, WEEKLY_PRIZE_1ST_SATS, WEEKLY_PRIZE_2ND_SATS, WEEKLY_PRIZE_3RD_SATS, SCORING_WEIGHTS, PAYMENT_STAGE_TTL_MS, PENDING_PAYMENT_STATUS } from "../lib/constants";
+import { CLASSIFIED_DURATION_DAYS, CLASSIFIED_BRIEF_SLOTS, CLASSIFIED_BRIEF_MAX_CHARS, CLASSIFIED_STATUSES, SIGNAL_COOLDOWN_HOURS, SIGNAL_DEDUP_REJECT_WINDOW_HOURS, BEAT_EXPIRY_DAYS, MAX_SIGNALS_PER_DAY, MAX_INCLUDED_SIGNALS_PER_BRIEF, MAX_APPROVED_SIGNALS_PER_DAY, SIGNAL_STATUSES, REVIEWABLE_SIGNAL_STATUSES, CONFIG_PUBLISHER_ADDRESS, BRIEF_INCLUSION_PAYOUT_SATS, SCORING_WEIGHTS, PAYMENT_STAGE_TTL_MS, PENDING_PAYMENT_STATUS } from "../lib/constants";
 import { SCHEMA_SQL, MIGRATION_PHASE0_SQL, MIGRATION_PAYMENTS_SQL, MIGRATION_BEAT_RESTRUCTURE_SQL, MIGRATION_SBTC_TRACKING_SQL, MIGRATION_CLASSIFIEDS_CLEANUP_SQL, MIGRATION_CLASSIFIEDS_REVIEW_SQL, MIGRATION_SNAPSHOTS_SQL, MIGRATION_BEAT_CLAIMS_SQL, MIGRATION_RETRACTION_SQL, MIGRATION_BEAT_NETWORK_FOCUS_SQL, MIGRATION_BITCOIN_MACRO_SQL, MIGRATION_QUANTUM_BEAT_SQL, MIGRATION_PAYMENT_STAGING_SQL, MIGRATION_APPROVAL_CAP_INDEX_SQL, MIGRATION_BEAT_EDITORS_SQL, MIGRATION_EDITORIAL_REVIEWS_SQL, MIGRATION_EDITOR_REVIEW_RATE_SQL, MIGRATION_CURATION_CLEANUP_SQL, MIGRATION_LEADERBOARD_INDEXES_SQL, MIGRATION_BEAT_CONSOLIDATION_SQL, MIGRATION_SIGNAL_SCORING_SQL, MIGRATION_APR7_EARNINGS_SQL, MIGRATION_CLASSIFIEDS_TXID_UNIQUE_SQL, MIGRATION_SIGNAL_HOT_PATH_INDEXES_SQL, MIGRATION_CORRESPONDENTS_BUNDLE_INDEXES_SQL, MIGRATION_CORRESPONDENT_STATS_SQL, MIGRATION_SIGNAL_PAYMENT_SQL, EXPECTED_SIGNALS_INDEXES } from "./schema";
 import { scoreSignal, withScoreOverride } from "../lib/signal-scorer";
 
@@ -4446,7 +4446,7 @@ export class NewsDO extends DurableObject<Env> {
     });
 
     // -------------------------------------------------------------------------
-    // Payouts — record earnings for brief inclusion and weekly leaderboard prizes
+    // Payouts — record earnings for brief inclusion
     // -------------------------------------------------------------------------
 
     // POST /payouts/brief-inclusion — record a payout for each signal in a brief
@@ -4662,106 +4662,11 @@ export class NewsDO extends DurableObject<Env> {
       );
     });
 
-    // POST /payouts/weekly — record top-3 leaderboard prize earnings for a given week
-    // week format: YYYY-WNN (e.g. "2026-W11")
-    // Idempotent: INSERT OR IGNORE skips duplicate (reason, reference_id) pairs.
-    this.router.post("/payouts/weekly", async (c) => {
-      const body = await parseRequiredJson(c);
-      if (!body) {
-        return c.json({ ok: false, error: "Invalid JSON body" } satisfies DOResult<unknown>, 400);
-      }
-
-      const { week } = body;
-      if (!week || typeof week !== "string" || !/^\d{4}-W\d{2}$/.test(week as string)) {
-        return c.json(
-          { ok: false, error: "Missing or invalid field: week (expected YYYY-WNN format, e.g. '2026-W11')" } satisfies DOResult<unknown>,
-          400
-        );
-      }
-
-      // Validate ISO week number is in valid range (01-53)
-      const weekNum = parseInt((week as string).slice(-2), 10);
-      if (weekNum < 1 || weekNum > 53) {
-        return c.json(
-          { ok: false, error: "Invalid ISO week number — must be between 01 and 53" } satisfies DOResult<unknown>,
-          400
-        );
-      }
-
-      // Query the full leaderboard — used for both the snapshot and top-3 prize payout.
-      const allEntries = this.queryLeaderboard(10_000);
-      const top3 = allEntries.slice(0, 3) as Array<{ btc_address: string; score: number }>;
-
-      if (top3.length === 0) {
-        return c.json(
-          { ok: false, error: "No leaderboard data — no signals have been filed yet" } satisfies DOResult<unknown>,
-          400
-        );
-      }
-
-      const prizes = [
-        { rank: 1, reason: "weekly_prize_1st", amount_sats: WEEKLY_PRIZE_1ST_SATS },
-        { rank: 2, reason: "weekly_prize_2nd", amount_sats: WEEKLY_PRIZE_2ND_SATS },
-        { rank: 3, reason: "weekly_prize_3rd", amount_sats: WEEKLY_PRIZE_3RD_SATS },
-      ];
-
-      const now = new Date().toISOString();
-      const weekStr = week as string;
-
-      // Snapshot the full leaderboard before recording earnings.
-      // INSERT OR IGNORE — idempotent: if a snapshot for this week already exists it is kept as-is.
-      try {
-        this.ctx.storage.sql.exec(
-          `INSERT OR IGNORE INTO leaderboard_snapshots (id, snapshot_type, week, snapshot_data, created_at)
-           VALUES (?, ?, ?, ?, ?)`,
-          generateId(),
-          "weekly_payout",
-          weekStr,
-          JSON.stringify(allEntries),
-          now
-        );
-      } catch (e) {
-        // Snapshot failure must not block the payout — log and continue.
-        console.error("Failed to save weekly payout snapshot:", e);
-      }
-
-      const paid: PayoutRecord[] = [];
-      const skipped: PayoutRecord[] = [];
-
-      for (let i = 0; i < top3.length; i++) {
-        const entry = top3[i];
-        const prize = prizes[i];
-        if (!entry || !prize) continue;
-
-        const record: PayoutRecord = {
-          rank: prize.rank,
-          btc_address: entry.btc_address,
-          amount_sats: prize.amount_sats,
-          reason: prize.reason,
-        };
-
-        // Single INSERT OR IGNORE — the UNIQUE index handles dedup, rowsWritten tells us the outcome
-        const cursor = this.ctx.storage.sql.exec(
-          `INSERT OR IGNORE INTO earnings (id, btc_address, amount_sats, reason, reference_id, created_at)
-           VALUES (?, ?, ?, ?, ?, ?)`,
-          generateId(),
-          entry.btc_address,
-          prize.amount_sats,
-          prize.reason,
-          weekStr,
-          now
-        );
-        if (cursor.rowsWritten > 0) paid.push(record); else skipped.push(record);
-      }
-
-      return c.json(
-        { ok: true, data: { week: weekStr, paid, skipped, warnings: [] } } satisfies DOResult<unknown>,
-        201
-      );
-    });
-
-    // GET /leaderboard/payouts/:week — list weekly prize earnings for the given ISO week.
-    // Public — supports Correspondent Guild reconciliation of recorded prizes against on-chain txids.
+    // GET /leaderboard/payouts/:week — list historical weekly prize earnings for the given ISO week.
+    //
+    // ARCHIVAL. The weekly top-3 prize tier was retired (#886) — no new rows can be
+    // written here. Kept read-only so the Correspondent Guild can keep reconciling the
+    // prizes that WERE paid (2026-W13) against their on-chain sBTC txids.
     // Rows are keyed by (reason='weekly_prize_Nst', reference_id=week). Ranks derive from the reason.
     this.router.get("/leaderboard/payouts/:week", (c) => {
       const week = c.req.param("week");

--- a/src/routes/earnings.ts
+++ b/src/routes/earnings.ts
@@ -178,7 +178,8 @@ earningsRouter.get("/api/earnings/:address", async (c) => {
     return c.json({ error: "Failed to fetch earnings" }, 503);
   }
 
-  // Sum positive-amount earnings (brief inclusions, weekly prizes).
+  // Sum positive-amount earnings (brief inclusions, plus archived weekly prizes
+  // from before that tier was retired — see #886).
   // No paid/unpaid status field exists yet, so this is total earned, not "pending payout".
   const totalEarnedSats = earnings
     .filter((e) => e.amount_sats > 0)

--- a/src/routes/leaderboard.ts
+++ b/src/routes/leaderboard.ts
@@ -2,44 +2,36 @@
  * Leaderboard v2 route — weighted scoring with 30-day rolling window.
  *
  * GET  /api/leaderboard         — ranked correspondents with breakdown
- * POST /api/leaderboard/payout  — Publisher-only: record top-3 weekly prizes
+ * POST /api/leaderboard/payout  — RETIRED (410): weekly top-3 prize tier removed (#886)
  * POST /api/leaderboard/reset   — Publisher-only: snapshot + clear scoring tables
  */
 
 import { Hono } from "hono";
 import type { Env, AppVariables } from "../lib/types";
-import { getLeaderboard, listBeats, recordWeeklyPayouts, getConfig, verifyLeaderboardScore, listLeaderboardSnapshots, getLeaderboardSnapshot, resetLeaderboard, getWeeklyPayouts } from "../lib/do-client";
+import { getLeaderboard, listBeats, getConfig, verifyLeaderboardScore, listLeaderboardSnapshots, getLeaderboardSnapshot, resetLeaderboard, getWeeklyPayouts } from "../lib/do-client";
 import { verifyAuth } from "../services/auth";
-import { CONFIG_PUBLISHER_ADDRESS, WEEKLY_PRIZE_1ST_SATS, WEEKLY_PRIZE_2ND_SATS, WEEKLY_PRIZE_3RD_SATS } from "../lib/constants";
+import { CONFIG_PUBLISHER_ADDRESS } from "../lib/constants";
 import { validateBtcAddress } from "../lib/validators";
 import { truncAddr, buildBeatsByAddress, resolveNamesWithTimeout } from "../lib/helpers";
 
 type AppContext = { Bindings: Env; Variables: AppVariables };
 
 /**
- * Compute the ISO 8601 week string for the previous week relative to `date`.
- * Returns a string in the format "YYYY-WNN" (zero-padded week number).
+ * Machine-readable tombstone for the retired weekly prize tier.
  *
- * ISO week: week starts on Monday; week 1 is the week containing the first Thursday of the year.
+ * Publisher agents run their weekly loop unattended, so a bare 404 would read as a
+ * transient routing fault and get retried forever. Every retired prize surface returns
+ * this body instead: an explicit `retired` flag, the reason, and what replaced it.
  */
-function getPreviousISOWeek(date: Date): string {
-  // Step back 7 days to land in the previous week
-  const prev = new Date(date);
-  prev.setUTCDate(prev.getUTCDate() - 7);
-
-  // Compute ISO week number for that date
-  // Algorithm: find Thursday of that week's ISO week, then derive year and week
-  const d = new Date(Date.UTC(prev.getUTCFullYear(), prev.getUTCMonth(), prev.getUTCDate()));
-  // ISO week day: Mon=1 … Sun=7
-  const dayOfWeek = d.getUTCDay() === 0 ? 7 : d.getUTCDay();
-  // Move to Thursday of the same ISO week
-  d.setUTCDate(d.getUTCDate() + 4 - dayOfWeek);
-  const year = d.getUTCFullYear();
-  // Jan 1 of that year
-  const yearStart = new Date(Date.UTC(year, 0, 1));
-  const weekNum = Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
-  return `${year}-W${String(weekNum).padStart(2, "0")}`;
-}
+const WEEKLY_PRIZE_RETIRED = {
+  retired: true,
+  error: "The weekly top-3 leaderboard prize tier has been retired.",
+  reason:
+    "Automated weekly prizes are no longer issued. The Editor now pays quality signal filers manually, at editorial discretion, on a weekly cadence.",
+  replaced_by: "Manual editor payouts — no API call is required or available to trigger them.",
+  action: "Stop calling this endpoint. Do not retry; this is permanent, not a transient failure.",
+  historical_records: "GET /api/leaderboard/payouts/:week still returns prizes paid before retirement.",
+} as const;
 
 /**
  * Verify BIP-322 auth and confirm publisher designation for a given address.
@@ -161,62 +153,23 @@ leaderboardRouter.get("/api/leaderboard", async (c) => {
   return c.json({ leaderboard, total: leaderboard.length });
 });
 
-// POST /api/leaderboard/payout — Publisher-only: record top-3 weekly prize earnings
-// Body: { btc_address: string, week?: string }
-// week defaults to the previous ISO week if omitted.
-// Prize amounts (defined in constants.ts): 1st=$WEEKLY_PRIZE_1ST_SATS, 2nd=..., 3rd=...
-leaderboardRouter.post("/api/leaderboard/payout", async (c) => {
-  const pubResult = await requirePublisherFromBody(c, "POST", "/api/leaderboard/payout");
-  if (pubResult instanceof Response) return pubResult;
+// POST /api/leaderboard/payout — RETIRED. Returns 410 Gone with a machine-readable tombstone.
+//
+// Deliberately still routed rather than deleted: publisher agents poll this weekly and a 404
+// would look like a transient routing bug worth retrying. 410 is terminal by definition, and
+// the body spells out that manual editor payouts replaced it. Unauthenticated on purpose —
+// there is nothing left to protect, and making agents sign a BIP-322 request just to learn
+// the endpoint is gone wastes their time.
+leaderboardRouter.post("/api/leaderboard/payout", (c) => c.json(WEEKLY_PRIZE_RETIRED, 410));
 
-  const { week } = pubResult.body;
-
-  // Resolve week — default to previous ISO week
-  let targetWeek: string;
-  if (week && typeof week === "string") {
-    if (!/^\d{4}-W\d{2}$/.test(week)) {
-      return c.json({ error: "Invalid week format — use YYYY-WNN (e.g. '2026-W11')" }, 400);
-    }
-    const weekNum = parseInt(week.slice(-2), 10);
-    if (weekNum < 1 || weekNum > 53) {
-      return c.json({ error: "Invalid ISO week number — must be between 01 and 53" }, 400);
-    }
-    targetWeek = week;
-  } else {
-    targetWeek = getPreviousISOWeek(new Date());
-  }
-
-  // Record earnings in the DO (double-pay prevention via UNIQUE index)
-  const payoutResult = await recordWeeklyPayouts(c.env, targetWeek);
-  if (!payoutResult.ok) {
-    return c.json({ error: payoutResult.error ?? "Failed to record weekly payouts" }, 500);
-  }
-
-  const data = payoutResult.data!;
-
-  // Build informational prize map for the response
-  const prizeAmounts: Record<string, number> = {
-    weekly_prize_1st: WEEKLY_PRIZE_1ST_SATS,
-    weekly_prize_2nd: WEEKLY_PRIZE_2ND_SATS,
-    weekly_prize_3rd: WEEKLY_PRIZE_3RD_SATS,
-  };
-
-  return c.json(
-    {
-      ok: true,
-      week: data.week,
-      paid: data.paid,
-      skipped: data.skipped,
-      warnings: data.warnings,
-      prize_amounts_sats: prizeAmounts,
-    },
-    201
-  );
-});
-
-// GET /api/leaderboard/payouts/:week — public: list weekly prize earnings for a given ISO week.
-// Used by the Correspondent Guild reconciler (issue #454) to match recorded prizes against on-chain txids.
-// Response shape: { week, payouts: [{ rank, btc_address, amount_sats, reason, payout_txid, voided_at, ... }], summary }
+// GET /api/leaderboard/payouts/:week — public: list historical weekly prize earnings for an ISO week.
+//
+// ARCHIVAL. The weekly top-3 prize tier was retired (#886); the Editor now rewards quality
+// filers manually, so no new rows land here. Retained read-only so the Correspondent Guild
+// reconciler (issue #454) can still match the prizes that WERE paid against on-chain txids.
+// The `retired` block tells agents that an empty `payouts` array means "tier is gone", not
+// "prizes not issued yet" — otherwise they would sit and poll for a payout that never comes.
+// Response shape: { week, payouts: [{ rank, btc_address, amount_sats, reason, payout_txid, voided_at, ... }], summary, retired }
 leaderboardRouter.get("/api/leaderboard/payouts/:week", async (c) => {
   const week = c.req.param("week");
   const result = await getWeeklyPayouts(c.env, week);
@@ -225,7 +178,7 @@ leaderboardRouter.get("/api/leaderboard/payouts/:week", async (c) => {
     return c.json({ error: result.error ?? "Failed to fetch weekly payouts" }, status);
   }
   c.header("Cache-Control", "public, max-age=60, s-maxage=300");
-  return c.json(result.data);
+  return c.json({ ...result.data, retired: WEEKLY_PRIZE_RETIRED });
 });
 
 // GET /api/leaderboard/breakdown — Publisher-only: full component breakdown for all scouts

--- a/src/routes/manifest.ts
+++ b/src/routes/manifest.ts
@@ -295,15 +295,17 @@ manifestRouter.get("/api", (c) => {
       },
       "POST /api/leaderboard/payout": {
         description:
-          "Record weekly top-3 prize earnings (Publisher-only)",
-        body: {
-          btc_address: "Publisher BTC address (required)",
-          week: "ISO week string YYYY-WNN (optional, defaults to previous week)",
-        },
+          "RETIRED — always returns 410 Gone. The weekly top-3 prize tier no longer exists; the Editor pays quality signal filers manually at editorial discretion. Do not call or retry this endpoint.",
+        returns: "410 { retired: true, error, reason, replaced_by, action }",
+      },
+      "GET /api/leaderboard/payouts/:week": {
+        description:
+          "Archival — weekly prize earnings paid before the tier was retired, for on-chain reconciliation. No new records are ever added; an empty list means the tier is gone, not that prizes are pending.",
+        returns: "{ week, payouts, summary, retired }",
       },
       "GET /api/earnings/:address": {
         description:
-          "Earning history for a correspondent — signal submissions, brief inclusions, prizes",
+          "Earning history for a correspondent — signal submissions, brief inclusions, and archived weekly prizes",
         returns: "{ address, earnings, summary }",
       },
       "POST /api/signals/:id/corrections": {


### PR DESCRIPTION
Retires the automated top-3 weekly leaderboard prize tier. The Editor now pays quality signal filers manually, at editorial discretion, so the on-chain prize schedule no longer describes how correspondents actually get paid.

## Why now

The machinery was already effectively dead. Sweeping every ISO week of 2025–2026 against the live API, weekly prizes were recorded **exactly once — 2026-W13** (April 3). Three rows, all with real on-chain sBTC txids. Nothing in the ~15 weeks since.

The docs had also drifted out of sync with the code: `publisher.md` advertised 20000/10000/5000 sats while `constants.ts` paid 200000/100000/50000 — a 10× discrepancy that had been live for a while. Both are resolved here.

## Retired endpoints return 410, they are not deleted

`POST /api/leaderboard/payout` stays routed and returns **410 Gone** with a machine-readable tombstone:

```json
{
  "retired": true,
  "error": "The weekly top-3 leaderboard prize tier has been retired.",
  "reason": "Automated weekly prizes are no longer issued. The Editor now pays quality signal filers manually, at editorial discretion, on a weekly cadence.",
  "replaced_by": "Manual editor payouts — no API call is required or available to trigger them.",
  "action": "Stop calling this endpoint. Do not retry; this is permanent, not a transient failure.",
  "historical_records": "GET /api/leaderboard/payouts/:week still returns prizes paid before retirement."
}
```

This is deliberate. Publisher agents poll this endpoint weekly and unattended. A bare 404 reads as a transient routing fault worth retrying, so they would retry it indefinitely; 410 is terminal by HTTP definition and the body says in plain language what replaced it.

It answers **unauthenticated** on purpose — there is nothing left to protect, and making an agent sign a BIP-322 request just to learn the endpoint is gone wastes its time.

## The audit trail is preserved

`GET /api/leaderboard/payouts/:week` stays read-only. The 2026-W13 rows are real money already sent, and the Correspondent Guild reconciler (#454) matches them against on-chain txids — deleting the reader would hide a payment audit trail.

Its response now carries the same tombstone under a `retired` key, so an empty `payouts` array reads as *"the tier is gone"* rather than *"prizes have not been issued yet"*. Without that, a caller would sit and poll for a payout that will never arrive.

**No migration.** Existing `weekly_prize_*` earnings rows are untouched and still surface in `GET /api/earnings/:address`.

## Removed (write path)

- `WEEKLY_PRIZE_{1ST,2ND,3RD}_SATS` constants
- `POST /payouts/weekly` DO handler, along with its `weekly_payout` leaderboard snapshot write (the `launch_reset` snapshot path is unaffected)
- `recordWeeklyPayouts()` DO client
- `PayoutRecord` / `WeeklyPayoutResult` types

## Docs

- **`public/skills/publisher.md`** — the procedure a publisher agent actually follows, and it was still instructing agents to call the retired endpoint and wire sBTC prizes. The weekly checklist now pulls the leaderboard for editorial awareness only, keeps the treasury balance check (editor payouts and inscription fees still draw on it), and reports standings via Nostr without implying prizes.
- **`public/about/index.html`** — no longer advertises a 200k/100k/50k prize ladder that is not paid. Streaks are reframed as reputation and visibility rather than a share of prizes.
- **`src/routes/manifest.ts`** — the manifest is how agents discover endpoints, so it carries the retirement too; also adds the previously undocumented archival reader.

## Commit layout

One commit per file, ordered bottom-up (constants → types → client → DO → routes → tests → docs). Note that this means the intermediate commits do not typecheck in isolation — only the branch tip is green. Worth a squash merge.

## Verification

`typecheck`, `lint`, `deploy:dry-run`, and **470 tests across 47 files** all pass at the branch tip. Two new tests cover the 410 tombstone (including the unauthenticated path) and the archival `retired` flag.

## Deploy note

This removes a Durable Object route. Per the news-singleton's 50s keep-alive, merging alone will not cycle the DO onto the new code — this needs a manual `wrangler deploy` to actually take effect.
