### PR TITLE
fix(agents): page the whole agent registry, not the first 1000 (#320)

### DIFF
--- a/src/__tests__/agent-resolver-pagination.test.ts
+++ b/src/__tests__/agent-resolver-pagination.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { resolveAgentNames } from "../services/agent-resolver";
+
+/**
+ * Regression tests for the bulk agent-name fetch pagination (issue #320).
+ *
+ * The bulk path previously stopped after a hardcoded 10 pages (1000 agents).
+ * Once the aibtc.com registry passed that size, every agent beyond index 999
+ * became permanently unresolvable in batch lookups and rendered on the agents
+ * page as a truncated BTC address, even though the registry held a displayName
+ * for them. The loop is now sized from `pagination.total`.
+ */
+
+function makeKV(initial: Record<string, string> = {}): KVNamespace {
+  const store = new Map<string, string>(Object.entries(initial));
+  return {
+    async get(key: string) {
+      return store.get(key) ?? null;
+    },
+    async put(key: string, value: string) {
+      store.set(key, value);
+    },
+    async delete(key: string) {
+      store.delete(key);
+    },
+    async list() {
+      return { keys: [], list_complete: true, cursor: "" };
+    },
+    async getWithMetadata(key: string) {
+      return { value: store.get(key) ?? null, metadata: null };
+    },
+  } as unknown as KVNamespace;
+}
+
+const PAGE_SIZE = 100;
+
+/** Deterministic synthetic registry: agent N lives at index N. */
+function addressAt(index: number): string {
+  return `bc1qagent${String(index).padStart(6, "0")}`;
+}
+
+/**
+ * Stubs the paginated `GET /api/agents` endpoint with a registry of `total`
+ * agents. Returns the spy so tests can assert how many pages were requested.
+ */
+function stubRegistry(total: number) {
+  return vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = new URL(String(input));
+    const offset = Number(url.searchParams.get("offset") ?? "0");
+    const limit = Number(url.searchParams.get("limit") ?? String(PAGE_SIZE));
+
+    const agents = [];
+    for (let i = offset; i < Math.min(offset + limit, total); i++) {
+      agents.push({
+        btcAddress: addressAt(i),
+        displayName: `Agent ${i}`,
+      });
+    }
+
+    return new Response(
+      JSON.stringify({
+        agents,
+        pagination: { total, limit, offset, hasMore: offset + limit < total },
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("resolveAgentNames — registry larger than the old 1000-agent cap", () => {
+  it("resolves an agent past index 999 (the #320 truncation boundary)", async () => {
+    stubRegistry(1049);
+    const kv = makeKV();
+
+    // Index 1048 is the last agent in the registry — on page 10, the first
+    // page the old `page < 10` loop never requested.
+    const target = addressAt(1048);
+    const result = await resolveAgentNames(kv, [target]);
+
+    expect(result.get(target)?.name).toBe("Agent 1048");
+  });
+
+  it("resolves agents on both sides of the boundary in one call", async () => {
+    stubRegistry(1049);
+    const kv = makeKV();
+
+    const early = addressAt(3); // page 0 — worked before the fix
+    const late = addressAt(1002); // page 10 — did not
+    const result = await resolveAgentNames(kv, [early, late]);
+
+    expect(result.get(early)?.name).toBe("Agent 3");
+    expect(result.get(late)?.name).toBe("Agent 1002");
+  });
+
+  it("positively caches a past-boundary name so the next call skips the fetch", async () => {
+    const fetchSpy = stubRegistry(1049);
+    const kv = makeKV();
+    const target = addressAt(1040);
+
+    await resolveAgentNames(kv, [target]);
+    const callsAfterFirst = fetchSpy.mock.calls.length;
+
+    const second = await resolveAgentNames(kv, [target]);
+
+    expect(second.get(target)?.name).toBe("Agent 1040");
+    expect(fetchSpy.mock.calls.length).toBe(callsAfterFirst);
+  });
+
+  it("stops at the real end of the registry rather than walking to the ceiling", async () => {
+    const fetchSpy = stubRegistry(1049);
+    const kv = makeKV();
+
+    await resolveAgentNames(kv, [addressAt(1048)]);
+
+    // 1049 agents / 100 per page = 11 pages (offsets 0..1000). Anything more
+    // means the loop ignored `total`/`hasMore` and kept paging into the void.
+    expect(fetchSpy.mock.calls.length).toBe(11);
+  });
+
+  it("still negative-caches a genuinely absent address once the full registry is read", async () => {
+    const fetchSpy = stubRegistry(1049);
+    const kv = makeKV();
+    const absent = "bc1qnotregisteredanywhere";
+
+    const first = await resolveAgentNames(kv, [absent]);
+    expect(first.get(absent)?.name).toBeNull();
+
+    const callsAfterFirst = fetchSpy.mock.calls.length;
+    const second = await resolveAgentNames(kv, [absent]);
+
+    expect(second.get(absent)?.name).toBeNull();
+    // The negative cache must be written — otherwise every rebuild re-runs the
+    // full multi-page registry pull, which is the cost #867 set out to remove.
+    expect(fetchSpy.mock.calls.length).toBe(callsAfterFirst);
+  });
+
+  it("does not negative-cache when the registry fetch is incomplete", async () => {
+    // Page 0 succeeds and advertises more, page 1 fails: the fetch is partial,
+    // so an unmatched address must not be recorded as "no such agent".
+    let call = 0;
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async () => {
+        call++;
+        if (call === 1) {
+          return new Response(
+            JSON.stringify({
+              agents: [{ btcAddress: addressAt(0), displayName: "Agent 0" }],
+              pagination: { total: 500, limit: PAGE_SIZE, offset: 0, hasMore: true },
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+        return new Response("upstream down", { status: 503 });
+      });
+
+    const kv = makeKV();
+    const absent = addressAt(400);
+
+    await resolveAgentNames(kv, [absent]);
+    const callsAfterFirst = fetchSpy.mock.calls.length;
+
+    await resolveAgentNames(kv, [absent]);
+
+    expect(fetchSpy.mock.calls.length).toBeGreaterThan(callsAfterFirst);
+  });
+});

--- a/src/services/agent-resolver.ts
+++ b/src/services/agent-resolver.ts
@@ -21,7 +21,14 @@ const NEGATIVE_CACHE_TTL_SECONDS = 1800; // 30 minutes for unresolved names
 const CACHE_KEY_PREFIX = "agent-name:";
 const AGENT_API_BASE = "https://aibtc.com/api/agents";
 const BULK_PAGE_SIZE = 100; // max allowed by aibtc.com
-const BULK_MAX_PAGES = 10; // safety cap: 1000 agents max
+// Runaway guard only — NOT a coverage limit. The page loop stops on
+// `pagination.hasMore`, and additionally sizes itself from `pagination.total` on
+// the first page, so this ceiling is never the thing that ends a healthy fetch.
+// It exists so a registry that always reports hasMore cannot spin forever.
+// Keep it comfortably above the real registry size (issue #320: a 10-page cap
+// silently truncated the fetch at 1000 once the registry reached 1049 agents,
+// making every agent past that index permanently unresolvable).
+const BULK_HARD_PAGE_CEILING = 200; // 20,000 agents
 
 export interface AgentInfo {
   name: string | null;
@@ -102,8 +109,11 @@ async function fetchBulkAgents(): Promise<BulkFetchResult> {
   const allAgents = new Map<string, AgentInfo>();
   let offset = 0;
   let complete = false;
+  // Derived from `pagination.total` on the first page; until then, allow the
+  // hard ceiling so the first request can happen at all.
+  let maxPages = BULK_HARD_PAGE_CEILING;
 
-  for (let page = 0; page < BULK_MAX_PAGES; page++) {
+  for (let page = 0; page < maxPages; page++) {
     try {
       const res = await fetch(
         `${AGENT_API_BASE}?limit=${BULK_PAGE_SIZE}&offset=${offset}`,
@@ -117,8 +127,20 @@ async function fetchBulkAgents(): Promise<BulkFetchResult> {
 
       const data = (await res.json()) as {
         agents: Array<Record<string, unknown>>;
-        pagination?: { hasMore?: boolean };
+        pagination?: { hasMore?: boolean; total?: number };
       };
+
+      // Size the loop to the registry the first time we learn how big it is,
+      // so growth past any fixed cap can never silently truncate the fetch.
+      if (page === 0) {
+        const total = data.pagination?.total;
+        if (typeof total === "number" && total > 0) {
+          maxPages = Math.min(
+            Math.ceil(total / BULK_PAGE_SIZE),
+            BULK_HARD_PAGE_CEILING,
+          );
+        }
+      }
 
       for (const agent of data.agents) {
         const btcAddr = agent.btcAddress as string | undefined;


### PR DESCRIPTION
Closes #320.

## Root cause

`fetchBulkAgents()` in `src/services/agent-resolver.ts` capped its pagination loop at a hardcoded `BULK_MAX_PAGES = 10`:

```js
const BULK_PAGE_SIZE = 100; // max allowed by aibtc.com
const BULK_MAX_PAGES = 10;  // safety cap: 1000 agents max

for (let page = 0; page < BULK_MAX_PAGES; page++) { ... }
```

That covers offsets 0–999. The aibtc.com registry now returns `pagination.total: 1049` — **11 pages**. Page 10 was never requested, so every agent past index 999 was unreachable in the batch resolution path and rendered on `/agents` as a truncated BTC address.

## Verification against production

Of the 20 correspondents currently showing an address instead of a name, 9 have an upstream `displayName` (the other 11 are genuinely unnamed — correct fallback). Every one I traced sits on page 10:

| Agent | Rank | Signals | Registry page | Upstream `displayName` |
|---|---|---|---|---|
| Encrypted Zara | 14 | 239 | **10** | `'Encrypted Zara'` |
| Dual Cougar | 45 | 177 | **10** | `'Dual Cougar'` |
| Secret Mars | 49 | 175 | **10** | `'Secret Mars'` |
| Ionic Anvil | 155 | 103 | **10** | `'Ionic Anvil'` |

This also explains why #320 read as intermittent. Its original March screenshot cited *Ionic Anvil* and *Dual Cougar* as the agents displaying **correctly**. They fell off the end as the registry grew past 1,000 — a boundary crossing, not the race condition the issue hypothesised.

## Second-order effect

When the loop exited on the page cap, `hasMore` was still true, so `complete` stayed `false` and the negative-cache write at line 223 was skipped. Those addresses were therefore re-fetched on **every** correspondents rebuild — 10 sequential registry pages, 15s timeout each, all still failing — re-introducing exactly the cold-rebuild cost #867 set out to remove (see #690).

## The fix

The loop now sizes itself from `pagination.total` on the first page, and still stops on `hasMore`. The surviving constant is renamed `BULK_HARD_PAGE_CEILING` and raised to 200 pages, documented as a runaway guard rather than a coverage limit, so registry growth can never silently truncate the fetch again.

## Tests

New `src/__tests__/agent-resolver-pagination.test.ts` covers:

1. Resolving an agent past index 999 (the truncation boundary)
2. Both sides of the boundary in one call
3. Positive caching of a past-boundary name
4. Page-count exactness — 11 pages for 1049 agents, not a walk to the ceiling
5. A genuinely absent address is still negative-cached on a complete fetch
6. No negative-caching when the fetch is incomplete

**5 of the 6 fail against the pre-fix resolver** (verified by reverting). Full suite green: 476 passed, 48 files. `tsc --noEmit` and `biome lint` clean on both changed files.

## Deploy note

This is served by the `news-singleton` DO path via `/api/correspondents` and `/api/init`. Per prior experience the DO keep-alive can block eviction onto new code — a manual `wrangler deploy` may be needed for the change to take effect, and existing negative-cache entries expire within 30 minutes.