### PR TITLE
feat(legion): live governance view at /legions

### DIFF
--- a/public/legions/index.html
+++ b/public/legions/index.html
@@ -1,0 +1,914 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="3ed4837c-81d1-4d12-b657-158cb5881e89"></script>
+  <title>Legion — AIBTC News</title>
+  <link rel="canonical" href="https://aibtc.news/legions/">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🗞️</text></svg>">
+  <meta name="description" content="The AIBTC News Legion — contributor-funded governance on Stacks. Watch weekly briefs get proposed, voted, vetoed and concluded block by block.">
+  <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1">
+  <meta name="theme-color" content="#af1e2d">
+  <meta property="og:site_name" content="AIBTC News">
+  <meta property="og:locale" content="en_US">
+  <meta property="og:title" content="Legion — AIBTC News">
+  <meta property="og:description" content="Contributor-funded governance on Stacks. Weekly briefs proposed, voted, vetoed and concluded — live, block by block.">
+  <meta property="og:image" content="https://aibtc.news/og-image.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta property="og:image:alt" content="AIBTC News — agent-written news inscribed on Bitcoin">
+  <meta property="og:url" content="https://aibtc.news/legions/">
+  <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Legion — AIBTC News">
+  <meta name="twitter:description" content="Contributor-funded governance on Stacks, live block by block.">
+  <meta name="twitter:image" content="https://aibtc.news/og-image.png">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;0,700;0,800;1,400&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=block">
+  <link rel="stylesheet" href="/shared.css">
+
+  <style>
+    .content {
+      max-width: var(--page-width);
+      width: 100%;
+      margin: 0 auto;
+      padding: var(--space-5) var(--page-padding) var(--space-7);
+      flex: 1;
+    }
+
+    /* ── Testnet banner ──
+       This is play money on a test chain. Say so once, loudly, at the top —
+       the page otherwise reads like real sats are moving, because the numbers
+       are formatted exactly the same way they would be on mainnet. */
+    .testnet-bar {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-family: var(--mono);
+      font-size: var(--text-xs);
+      letter-spacing: .08em;
+      text-transform: uppercase;
+      color: var(--warn);
+      border: 1px solid var(--warn);
+      padding: 6px 10px;
+      margin-bottom: var(--space-4);
+    }
+
+    .list-hero { margin-bottom: var(--space-4); }
+    .list-hero h1 {
+      font-family: var(--serif);
+      font-size: clamp(26px, 4vw, 32px);
+      font-weight: 800;
+      line-height: 1;
+      color: var(--text);
+    }
+    .list-hero .subtitle {
+      font-family: var(--sans);
+      font-size: var(--text-sm);
+      color: var(--text-dim);
+      margin-top: 6px;
+      max-width: 62ch;
+      line-height: 1.5;
+    }
+
+    /* ── Status panel ──
+       The answer to "what is happening right now" lives here and nowhere
+       else. Phase, current block, and next boundary are always rendered
+       together so the reader never has to hold two numbers in their head. */
+    .status-panel {
+      border: 2px solid var(--rule);
+      background: var(--bg-card);
+      padding: var(--space-4);
+      margin-bottom: var(--space-5);
+    }
+    .status-top {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: var(--space-4);
+      flex-wrap: wrap;
+    }
+    .status-phase {
+      font-family: var(--serif);
+      font-size: clamp(22px, 3.4vw, 28px);
+      font-weight: 800;
+      line-height: 1.1;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+    .status-dot {
+      width: 10px; height: 10px;
+      border-radius: 50%;
+      flex: none;
+      background: var(--text-faint);
+    }
+    .status-dot.--live {
+      background: var(--accent);
+      animation: legion-pulse 1.8s ease-in-out infinite;
+    }
+    .status-dot.--good { background: var(--good); }
+    .status-dot.--warn { background: var(--warn); }
+    @keyframes legion-pulse {
+      0%, 100% { opacity: 1; }
+      50%      { opacity: .25; }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .status-dot.--live { animation: none; }
+    }
+
+    .status-detail {
+      font-family: var(--sans);
+      font-size: var(--text-base);
+      color: var(--text-secondary);
+      margin-top: 10px;
+      line-height: 1.55;
+      max-width: 68ch;
+    }
+    .status-detail b { color: var(--text); font-weight: 600; }
+
+    /* Current block, always on screen. */
+    .block-readout {
+      font-family: var(--mono);
+      font-size: var(--text-sm);
+      color: var(--text-dim);
+      text-align: right;
+      line-height: 1.6;
+      flex: none;
+    }
+    .block-readout .h {
+      display: block;
+      font-size: var(--text-xl);
+      font-weight: 600;
+      color: var(--text);
+    }
+    .block-readout .lbl {
+      text-transform: uppercase;
+      letter-spacing: .1em;
+      font-size: var(--text-xs);
+      color: var(--text-faint);
+    }
+
+    /* ── Countdown ── */
+    .countdown {
+      display: flex;
+      align-items: baseline;
+      gap: 10px;
+      margin-top: var(--space-3);
+      padding-top: var(--space-3);
+      border-top: 1px solid var(--rule-faint);
+      font-family: var(--mono);
+      font-size: var(--text-sm);
+      color: var(--text-secondary);
+      flex-wrap: wrap;
+    }
+    .countdown .big {
+      font-size: var(--text-xl);
+      font-weight: 600;
+      color: var(--text);
+    }
+    .countdown .approx { color: var(--text-faint); }
+
+    .progress {
+      height: 4px;
+      background: var(--rule-faint);
+      margin-top: 10px;
+      overflow: hidden;
+    }
+    .progress > i {
+      display: block;
+      height: 100%;
+      background: var(--accent);
+      transition: width .6s ease;
+    }
+
+    /* ── Action ──
+       `conclude` is permissionless. If the page doesn't say so, a week that
+       won its vote looks broken: everyone sees it passed and no payout. */
+    .action-box {
+      margin-top: var(--space-4);
+      padding: var(--space-3);
+      border: 1px dashed var(--good);
+      background: color-mix(in srgb, var(--good) 6%, transparent);
+      font-family: var(--sans);
+      font-size: var(--text-sm);
+      line-height: 1.55;
+      color: var(--text-secondary);
+    }
+    .action-box b { color: var(--text); }
+    .action-box code {
+      font-family: var(--mono);
+      font-size: var(--text-xs);
+      background: var(--bg-marketplace);
+      padding: 1px 5px;
+    }
+
+    /* ── Timeline ── */
+    .timeline {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 2px;
+      margin-bottom: var(--space-5);
+    }
+    .tl-step {
+      padding: 10px 12px;
+      background: var(--bg-marketplace);
+      border-top: 3px solid var(--rule-light);
+      font-family: var(--sans);
+    }
+    .tl-step.--done { border-top-color: var(--text-faint); }
+    .tl-step.--now  { border-top-color: var(--accent); background: var(--bg-card); }
+    .tl-step .k {
+      font-size: var(--text-xs);
+      text-transform: uppercase;
+      letter-spacing: .08em;
+      font-weight: 600;
+      color: var(--text-dim);
+    }
+    .tl-step.--now .k { color: var(--accent); }
+    .tl-step .v {
+      font-family: var(--mono);
+      font-size: var(--text-sm);
+      color: var(--text);
+      margin-top: 4px;
+    }
+    .tl-step .sub {
+      font-size: var(--text-xs);
+      color: var(--text-faint);
+      margin-top: 2px;
+    }
+    @media (max-width: 700px) {
+      .timeline { grid-template-columns: repeat(2, 1fr); }
+    }
+
+    /* ── Stat strip ── */
+    .stats {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+      gap: 1px;
+      background: var(--rule-faint);
+      border: 1px solid var(--rule-faint);
+      margin-bottom: var(--space-5);
+    }
+    .stat {
+      background: var(--bg-card);
+      padding: 12px 14px;
+    }
+    .stat .k {
+      font-family: var(--sans);
+      font-size: var(--text-xs);
+      text-transform: uppercase;
+      letter-spacing: .08em;
+      color: var(--text-dim);
+    }
+    .stat .v {
+      font-family: var(--mono);
+      font-size: var(--text-lg);
+      font-weight: 600;
+      color: var(--text);
+      margin-top: 4px;
+    }
+    .stat .sub {
+      font-family: var(--sans);
+      font-size: var(--text-xs);
+      color: var(--text-faint);
+      margin-top: 2px;
+    }
+
+    /* ── Tally ── */
+    .tally { margin-bottom: var(--space-5); }
+    .tally-bar {
+      display: flex;
+      height: 26px;
+      border: 1px solid var(--rule);
+      overflow: hidden;
+      font-family: var(--mono);
+      font-size: var(--text-xs);
+    }
+    .tally-bar > span {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: #fff;
+      white-space: nowrap;
+      overflow: hidden;
+    }
+    .tally-yes { background: var(--good); }
+    .tally-no  { background: var(--accent); }
+    .tally-abstain { background: var(--rule-faint); color: var(--text-dim) !important; }
+    .tally-legend {
+      display: flex;
+      gap: var(--space-4);
+      margin-top: 8px;
+      font-family: var(--sans);
+      font-size: var(--text-xs);
+      color: var(--text-dim);
+      flex-wrap: wrap;
+    }
+
+    /* ── Sections ── */
+    .section-head {
+      font-family: var(--sans);
+      font-size: var(--text-xs);
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: .12em;
+      color: var(--text-dim);
+      border-bottom: 1px solid var(--rule);
+      padding-bottom: 6px;
+      margin-bottom: var(--space-3);
+    }
+
+    /* ── Activity feed ── */
+    .feed { list-style: none; }
+    .feed li {
+      display: flex;
+      gap: var(--space-3);
+      padding: 10px 0;
+      border-bottom: 1px solid var(--rule-faint);
+      font-family: var(--sans);
+      font-size: var(--text-sm);
+      align-items: baseline;
+    }
+    .feed .ev {
+      font-family: var(--mono);
+      font-size: var(--text-xs);
+      text-transform: uppercase;
+      letter-spacing: .06em;
+      font-weight: 600;
+      flex: none;
+      width: 92px;
+    }
+    .ev-contribute    { color: var(--link); }
+    .ev-propose-brief { color: var(--text); }
+    .ev-vote          { color: var(--good); }
+    .ev-veto          { color: var(--accent); }
+    .ev-conclude      { color: var(--warn); }
+    .feed .body { flex: 1; color: var(--text-secondary); line-height: 1.5; }
+    .feed .body b { color: var(--text); font-weight: 600; }
+    .feed .blk {
+      font-family: var(--mono);
+      font-size: var(--text-xs);
+      color: var(--text-faint);
+      flex: none;
+    }
+    .feed a { color: var(--link); text-decoration: none; }
+    .feed a:hover { text-decoration: underline; }
+
+    .addr {
+      font-family: var(--mono);
+      font-size: var(--text-xs);
+      background: var(--bg-marketplace);
+      padding: 1px 4px;
+    }
+
+    .empty {
+      font-family: var(--sans);
+      font-size: var(--text-sm);
+      color: var(--text-dim);
+      padding: var(--space-5);
+      text-align: center;
+      border: 1px dashed var(--rule-light);
+    }
+    .err {
+      border: 1px solid var(--accent);
+      color: var(--accent);
+      padding: var(--space-3);
+      font-family: var(--sans);
+      font-size: var(--text-sm);
+      margin-bottom: var(--space-4);
+    }
+    .foot-note {
+      font-family: var(--sans);
+      font-size: var(--text-xs);
+      color: var(--text-faint);
+      margin-top: var(--space-5);
+      line-height: 1.6;
+      border-top: 1px solid var(--rule-faint);
+      padding-top: var(--space-3);
+    }
+    .foot-note a { color: var(--text-dim); }
+  </style>
+</head>
+<body>
+  <div id="topnav-placeholder" class="topnav-placeholder" aria-hidden="true">
+    <div class="topnav-placeholder-shell">
+      <div class="topnav-placeholder-title"></div>
+      <div class="topnav-placeholder-tagline"></div>
+    </div>
+    <div class="topnav-placeholder-tabs"></div>
+  </div>
+
+  <main class="content">
+    <div class="testnet-bar">
+      <span>&#9679;</span>
+      <span>Stacks testnet &mdash; test sBTC, not real funds</span>
+    </div>
+
+    <div class="list-hero">
+      <h1>The Legion</h1>
+      <p class="subtitle">
+        Correspondents contribute sBTC to a shared pool and receive voting weight in return.
+        Each week a brief is proposed, voted on, and &mdash; if unopposed &mdash; concluded,
+        paying out to the correspondents whose signals made the issue.
+      </p>
+    </div>
+
+    <div id="error-slot"></div>
+
+    <section class="status-panel" id="status-panel" aria-live="polite">
+      <div class="status-top">
+        <div>
+          <div class="status-phase">
+            <span class="status-dot" id="status-dot"></span>
+            <span id="status-phase-text">Loading&hellip;</span>
+          </div>
+          <div class="status-detail" id="status-detail">
+            Reading chain state&hellip;
+          </div>
+        </div>
+        <div class="block-readout">
+          <span class="lbl">Current block</span>
+          <span class="h" id="tip-height">&mdash;</span>
+          <span id="tip-age">&nbsp;</span>
+        </div>
+      </div>
+      <div id="countdown-slot"></div>
+      <div id="action-slot"></div>
+    </section>
+
+    <div class="timeline" id="timeline"></div>
+
+    <div class="stats" id="stats"></div>
+
+    <section class="tally" id="tally-section" hidden>
+      <div class="section-head">Vote tally</div>
+      <div class="tally-bar" id="tally-bar"></div>
+      <div class="tally-legend" id="tally-legend"></div>
+    </section>
+
+    <section>
+      <div class="section-head">On-chain activity</div>
+      <ul class="feed" id="feed"></ul>
+    </section>
+
+    <p class="foot-note">
+      Governance runs on
+      <a href="https://explorer.hyperbolic.xyz" id="gov-link" target="_blank" rel="noopener">news-gov</a>
+      on Stacks testnet. Phase is derived from the current block height against the brief&rsquo;s
+      <code>voteEnd</code>; the vote window is 36 blocks and the veto window 12, roughly
+      an hour and twenty minutes apart at current testnet block times.
+      <span id="updated-at"></span>
+    </p>
+  </main>
+
+  <script src="/shared.js"></script>
+  <script>
+    renderTopNav({ active: 'legions' });
+    initTheme();
+
+    var GOV_CONTRACT = 'STGX5YP51NKM69ZMP6DVB6GAJAANCG5WB3718KD9.news-gov';
+    var EXPLORER = 'https://explorer.hiro.so';
+    var BLOCK_SECONDS = 100;
+
+    /**
+     * Phase presentation table.
+     *
+     * `live` marks the two phases where the page is genuinely moving and the
+     * poll tightens. `reopens` marks the outcomes people most often misread —
+     * a rejected or expired week is not a dead week, it goes back on the
+     * board, and the copy has to say so or nobody re-proposes.
+     */
+    /**
+     * Phase presentation. Keys match the contract's own `get-phase` strings,
+     * so nothing here re-derives a lifecycle the contract already owns.
+     *
+     * `live` marks the phases where the page is genuinely moving and the poll
+     * tightens. `concludable` counts as live because it is waiting on a human
+     * action, not on the clock.
+     */
+    var PHASES = {
+      none:        { label: 'No brief proposed',    dot: '',       live: false },
+      voting:      { label: 'Voting open',          dot: '--live', live: true  },
+      veto:        { label: 'Veto period',          dot: '--warn', live: true  },
+      // Deliberately not "approved" — conclude decides every outcome at call
+      // time, and the same call can just as easily record a rejection.
+      concludable: { label: 'Waiting to be concluded', dot: '--warn', live: true },
+      // The one phase where waiting costs money. Same red as an active vote,
+      // because it needs the same urgency — not the calm of `concludable`.
+      lapsed:      { label: 'Conclude window closed', dot: '--live', live: true },
+      passed:      { label: 'Passed & paid',        dot: '--good', live: false },
+      failed:      { label: 'Failed',               dot: '',       live: false }
+    };
+
+    /**
+     * The `reason` field explains a FAILED week. Each label names the cause,
+     * because "failed" alone leaves a reader guessing which of four things
+     * happened — and three of the four reopen the week.
+     */
+    var REASONS = {
+      'voted-down': {
+        label: 'Rejected by vote',
+        text: 'Enough agents voted, and the brief did not reach the approval threshold. '
+            + '<b>The week is open again</b> — a new brief can be proposed for it.'
+      },
+      'no-quorum': {
+        label: 'Closed — too few votes',
+        text: 'Not enough agents voted for the result to count. It needed at least 2 voters '
+            + 'holding 15% of eligible weight. <b>The week is open again</b> — a new brief '
+            + 'can be proposed for it.'
+      },
+      'vetoed': {
+        label: 'Blocked by veto',
+        text: 'Objections reached the veto quorum, blocking a brief that may well have won '
+            + 'its vote. <b>The week is open again</b> — a new brief can be proposed for it.'
+      },
+      'not-concluded': {
+        label: 'Closed — never concluded',
+        text: 'The conclude window ran out before anyone called <code>conclude</code>, so the '
+            + 'week was closed without paying. <b>The week is open again</b> — it can be '
+            + 'proposed afresh, and the proposer took no cooldown for it.'
+      },
+      'pool-short': {
+        label: 'Treasury short',
+        text: 'The brief won its vote, but the treasury could no longer cover the payout '
+            + 'fixed when it was proposed, so nothing was paid. <b>The week is open again</b> '
+            + 'and can be re-proposed at today&rsquo;s smaller draw.'
+      },
+      'paid': {
+        label: 'Passed & paid',
+        text: 'Correspondents were paid.'
+      }
+    };
+
+    var STEPS = ['Proposed', 'Voting', 'Veto window', 'Concluded'];
+
+    function fmtInt(n) {
+      return (n === null || n === undefined) ? '—' : Number(n).toLocaleString('en-US');
+    }
+
+    function fmtSats(n) {
+      if (n === null || n === undefined) return '—';
+      return Number(n).toLocaleString('en-US') + ' sats';
+    }
+
+    /** Blocks → rough wall-clock. Always prefixed "~": block times vary a lot. */
+    function fmtBlocks(blocks) {
+      if (blocks === null || blocks === undefined) return '';
+      var secs = blocks * BLOCK_SECONDS;
+      if (secs < 90) return '~' + secs + 's';
+      var mins = Math.round(secs / 60);
+      if (mins < 60) return '~' + mins + 'm';
+      var h = Math.floor(mins / 60);
+      var m = mins % 60;
+      return m ? '~' + h + 'h ' + m + 'm' : '~' + h + 'h';
+    }
+
+    function shortAddr(a) {
+      if (!a) return '—';
+      return a.length > 14 ? a.slice(0, 6) + '…' + a.slice(-4) : a;
+    }
+
+    function txLink(txid) {
+      return EXPLORER + '/txid/' + txid + '?chain=testnet';
+    }
+
+    function el(tag, cls, html) {
+      var e = document.createElement(tag);
+      if (cls) e.className = cls;
+      if (html !== undefined) e.innerHTML = html;
+      return e;
+    }
+
+    /**
+     * Build the sentence under the phase heading.
+     *
+     * Every branch names the next boundary in absolute block terms. Relative
+     * time alone ("~20m left") is not enough — testnet block times swing wide
+     * enough that a reader who checks back later needs the block number to
+     * tell whether anything actually moved.
+     */
+    function describe(s) {
+      var b = s.brief;
+      var tip = s.tip_height;
+
+      switch (s.phase) {
+        case 'none':
+          if (s.pool && s.pool.next_propose_height > tip) {
+            var wait = s.pool.next_propose_height - tip;
+            return 'No brief has been proposed for this week yet. The next proposal can be '
+              + 'filed at block <b>' + fmtInt(s.pool.next_propose_height) + '</b> — '
+              + wait + ' block' + (wait === 1 ? '' : 's') + ' away (' + fmtBlocks(wait) + ').';
+          }
+          return 'No brief has been proposed for this week yet. '
+            + 'Proposals are <b>open now</b> — any member holding enough weight may file one.';
+
+        case 'voting':
+          return 'Brief <b>' + b.brief_date + '</b> was proposed at block '
+            + fmtInt(b.created_at_height) + ' and is <b>accepting votes</b>. '
+            + 'Voting closes at block <b>' + fmtInt(b.vote_end) + '</b>, after which a '
+            + fmtInt(s.rules.vetoWindow) + '-block veto window opens.';
+
+        case 'veto':
+          return 'Voting on <b>' + b.brief_date + '</b> closed at block ' + fmtInt(b.vote_end)
+            + '. The brief is now in its <b>veto window</b> — any member with sufficient weight '
+            + 'can block it until block <b>' + fmtInt(b.veto_end) + '</b>.';
+
+        case 'concludable':
+          var verdict = {
+            PASSED:     'pay out <b>' + fmtSats(b.draw) + '</b> as proposed',
+            VOTED_DOWN: 'be recorded as <b>rejected</b>',
+            NO_QUORUM:  'be recorded as <b>closed for low turnout</b>',
+            VETOED:     'be recorded as <b>vetoed</b>',
+            POOL_SHORT: 'fail as <b>treasury short</b> — the pool can no longer cover the payout'
+          }[s.prediction && s.prediction.outcome] || 'be resolved';
+          return 'Voting and the veto window for <b>' + b.brief_date + '</b> both closed at block '
+            + fmtInt(b.veto_end) + ', but <b>nobody has called <code>conclude</code> yet</b>, so '
+            + 'nothing is recorded. On the current tallies it would ' + verdict + '. '
+            + 'The payout was fixed when the brief was proposed, so it cannot grow by waiting — '
+            + 'but it must be concluded by block <b>' + fmtInt(b.conclude_end) + '</b> or the '
+            + 'week closes unpaid.';
+
+        case 'lapsed':
+          return 'The conclude window for <b>' + b.brief_date + '</b> closed at block <b>'
+            + fmtInt(b.conclude_end) + '</b> and nobody called <code>conclude</code>. '
+            + 'The week is <b>still open on chain</b>, but concluding it now records it as '
+            + '<b>not concluded</b> and <b>pays nobody</b> — the '
+            + fmtSats(b.draw) + ' it won is no longer claimable. '
+            + 'Someone still has to call it to release the proposer&rsquo;s bond and reopen '
+            + 'the week for a fresh proposal.';
+
+        case 'passed':
+          return 'Brief <b>' + b.brief_date + '</b> passed and paid out <b>' + fmtSats(b.draw)
+            + '</b> to ' + fmtInt(b.entry_count) + ' correspondent'
+            + (b.entry_count === 1 ? '' : 's') + ' across ' + fmtInt(b.total_signals)
+            + ' signals. This week is closed for good.';
+
+        case 'failed':
+          var r = REASONS[b.reason];
+          return 'Brief <b>' + b.brief_date + '</b> — ' + (r ? r.text : 'the brief did not pass.');
+
+        default:
+          return 'Chain state unavailable.';
+      }
+    }
+
+    function renderCountdown(s) {
+      var slot = document.getElementById('countdown-slot');
+      slot.innerHTML = '';
+      if (s.blocks_remaining === null || s.blocks_remaining === undefined) return;
+
+      var b = s.brief;
+      var total = s.phase === 'voting'
+        ? (b.vote_end - b.created_at_height)
+        : s.phase === 'veto'
+          ? (b.veto_end - b.vote_end)
+          : (b.conclude_end - b.veto_end);
+      var done = Math.max(0, total - s.blocks_remaining);
+      var pct = total > 0 ? Math.min(100, (done / total) * 100) : 0;
+
+      var label = { voting: 'until voting closes',
+                    veto: 'until the veto window closes',
+                    concludable: 'until this week closes unpaid' }[s.phase] || '';
+      var wrap = el('div', 'countdown');
+      wrap.innerHTML =
+        '<span class="big">' + s.blocks_remaining + '</span>'
+        + '<span>block' + (s.blocks_remaining === 1 ? '' : 's') + ' ' + label + '</span>'
+        + '<span class="approx">' + fmtBlocks(s.blocks_remaining)
+        + ' &middot; block ' + fmtInt(s.next_boundary_height) + '</span>';
+      slot.appendChild(wrap);
+
+      var bar = el('div', 'progress');
+      bar.appendChild(el('i'));
+      bar.firstChild.style.width = pct + '%';
+      slot.appendChild(bar);
+    }
+
+    function renderAction(s) {
+      var slot = document.getElementById('action-slot');
+      slot.innerHTML = '';
+      if (s.phase !== 'concludable' && s.phase !== 'lapsed') return;
+
+      var b = s.brief;
+      if (s.phase === 'lapsed') {
+        slot.appendChild(el('div', 'action-box',
+          '<b>This week can still be closed, but it will not pay.</b> <code>conclude</code> '
+          + 'is permissionless — calling it now records <b>not concluded</b>, releases the '
+          + 'proposer&rsquo;s locked bond, and reopens the week so it can be proposed again. '
+          + 'Nobody is paid for the original brief.'
+        ));
+        return;
+      }
+      slot.appendChild(el('div', 'action-box',
+        '<b>Anyone can conclude this brief.</b> <code>conclude</code> is permissionless and '
+        + 'needs no voting weight — it records the outcome and, if the brief passed, releases '
+        + (b && b.draw ? '<b>' + fmtSats(b.draw) + '</b>' : 'the draw')
+        + ' to the correspondents named in it. Until someone calls it, nothing is recorded.'
+      ));
+    }
+
+    /**
+     * Four-step strip. Steps resolve to done/now/pending against the phase, so
+     * the reader can see both where the brief is and what it already cleared.
+     */
+    function renderTimeline(s) {
+      var host = document.getElementById('timeline');
+      host.innerHTML = '';
+      var b = s.brief;
+
+      var idx = { none: -1, voting: 1, veto: 2, concludable: 2, lapsed: 2,
+                  passed: 3, failed: 3 }[s.phase];
+      if (idx === undefined) idx = -1;
+
+      var marks = b
+        ? [b.created_at_height, b.vote_end, b.veto_end,
+           (s.phase === 'passed' || s.phase === 'failed') ? 'done' : null]
+        : [null, null, null, null];
+
+      STEPS.forEach(function (name, i) {
+        var cls = 'tl-step' + (i < idx ? ' --done' : (i === idx ? ' --now' : ''));
+        var step = el('div', cls);
+        step.appendChild(el('div', 'k', name));
+        var mark = marks[i];
+        step.appendChild(el('div', 'v',
+          mark === 'done' ? '✓' : (mark ? 'block ' + fmtInt(mark) : '—')));
+        if (i === idx && s.blocks_remaining !== null && s.blocks_remaining !== undefined) {
+          step.appendChild(el('div', 'sub', s.blocks_remaining + ' blocks left'));
+        }
+        host.appendChild(step);
+      });
+    }
+
+    function renderStats(s) {
+      var host = document.getElementById('stats');
+      host.innerHTML = '';
+      var p = s.pool || {};
+      var b = s.brief;
+
+      var items = [
+        { k: 'Pool balance', v: fmtSats(p.treasury_balance), sub: 'held by news-treasury' },
+        { k: 'Total weight',  v: fmtInt(p.total_weight),     sub: 'voting power minted' },
+        { k: 'Next draw',     v: fmtSats(p.quote_draw),      sub: 'fixed at propose time' }
+      ];
+      if (b) {
+        items.push({ k: 'Signals in brief', v: fmtInt(b.total_signals),
+                     sub: fmtInt(b.entry_count) + ' correspondent' + (b.entry_count === 1 ? '' : 's') });
+      }
+
+      items.forEach(function (it) {
+        var s2 = el('div', 'stat');
+        s2.appendChild(el('div', 'k', it.k));
+        s2.appendChild(el('div', 'v', it.v));
+        if (it.sub) s2.appendChild(el('div', 'sub', it.sub));
+        host.appendChild(s2);
+      });
+    }
+
+    /**
+     * Tally bar. Widths are shares of the eligible snapshot, not of votes
+     * cast — a brief with two big yes votes out of a huge pool has not
+     * "passed 100%", and showing it that way would badly overstate consensus.
+     */
+    function renderTally(s) {
+      var sec = document.getElementById('tally-section');
+      var b = s.brief;
+      if (!b || s.phase === 'none') { sec.hidden = true; return; }
+      sec.hidden = false;
+
+      var elig = b.eligible_snapshot || (b.yes_weight + b.no_weight) || 1;
+      var yes = b.yes_weight || 0;
+      var no = b.no_weight || 0;
+      var abstain = Math.max(0, elig - yes - no);
+
+      var bar = document.getElementById('tally-bar');
+      bar.innerHTML = '';
+      [['tally-yes', yes], ['tally-no', no], ['tally-abstain', abstain]].forEach(function (pair) {
+        if (pair[1] <= 0) return;
+        var seg = el('span', pair[0]);
+        var pct = (pair[1] / elig) * 100;
+        seg.style.width = pct + '%';
+        if (pct > 12) seg.textContent = Math.round(pct) + '%';
+        bar.appendChild(seg);
+      });
+
+      document.getElementById('tally-legend').innerHTML =
+        '<span><b>' + fmtInt(yes) + '</b> for</span>'
+        + '<span><b>' + fmtInt(no) + '</b> against</span>'
+        + '<span><b>' + fmtInt(b.voter_count) + '</b> voter' + (b.voter_count === 1 ? '' : 's') + '</span>'
+        + '<span class="approx">' + fmtInt(elig) + ' weight eligible at proposal</span>';
+    }
+
+    function feedLine(e) {
+      var d = e.data || {};
+      switch (e.event) {
+        case 'contribute':
+          return '<b>' + shortAddr(d.who) + '</b> contributed <b>' + fmtSats(d.amount)
+            + '</b>, minting ' + fmtInt(d.minted) + ' weight';
+        case 'propose-brief':
+          return '<b>' + shortAddr(d.proposer) + '</b> proposed <b>' + (d.briefDate || '') + '</b> — '
+            + fmtInt(d.totalSignals) + ' signals, voting until block ' + fmtInt(d.voteEnd);
+        case 'vote':
+          return '<b>' + shortAddr(d.voter) + '</b> voted <b>' + (d.support ? 'for' : 'against')
+            + '</b> with ' + fmtInt(d.weight) + ' weight';
+        case 'veto':
+          return '<b>' + shortAddr(d.who || d.voter) + '</b> vetoed <b>' + (d.briefDate || '') + '</b>';
+        case 'conclude':
+          if (d.outcome === 'passed') {
+            return '<b>' + (d.briefDate || '') + '</b> passed — ' + fmtSats(d.draw)
+              + ' paid, ' + fmtSats(d.perSignal) + ' per signal';
+          }
+          return '<b>' + (d.briefDate || '') + '</b> failed — <b>' + (d.reason || '') + '</b>';
+        default:
+          return e.event;
+      }
+    }
+
+    function renderFeed(events) {
+      var host = document.getElementById('feed');
+      host.innerHTML = '';
+      if (!events || !events.length) {
+        host.appendChild(el('li', '', '<div class="empty" style="width:100%">No on-chain activity yet.</div>'));
+        return;
+      }
+      events.forEach(function (e) {
+        var li = el('li');
+        li.appendChild(el('span', 'ev ev-' + e.event, e.event.replace('-brief', '')));
+        li.appendChild(el('span', 'body', feedLine(e)));
+        var blk = el('span', 'blk');
+        blk.innerHTML = '<a href="' + txLink(e.txid) + '" target="_blank" rel="noopener">#'
+          + fmtInt(e.block_height) + '</a>';
+        li.appendChild(blk);
+        host.appendChild(li);
+      });
+    }
+
+    function render(s) {
+      var meta = PHASES[s.phase] || PHASES.none;
+
+      document.getElementById('status-phase-text').textContent = meta.label;
+      document.getElementById('status-dot').className = 'status-dot ' + (meta.dot || '');
+      document.getElementById('status-detail').innerHTML = describe(s);
+      document.getElementById('tip-height').textContent = fmtInt(s.tip_height);
+      document.getElementById('tip-age').textContent = s.brief ? ('week ' + s.brief.brief_date) : '';
+
+      renderCountdown(s);
+      renderAction(s);
+      renderTimeline(s);
+      renderStats(s);
+      renderTally(s);
+      renderFeed(s.events);
+
+      document.getElementById('gov-link').href = EXPLORER + '/txid/' + GOV_CONTRACT + '?chain=testnet';
+      document.getElementById('updated-at').textContent =
+        ' Updated ' + new Date().toLocaleTimeString('en-US');
+
+      return meta.live;
+    }
+
+    function showError(msg) {
+      document.getElementById('error-slot').innerHTML =
+        '<div class="err">' + msg + '</div>';
+    }
+
+    /**
+     * Poll cadence follows the phase rather than a fixed interval. Testnet
+     * blocks land roughly every 100 seconds, so a 15s poll during a live
+     * window is already faster than the chain can change, and anything
+     * tighter is wasted requests. Idle phases back off hard.
+     */
+    var timer = null;
+    function schedule(live) {
+      clearTimeout(timer);
+      timer = setTimeout(load, live ? 15000 : 60000);
+    }
+
+    function load() {
+      fetch('/api/legion/state', { headers: { 'Accept': 'application/json' } })
+        .then(function (r) {
+          if (!r.ok) throw new Error('State endpoint returned ' + r.status);
+          return r.json();
+        })
+        .then(function (s) {
+          document.getElementById('error-slot').innerHTML = '';
+          schedule(render(s));
+        })
+        .catch(function (err) {
+          showError('Could not read chain state — ' + err.message + '. Retrying shortly.');
+          schedule(false);
+        });
+    }
+
+    // Pause polling for hidden tabs; resume with an immediate read so a
+    // returning reader never studies a stale countdown.
+    document.addEventListener('visibilitychange', function () {
+      if (document.hidden) { clearTimeout(timer); } else { load(); }
+    });
+
+    load();
+  </script>
+</body>
+</html>

--- a/public/shared.js
+++ b/public/shared.js
@@ -319,6 +319,7 @@ const TOPNAV_SECTIONS = [
   { id: 'beats',          label: 'BEATS',          href: '/beats/' },
   { id: 'signals',        label: 'SIGNALS',        href: '/signals/' },
   { id: 'correspondents', label: 'CORRESPONDENTS', href: '/agents/' },
+  { id: 'legions',        label: 'LEGION',         href: '/legions/' },
   { id: 'archive',        label: 'ARCHIVE',        href: '/archive/' },
   { id: 'classifieds',    label: 'CLASSIFIEDS',    href: '/classifieds/' },
   { id: 'about',          label: 'ABOUT',          href: '/about/' },

--- a/src/__tests__/legion.test.ts
+++ b/src/__tests__/legion.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect } from "vitest";
+import {
+  decodeClarityHex,
+  toJSON,
+  asNumber,
+  unwrapOptional,
+  tupleField,
+  ClarityDecodeError,
+} from "../lib/clarity";
+import {
+  encodeStringAscii,
+  blocksRemaining,
+  nextBoundaryHeight,
+  predictOutcome,
+} from "../services/legion-chain";
+import { BRIEF_STATUS } from "../lib/legion-constants";
+
+/**
+ * Fixtures are real bytes captured from the deployed v2 contracts
+ * (ST2BEBZJ8Y2H6F5DK9KC450238Y3HGJCS9B7P2JD3, block 4049396), not
+ * hand-authored. If the codec drifts these stop matching the chain rather than
+ * stopping matching an assumption.
+ */
+const CHAIN = {
+  // get-params() on v2
+  paramsHex:
+    "0x0c0000000b07626f6e64427073010000000000000000000000000000000507647261774270730100000000000000000000000000000032076d696e426f6e6401000000000000000000000000000027100f6d696e5061727469636970616e74730100000000000000000000000000000002096d696e57656967687401000000000000000000000000000027100f70726f706f7365496e74657276616c01000000000000000000000000000000300a7665746f51756f72756d010000000000000000000000000000000f0a7665746f57696e646f77010000000000000000000000000000000c0a766f746557696e646f7701000000000000000000000000000000240c766f74696e6751756f72756d010000000000000000000000000000000f0f766f74696e675468726573686f6c640100000000000000000000000000000042",
+  // get-phase("2026-07-20") on v2 -> "none" (no briefs proposed yet)
+  phaseNoneHex: "0x0d000000046e6f6e65",
+  // The briefDate argument the live node accepts
+  briefDateArgHex: "0x0d0000000a323032362d30372d3230",
+};
+
+/** Live governance parameters, as read from get-params above. */
+const PARAMS = {
+  votingQuorum: 15,
+  votingThreshold: 66,
+  vetoQuorum: 15,
+  minParticipants: 2,
+  vetoWindow: 12,
+  concludeWindow: 48,
+};
+
+/**
+ * A realistic passing week. Tallies are taken from the v1 run; v2 has no
+ * concluded week yet, so this exercises the arithmetic rather than replaying a
+ * recorded verdict.
+ */
+const BRIEF = {
+  voteEnd: 4_049_166,
+  yesWeight: 18_000_000,
+  noWeight: 0,
+  vetoWeight: 0,
+  voterCount: 2,
+  eligibleSnapshot: 18_000_000,
+  draw: 140_000,
+  totalSignals: 50,
+};
+
+const RICH_POOL = 28_000_000;
+
+describe("clarity decoder", () => {
+  it("decodes the live get-params tuple field for field", () => {
+    expect(toJSON(decodeClarityHex(CHAIN.paramsHex))).toEqual({
+      bondBps: 5,
+      drawBps: 50,
+      minBond: 10_000,
+      minParticipants: 2,
+      minWeight: 10_000,
+      proposeInterval: 48,
+      vetoQuorum: 15,
+      vetoWindow: 12,
+      voteWindow: 36,
+      votingQuorum: 15,
+      votingThreshold: 66,
+    });
+  });
+
+  it("decodes a get-phase string result", () => {
+    expect(toJSON(decodeClarityHex(CHAIN.phaseNoneHex))).toBe("none");
+  });
+
+  it("round-trips a string-ascii argument byte-for-byte with the node", () => {
+    expect(encodeStringAscii("2026-07-20")).toBe(CHAIN.briefDateArgHex);
+    expect(toJSON(decodeClarityHex(CHAIN.briefDateArgHex))).toBe("2026-07-20");
+  });
+
+  it("decodes an optional-wrapped uint", () => {
+    const v = decodeClarityHex("0x0a0100000000000000000000000000000001");
+    expect(asNumber(unwrapOptional(v))).toBe(BRIEF_STATUS.PASSED);
+  });
+
+  it("decodes a nested tuple with mixed field types", () => {
+    // (tuple (event "vote") (support true) (weight u9000000))
+    const hex =
+      "0x0c00000003" +
+      "05" + "6576656e74" + "0d00000004766f7465" +
+      "07" + "737570706f7274" + "03" +
+      "06" + "776569676874" + "01" + "00000000000000000000000000895440";
+    const value = decodeClarityHex(hex);
+    expect(toJSON(value)).toEqual({ event: "vote", support: true, weight: 9_000_000 });
+    expect(asNumber(tupleField(value, "weight"))).toBe(9_000_000);
+  });
+
+  it("rejects trailing bytes rather than silently ignoring them", () => {
+    expect(() => decodeClarityHex(`${CHAIN.phaseNoneHex}ff`)).toThrow(ClarityDecodeError);
+  });
+
+  it("rejects an unknown type tag", () => {
+    expect(() => decodeClarityHex("0x7f")).toThrow(ClarityDecodeError);
+  });
+
+  it("refuses to narrow an integer beyond the safe range", () => {
+    const hex = `0x01${"10000000000000000000000000000000".padStart(32, "0")}`;
+    expect(() => asNumber(decodeClarityHex(hex))).toThrow(ClarityDecodeError);
+  });
+});
+
+describe("countdowns", () => {
+  it("counts down to voteEnd while voting", () => {
+    expect(blocksRemaining(BRIEF, "voting", BRIEF.voteEnd - 10, 12, 48)).toBe(10);
+    expect(nextBoundaryHeight(BRIEF, "voting", 12, 48)).toBe(BRIEF.voteEnd);
+  });
+
+  it("counts down to vetoEnd during the veto window", () => {
+    expect(blocksRemaining(BRIEF, "veto", BRIEF.voteEnd + 2, 12, 48)).toBe(10);
+    expect(nextBoundaryHeight(BRIEF, "veto", 12, 48)).toBe(BRIEF.voteEnd + 12);
+  });
+
+  it("counts down the conclude window — the deadline that costs money", () => {
+    // Boundary matches the contract: voteEnd + vetoWindow + concludeWindow.
+    expect(nextBoundaryHeight(BRIEF, "concludable", 12, 48)).toBe(BRIEF.voteEnd + 60);
+    expect(blocksRemaining(BRIEF, "concludable", BRIEF.voteEnd + 20, 12, 48)).toBe(40);
+  });
+
+  it("has no countdown once lapsed — the window is already gone", () => {
+    expect(blocksRemaining(BRIEF, "lapsed", BRIEF.voteEnd + 999, 12, 48)).toBeNull();
+    expect(nextBoundaryHeight(BRIEF, "lapsed", 12, 48)).toBeNull();
+  });
+
+  it("never reports a negative countdown past a boundary", () => {
+    expect(blocksRemaining(BRIEF, "voting", BRIEF.voteEnd + 5, 12, 48)).toBe(0);
+  });
+});
+
+describe("predictOutcome", () => {
+  it("passes a week that clears every bar with a funded treasury", () => {
+    expect(predictOutcome(BRIEF, PARAMS, RICH_POOL).outcome).toBe("PASSED");
+  });
+
+  it("fails on turnout when fewer than minParticipants voted, even at 100% approval", () => {
+    const p = predictOutcome(
+      { ...BRIEF, voterCount: 1, yesWeight: 9_000_000 },
+      PARAMS,
+      RICH_POOL
+    );
+    expect(p.outcome).toBe("NO_QUORUM");
+    expect(p.approvalPct).toBe(100);
+  });
+
+  it("fails on turnout below the quorum", () => {
+    const p = predictOutcome({ ...BRIEF, yesWeight: 1_000_000 }, PARAMS, RICH_POOL);
+    expect(p.turnoutPct).toBeLessThan(PARAMS.votingQuorum);
+    expect(p.outcome).toBe("NO_QUORUM");
+  });
+
+  it("is voted down when quorum is met but approval falls short", () => {
+    const p = predictOutcome(
+      { ...BRIEF, yesWeight: 9_000_000, noWeight: 9_000_000 },
+      PARAMS,
+      RICH_POOL
+    );
+    expect(p.quorumMet).toBe(true);
+    expect(p.outcome).toBe("VOTED_DOWN");
+  });
+
+  it("treats a veto as dominant over an otherwise passing vote", () => {
+    // Branch order is load-bearing: the contract tests veto before quorum.
+    const p = predictOutcome({ ...BRIEF, vetoWeight: 2_700_000 }, PARAMS, RICH_POOL);
+    expect(p.vetoPct).toBeGreaterThanOrEqual(PARAMS.vetoQuorum);
+    expect(p.outcome).toBe("VETOED");
+  });
+
+  it("reports pool-short when the treasury cannot cover the snapshotted draw", () => {
+    const p = predictOutcome(BRIEF, PARAMS, 1_000);
+    expect(p.poolShort).toBe(true);
+    expect(p.outcome).toBe("POOL_SHORT");
+  });
+
+  it("ranks a lost vote above a pool shortfall", () => {
+    // Both conditions true: the reason a reader needs is the vote, not the pool.
+    const p = predictOutcome(
+      { ...BRIEF, yesWeight: 9_000_000, noWeight: 9_000_000 },
+      PARAMS,
+      1_000
+    );
+    expect(p.poolShort).toBe(true);
+    expect(p.outcome).toBe("VOTED_DOWN");
+  });
+
+  it("compares the real disbursement, not the draw, against the balance", () => {
+    // perSignal floors to 46666, so the true spend is 139998 — two sats under
+    // the 140000 draw. A balance in that gap is still payable.
+    const brief = { ...BRIEF, totalSignals: 3 };
+    const p = predictOutcome(brief, PARAMS, 139_999);
+    expect(p.perSignal).toBe(46_666);
+    expect(p.poolShort).toBe(false);
+    expect(p.outcome).toBe("PASSED");
+  });
+
+  it("short-circuits to not-concluded once lapsed, whatever the vote said", () => {
+    // The contract tests lapsed before every other branch: a week that would
+    // otherwise have passed still fails once the window closes.
+    const p = predictOutcome(BRIEF, PARAMS, RICH_POOL, true);
+    expect(p.outcome).toBe("NOT_CONCLUDED");
+    expect(p.thresholdMet).toBe(true);
+  });
+
+  it("uses truncating division so a boundary predicts as the contract concludes", () => {
+    // 65.9% approval truncates to 65, below the 66 threshold.
+    const p = predictOutcome(
+      { ...BRIEF, yesWeight: 6_590_000, noWeight: 3_410_000, eligibleSnapshot: 10_000_000 },
+      PARAMS,
+      RICH_POOL
+    );
+    expect(p.approvalPct).toBe(65);
+    expect(p.thresholdMet).toBe(false);
+    expect(p.outcome).toBe("VOTED_DOWN");
+  });
+});

--- a/src/__tests__/x402-rpc.test.ts
+++ b/src/__tests__/x402-rpc.test.ts
@@ -30,6 +30,7 @@ function makeEnv(
     // Stubs for required Env fields that are not exercised by verifyPayment
     NEWS_KV: {} as unknown as KVNamespace,
     NEWS_DO: {} as unknown as DurableObjectNamespace,
+    LEGION_DO: {} as unknown as DurableObjectNamespace,
     ASSETS: {} as unknown as Fetcher,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ import { seoRouter } from "./routes/seo";
 import { homeRouter } from "./routes/home-page";
 import { agentPageRouter } from "./routes/agent-page";
 import { beatPageRouter } from "./routes/beat-page";
+import { legionRouter } from "./routes/legion";
 
 // Create Hono app with type safety
 const app = new Hono<{ Bindings: Env; Variables: AppVariables }>();
@@ -103,6 +104,7 @@ app.route("/", agentPageRouter);
 // /agents/:addr: listing page /beats/ stays static; per-beat URLs go through
 // the Worker because no static file matches them.
 app.route("/", beatPageRouter);
+app.route("/", legionRouter);
 
 // Mount init bundle (single request for initial page load) before other routes
 app.route("/", initRouter);
@@ -338,3 +340,4 @@ export default app;
 
 // Re-export NewsDO from its own module for wrangler to pick up
 export { NewsDO } from "./objects/news-do";
+export { LegionDO } from "./objects/legion-do";

--- a/src/lib/clarity.ts
+++ b/src/lib/clarity.ts
@@ -1,0 +1,273 @@
+/**
+ * Minimal Clarity value decoder.
+ *
+ * `/v2/contracts/call-read` returns results as a hex-serialised Clarity value
+ * and nothing else — no `repr`, no JSON. The Legion read path needs a handful
+ * of those (brief status, vote tallies, heights, treasury balance), so rather
+ * than pull in the full Stacks SDK for four call sites we decode the wire
+ * format directly. It is small and stable.
+ *
+ * Scope note: principals are deliberately left as raw hex. Rendering one as a
+ * `ST…` address requires c32check encoding, and the only principal the UI
+ * needs (a brief's proposer) already arrives as a decoded string on the
+ * chainhook event payload. Decoding it twice, in two formats, would mean
+ * hand-rolling an address encoder to serve a field we already have — so the
+ * read path carries the hex and the event path supplies the address.
+ *
+ * Reference: SIP-005 Clarity value serialisation.
+ */
+
+export type ClarityValue =
+  | { type: "uint"; value: bigint }
+  | { type: "int"; value: bigint }
+  | { type: "bool"; value: boolean }
+  | { type: "none" }
+  | { type: "some"; value: ClarityValue }
+  | { type: "ok"; value: ClarityValue }
+  | { type: "err"; value: ClarityValue }
+  | { type: "buffer"; hex: string }
+  | { type: "string"; value: string }
+  | { type: "list"; values: ClarityValue[] }
+  | { type: "tuple"; data: Record<string, ClarityValue> }
+  | { type: "principal"; hex: string };
+
+const TYPE_INT = 0x00;
+const TYPE_UINT = 0x01;
+const TYPE_BUFFER = 0x02;
+const TYPE_TRUE = 0x03;
+const TYPE_FALSE = 0x04;
+const TYPE_PRINCIPAL_STANDARD = 0x05;
+const TYPE_PRINCIPAL_CONTRACT = 0x06;
+const TYPE_OK = 0x07;
+const TYPE_ERR = 0x08;
+const TYPE_NONE = 0x09;
+const TYPE_SOME = 0x0a;
+const TYPE_LIST = 0x0b;
+const TYPE_TUPLE = 0x0c;
+const TYPE_STRING_ASCII = 0x0d;
+const TYPE_STRING_UTF8 = 0x0e;
+
+export class ClarityDecodeError extends Error {}
+
+class Reader {
+  private offset = 0;
+
+  constructor(private readonly bytes: Uint8Array) {}
+
+  get consumed(): number {
+    return this.offset;
+  }
+
+  take(n: number): Uint8Array {
+    if (this.offset + n > this.bytes.length) {
+      throw new ClarityDecodeError(
+        `truncated value: wanted ${n} bytes at offset ${this.offset}, have ${this.bytes.length - this.offset}`
+      );
+    }
+    const slice = this.bytes.subarray(this.offset, this.offset + n);
+    this.offset += n;
+    return slice;
+  }
+
+  u8(): number {
+    return this.take(1)[0];
+  }
+
+  /** Big-endian u32 length prefix, used by buffers, strings, lists and tuples. */
+  u32(): number {
+    const b = this.take(4);
+    // Shift-based assembly overflows into negatives at the high bit; multiply instead.
+    return b[0] * 0x1000000 + ((b[1] << 16) | (b[2] << 8) | b[3]);
+  }
+
+  /** Big-endian unsigned integer of `n` bytes. */
+  uintBE(n: number): bigint {
+    let out = 0n;
+    for (const byte of this.take(n)) out = (out << 8n) | BigInt(byte);
+    return out;
+  }
+
+  /** Big-endian two's-complement signed integer of `n` bytes. */
+  intBE(n: number): bigint {
+    const magnitude = this.uintBE(n);
+    const signBit = 1n << BigInt(n * 8 - 1);
+    return magnitude >= signBit ? magnitude - (signBit << 1n) : magnitude;
+  }
+
+  hex(n: number): string {
+    return bytesToHex(this.take(n));
+  }
+
+  ascii(n: number): string {
+    return new TextDecoder("ascii").decode(this.take(n));
+  }
+
+  utf8(n: number): string {
+    return new TextDecoder("utf-8").decode(this.take(n));
+  }
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  let out = "";
+  for (const b of bytes) out += b.toString(16).padStart(2, "0");
+  return out;
+}
+
+export function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.startsWith("0x") || hex.startsWith("0X") ? hex.slice(2) : hex;
+  if (clean.length % 2 !== 0) {
+    throw new ClarityDecodeError(`odd-length hex string (${clean.length} chars)`);
+  }
+  const out = new Uint8Array(clean.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    const byte = Number.parseInt(clean.slice(i * 2, i * 2 + 2), 16);
+    if (Number.isNaN(byte)) {
+      throw new ClarityDecodeError(`invalid hex at byte ${i}`);
+    }
+    out[i] = byte;
+  }
+  return out;
+}
+
+function readValue(r: Reader): ClarityValue {
+  const tag = r.u8();
+  switch (tag) {
+    case TYPE_INT:
+      return { type: "int", value: r.intBE(16) };
+    case TYPE_UINT:
+      return { type: "uint", value: r.uintBE(16) };
+    case TYPE_BUFFER:
+      return { type: "buffer", hex: r.hex(r.u32()) };
+    case TYPE_TRUE:
+      return { type: "bool", value: true };
+    case TYPE_FALSE:
+      return { type: "bool", value: false };
+    case TYPE_PRINCIPAL_STANDARD:
+      // 1 version byte + 20-byte hash160.
+      return { type: "principal", hex: r.hex(21) };
+    case TYPE_PRINCIPAL_CONTRACT: {
+      const base = r.hex(21);
+      const nameLen = r.u8();
+      return { type: "principal", hex: `${base}.${r.ascii(nameLen)}` };
+    }
+    case TYPE_OK:
+      return { type: "ok", value: readValue(r) };
+    case TYPE_ERR:
+      return { type: "err", value: readValue(r) };
+    case TYPE_NONE:
+      return { type: "none" };
+    case TYPE_SOME:
+      return { type: "some", value: readValue(r) };
+    case TYPE_LIST: {
+      const len = r.u32();
+      const values: ClarityValue[] = [];
+      for (let i = 0; i < len; i++) values.push(readValue(r));
+      return { type: "list", values };
+    }
+    case TYPE_TUPLE: {
+      const len = r.u32();
+      const data: Record<string, ClarityValue> = {};
+      for (let i = 0; i < len; i++) {
+        const key = r.ascii(r.u8());
+        data[key] = readValue(r);
+      }
+      return { type: "tuple", data };
+    }
+    case TYPE_STRING_ASCII:
+      return { type: "string", value: r.ascii(r.u32()) };
+    case TYPE_STRING_UTF8:
+      return { type: "string", value: r.utf8(r.u32()) };
+    default:
+      throw new ClarityDecodeError(`unknown Clarity type byte 0x${tag.toString(16).padStart(2, "0")}`);
+  }
+}
+
+/** Decode a hex-serialised Clarity value. Trailing bytes are an error, not ignored. */
+export function decodeClarityHex(hex: string): ClarityValue {
+  const bytes = hexToBytes(hex);
+  const reader = new Reader(bytes);
+  const value = readValue(reader);
+  if (reader.consumed !== bytes.length) {
+    throw new ClarityDecodeError(
+      `trailing bytes: consumed ${reader.consumed} of ${bytes.length}`
+    );
+  }
+  return value;
+}
+
+// ── Accessors ──
+//
+// Read-only results arrive wrapped — usually `(optional ...)`, sometimes
+// `(response ...)`. These unwrap without forcing every call site to switch on
+// the tag union.
+
+/** Unwrap `(some x)` to `x` and `none` to null. Passes other values through. */
+export function unwrapOptional(value: ClarityValue): ClarityValue | null {
+  if (value.type === "none") return null;
+  if (value.type === "some") return value.value;
+  return value;
+}
+
+/** Unwrap `(ok x)`. Throws on `(err ...)` so a failed call never reads as data. */
+export function unwrapResponse(value: ClarityValue): ClarityValue {
+  if (value.type === "err") {
+    throw new ClarityDecodeError(`contract returned err: ${JSON.stringify(toJSON(value.value))}`);
+  }
+  if (value.type === "ok") return value.value;
+  return value;
+}
+
+/**
+ * Narrow a uint/int to a JS number.
+ *
+ * Clarity integers are 128-bit; every field the Legion UI reads (heights,
+ * sats, weights) is far below 2^53, but a value that somehow exceeds it would
+ * silently lose precision, so reject rather than round.
+ */
+export function asNumber(value: ClarityValue | null | undefined): number {
+  if (!value || (value.type !== "uint" && value.type !== "int")) {
+    throw new ClarityDecodeError(`expected uint/int, got ${value?.type ?? "undefined"}`);
+  }
+  if (value.value > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new ClarityDecodeError(`integer ${value.value} exceeds safe range`);
+  }
+  return Number(value.value);
+}
+
+/** Read a field from a tuple, or null if absent / not a tuple. */
+export function tupleField(value: ClarityValue | null, key: string): ClarityValue | null {
+  if (!value || value.type !== "tuple") return null;
+  return value.data[key] ?? null;
+}
+
+/** Plain-JSON projection for logging and API responses. Bigints become numbers. */
+export function toJSON(value: ClarityValue): unknown {
+  switch (value.type) {
+    case "uint":
+    case "int":
+      return value.value <= BigInt(Number.MAX_SAFE_INTEGER)
+        ? Number(value.value)
+        : value.value.toString();
+    case "bool":
+      return value.value;
+    case "none":
+      return null;
+    case "some":
+    case "ok":
+      return toJSON(value.value);
+    case "err":
+      return { err: toJSON(value.value) };
+    case "buffer":
+    case "principal":
+      return value.hex;
+    case "string":
+      return value.value;
+    case "list":
+      return value.values.map(toJSON);
+    case "tuple": {
+      const out: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(value.data)) out[k] = toJSON(v);
+      return out;
+    }
+  }
+}

--- a/src/lib/legion-constants.ts
+++ b/src/lib/legion-constants.ts
@@ -1,0 +1,141 @@
+/**
+ * AIBTC News Legion — on-chain governance constants.
+ *
+ * The Legion is a contributor-funded pool on Stacks testnet. Agents contribute
+ * sBTC for voting weight; weekly briefs are proposed, voted, optionally vetoed,
+ * and settled, paying correspondents who filed signals that week.
+ *
+ * Testnet only for now. When this moves to mainnet the contract ids and
+ * HIRO_API_BASE change together — keep them in one place so the switch is a
+ * single edit rather than a grep.
+ */
+
+export const LEGION_NETWORK = "testnet";
+
+/** Hiro Stacks API root. Read-only calls and event backfill both go here. */
+export const HIRO_API_BASE = "https://api.testnet.hiro.so";
+
+export const LEGION_DEPLOYER = "STGX5YP51NKM69ZMP6DVB6GAJAANCG5WB3718KD9";
+export const LEGION_GOV_CONTRACT = `${LEGION_DEPLOYER}.news-gov`;
+export const LEGION_TREASURY_CONTRACT = `${LEGION_DEPLOYER}.news-treasury`;
+
+/**
+ * Block the current contracts were published. Lower bound for event backfill —
+ * nothing to index before this height. Superseded deployments keep their own
+ * history under their own contract_id, so a redeploy never truncates the feed.
+ */
+export const LEGION_GENESIS_BLOCK = 4049423;
+
+/**
+ * On-chain `status` uint from `get-brief`. Absent (none) means the week was
+ * never proposed, which is distinct from every value below.
+ *
+ * v2 collapsed five statuses into two. The cause of a failure moved to the
+ * separate `reason` field, because four different things produce FAILED and a
+ * reader needs to tell them apart.
+ */
+export const BRIEF_STATUS = {
+  OPEN: 0,
+  PASSED: 1,
+  FAILED: 2,
+} as const;
+
+/**
+ * Why a week ended as it did. Read verbatim from `get-brief`.`reason`.
+ *
+ *   ""           still open
+ *   "paid"       passed and paid out
+ *   "voted-down" quorum met, approval short of threshold
+ *   "no-quorum"  too few voters or too little weight cast
+ *   "vetoed"     a VETO_QUORUM minority blocked it
+ *   "pool-short" passed, but the treasury could no longer cover the draw
+ *   "not-concluded" the conclude window closed before anyone called it
+ *
+ * Only "pool-short" is retryable: that week reopens and can be re-proposed at
+ * the smaller draw, and uniquely it carries no proposer cooldown.
+ */
+export type BriefReason =
+  | ""
+  | "paid"
+  | "voted-down"
+  | "no-quorum"
+  | "vetoed"
+  | "pool-short"
+  | "not-concluded";
+
+/**
+ * Lifecycle phase, read from the contract's own `get-phase`.
+ *
+ * v2 exposes this directly, so the UI no longer derives it from height
+ * arithmetic and cannot drift from what the contract believes. The tip is
+ * still fetched, but only to render a countdown — never to decide a phase.
+ *
+ * CONCLUDABLE is not "approved". `conclude` is the only function that writes a
+ * terminal status and it decides every outcome at call time, so a week whose
+ * vote already failed still sits here until someone calls it.
+ *
+ * LAPSED is the urgent one. The conclude window has closed, the week is still
+ * OPEN on chain, and calling `conclude` now records "not-concluded" and pays
+ * nobody. It must never be rendered like `concludable` — during `concludable`
+ * waiting is free, because the draw is snapshotted at propose; once `lapsed`,
+ * the payout is already gone.
+ */
+export type LegionPhase =
+  | "none"
+  | "voting"
+  | "veto"
+  | "concludable"
+  | "lapsed"
+  | "passed"
+  | "failed";
+
+/** The verdict `conclude` would write if called right now. */
+export type PredictedOutcome =
+  | "PASSED"
+  | "VETOED"
+  | "NO_QUORUM"
+  | "VOTED_DOWN"
+  | "POOL_SHORT"
+  | "NOT_CONCLUDED";
+
+/**
+ * Governance parameters.
+ *
+ * v2 added `get-params`, so these are no longer the source of truth — they are
+ * a fallback for when that call fails, and the shape the live values are read
+ * into. Prefer the on-chain values; a redeploy that changes a threshold should
+ * not silently mispredict here.
+ */
+
+/** Percent of eligible weight that must have voted for the result to count. */
+export const VOTING_QUORUM_PCT = 15;
+
+/** Distinct voters required regardless of weight. */
+export const MIN_PARTICIPANTS = 2;
+
+/** Percent of *cast* weight that must be yes for a brief to pass. */
+export const VOTING_THRESHOLD_PCT = 66;
+
+/** Percent of eligible weight needed to block a brief outright. */
+export const VETO_QUORUM_PCT = 15;
+
+/** Treasury draw, in basis points of pool balance (50 = 0.5%). */
+export const DRAW_BPS = 50;
+
+/** Blocks a proposal accepts votes for, measured from proposal height. */
+export const VOTE_WINDOW_BLOCKS = 36;
+
+/** Global rate limit between proposals, any proposer. */
+export const PROPOSE_INTERVAL_BLOCKS = 48;
+
+/** Minimum weight to propose, vote, or veto. */
+export const MIN_WEIGHT = 10_000;
+
+/**
+ * Observed mean seconds per testnet Stacks block, measured across the
+ * v1 contract's history (blocks 4049130 → 4049347, ~96-112s). Used only to
+ * render human-readable countdowns; never for consensus decisions, which are
+ * always height comparisons.
+ */
+export const TESTNET_BLOCK_SECONDS = 100;
+

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -98,6 +98,10 @@ export interface Logger {
 export interface Env {
   NEWS_KV: KVNamespace;
   NEWS_DO: DurableObjectNamespace;
+  // Legion governance event store. Deliberately separate from NEWS_DO: its
+  // write path is a public third-party webhook, and it carries no keep-alive
+  // alarm so it hibernates between requests.
+  LEGION_DO: DurableObjectNamespace;
   // Static assets fetcher — bound via wrangler `assets.binding = "ASSETS"`.
   // Used by the homepage SSR handler to fetch public/index.html before
   // transforming it with HTMLRewriter.
@@ -114,6 +118,11 @@ export interface Env {
   ENVIRONMENT?: string;
   // Shared secret for internal endpoints (seed, migrate)
   MIGRATION_KEY?: string;
+  // Chainhooks account-wide consumer secret, used to authenticate inbound
+  // governance webhooks. Absent means the webhook refuses all deliveries.
+  CHAINHOOK_CONSUMER_SECRET?: string;
+  // Hiro API key. Optional — lifts the anonymous rate limit on chain reads.
+  HIRO_API_KEY?: string;
   // Set to "false" to enable x402 paywall for past briefs (default: "true" = free access)
   BRIEFS_FREE?: string;
   // Set to "true" to require x402 payment for signal submission (default: "false" = grace period)

--- a/src/objects/legion-do.ts
+++ b/src/objects/legion-do.ts
@@ -1,0 +1,259 @@
+/**
+ * LegionDO — chain event store for the Legion governance UI.
+ *
+ * Separate from NewsDO on purpose. Its write path is inbound chainhook
+ * webhooks on an unpredictable schedule and its read path backs a live page;
+ * folding either into the news singleton would add traffic to the DO that
+ * already dominates rows-read cost, and would couple a testnet-only feature to
+ * a DO that needs a manual redeploy to cycle onto new code.
+ *
+ * Storage is a Durable Object rather than KV because the requirement is
+ * "visible immediately". KV is eventually consistent with propagation up to a
+ * minute, so a webhook could commit and the page still serve the old value
+ * well after. A DO read observes the write the moment it lands.
+ */
+
+import { LEGION_SCHEMA_SQL } from "./legion-schema";
+
+/** One decoded print event from news-gov. */
+export interface LegionEventRow {
+  txid: string;
+  event_index: number;
+  contract_id: string;
+  block_height: number;
+  block_time: number | null;
+  event: string;
+  brief_date: string | null;
+  actor: string | null;
+  data: Record<string, unknown>;
+}
+
+// Index signature required by SqlStorage's row generic, which constrains to
+// Record<string, SqlStorageValue>.
+interface StoredRow extends Record<string, SqlStorageValue> {
+  txid: string;
+  event_index: number;
+  contract_id: string;
+  block_height: number;
+  block_time: number | null;
+  event: string;
+  brief_date: string | null;
+  actor: string | null;
+  payload: string;
+}
+
+/**
+ * Principal fields differ per event type — the chainhook payload names the
+ * actor `who` on a contribution, `proposer` on a proposal, `voter` on a vote.
+ * Normalising at write time keeps the read path from re-deriving it per row.
+ */
+const ACTOR_KEYS = ["who", "proposer", "voter", "sender"] as const;
+
+function extractActor(data: Record<string, unknown>): string | null {
+  for (const key of ACTOR_KEYS) {
+    const v = data[key];
+    if (typeof v === "string" && v.length > 0) return v;
+  }
+  return null;
+}
+
+function extractBriefDate(data: Record<string, unknown>): string | null {
+  const v = data.briefDate;
+  return typeof v === "string" && v.length > 0 ? v : null;
+}
+
+export class LegionDO implements DurableObject {
+  private readonly sql: SqlStorage;
+
+  constructor(private readonly ctx: DurableObjectState) {
+    this.sql = ctx.storage.sql;
+    // Schema is idempotent; running it per construction keeps a cold-started
+    // DO correct without a separate migration step.
+    this.sql.exec(LEGION_SCHEMA_SQL);
+  }
+
+  /**
+   * Upsert decoded events.
+   *
+   * Idempotent by (txid, event_index) so a chainhook redelivery — which the
+   * service will do on any non-2xx, and which also happens on replay — cannot
+   * duplicate a row. Returns how many rows were actually new so the caller can
+   * skip a cache purge when a redelivery changed nothing.
+   */
+  recordEvents(events: LegionEventRow[]): { inserted: number; total: number } {
+    if (events.length === 0) return { inserted: 0, total: 0 };
+
+    let inserted = 0;
+    const now = Date.now();
+
+    // One transaction: a partial apply would leave the feed showing a vote
+    // whose proposal is missing, which reads as data loss rather than lag.
+    this.ctx.storage.transactionSync(() => {
+      for (const e of events) {
+        const before = this.sql
+          .exec<{ n: number }>(
+            "SELECT COUNT(*) AS n FROM legion_events WHERE txid = ? AND event_index = ?",
+            e.txid,
+            e.event_index
+          )
+          .one().n;
+
+        this.sql.exec(
+          `INSERT INTO legion_events
+             (txid, event_index, contract_id, block_height, block_time,
+              event, brief_date, actor, payload, recorded_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(txid, event_index) DO UPDATE SET
+             block_height = excluded.block_height,
+             block_time   = excluded.block_time,
+             payload      = excluded.payload`,
+          e.txid,
+          e.event_index,
+          e.contract_id,
+          e.block_height,
+          e.block_time,
+          e.event,
+          e.brief_date ?? extractBriefDate(e.data),
+          e.actor ?? extractActor(e.data),
+          JSON.stringify(e.data),
+          now
+        );
+
+        if (before === 0) inserted++;
+      }
+    });
+
+    return { inserted, total: events.length };
+  }
+
+  /**
+   * Drop events invalidated by a reorg.
+   *
+   * Chainhook delivers a `rollback` list alongside `apply`. Without handling
+   * it a reorged vote stays on the page permanently, and the tallies rendered
+   * from the feed drift from what the contract actually holds.
+   */
+  rollbackEvents(txids: string[]): number {
+    if (txids.length === 0) return 0;
+
+    let removed = 0;
+    this.ctx.storage.transactionSync(() => {
+      for (const txid of txids) {
+        const cursor = this.sql.exec(
+          "DELETE FROM legion_events WHERE txid = ?",
+          txid
+        );
+        removed += cursor.rowsWritten;
+      }
+    });
+    return removed;
+  }
+
+  /** Newest-first feed, optionally scoped to one week. */
+  listEvents(opts: {
+    contractId: string;
+    briefDate?: string;
+    limit?: number;
+  }): LegionEventRow[] {
+    const limit = Math.min(Math.max(opts.limit ?? 50, 1), 200);
+
+    const rows = opts.briefDate
+      ? this.sql
+          .exec<StoredRow>(
+            `SELECT * FROM legion_events
+              WHERE contract_id = ? AND brief_date = ?
+              ORDER BY block_height DESC, event_index DESC
+              LIMIT ?`,
+            opts.contractId,
+            opts.briefDate,
+            limit
+          )
+          .toArray()
+      : this.sql
+          .exec<StoredRow>(
+            `SELECT * FROM legion_events
+              WHERE contract_id = ?
+              ORDER BY block_height DESC, event_index DESC
+              LIMIT ?`,
+            opts.contractId,
+            limit
+          )
+          .toArray();
+
+    return rows.map((r) => ({
+      txid: r.txid,
+      event_index: r.event_index,
+      contract_id: r.contract_id,
+      block_height: r.block_height,
+      block_time: r.block_time,
+      event: r.event,
+      brief_date: r.brief_date,
+      actor: r.actor,
+      data: JSON.parse(r.payload) as Record<string, unknown>,
+    }));
+  }
+
+  /**
+   * The most recent brief date seen on-chain.
+   *
+   * Used to decide which week the page should show without guessing from the
+   * calendar — a week can be proposed late, and the newest *proposed* week is
+   * what readers care about, not whichever week today falls in.
+   */
+  latestBriefDate(contractId: string): string | null {
+    const row = this.sql
+      .exec<{ brief_date: string | null }>(
+        `SELECT brief_date FROM legion_events
+          WHERE contract_id = ? AND brief_date IS NOT NULL
+          ORDER BY block_height DESC, event_index DESC
+          LIMIT 1`,
+        contractId
+      )
+      .toArray()[0];
+    return row?.brief_date ?? null;
+  }
+
+  /** Highest block indexed, so a backfill knows where to resume. */
+  watermark(contractId: string): number | null {
+    const row = this.sql
+      .exec<{ h: number | null }>(
+        "SELECT MAX(block_height) AS h FROM legion_events WHERE contract_id = ?",
+        contractId
+      )
+      .toArray()[0];
+    return row?.h ?? null;
+  }
+
+  /** Router for worker→DO calls. Kept minimal; the worker owns HTTP concerns. */
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+
+    try {
+      switch (url.pathname) {
+        case "/record": {
+          const body = (await request.json()) as { events: LegionEventRow[] };
+          return Response.json(this.recordEvents(body.events ?? []));
+        }
+        case "/rollback": {
+          const body = (await request.json()) as { txids: string[] };
+          return Response.json({ removed: this.rollbackEvents(body.txids ?? []) });
+        }
+        case "/events": {
+          const contractId = url.searchParams.get("contract_id") ?? "";
+          const briefDate = url.searchParams.get("brief_date") ?? undefined;
+          const limit = Number(url.searchParams.get("limit") ?? 50);
+          return Response.json({
+            events: this.listEvents({ contractId, briefDate, limit }),
+            latest_brief_date: this.latestBriefDate(contractId),
+            watermark: this.watermark(contractId),
+          });
+        }
+        default:
+          return new Response("Not found", { status: 404 });
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return Response.json({ error: message }, { status: 500 });
+    }
+  }
+}

--- a/src/objects/legion-schema.ts
+++ b/src/objects/legion-schema.ts
@@ -1,0 +1,65 @@
+/**
+ * SQL schema for LegionDO SQLite storage.
+ *
+ * Deliberately separate from NewsDO. The Legion write path is driven by
+ * inbound chainhook webhooks on an unpredictable schedule, and its read path
+ * backs a live-updating page; folding either into the news singleton would put
+ * that traffic onto the DO that already dominates rows-read cost, and would
+ * couple a testnet-only feature to a DO that needs a manual redeploy to cycle.
+ *
+ * All tables use CREATE TABLE IF NOT EXISTS for safe re-initialization.
+ */
+export const LEGION_SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS legion_events (
+  txid          TEXT NOT NULL,
+  event_index   INTEGER NOT NULL DEFAULT 0,
+  -- Which deployment emitted this. Clarity contracts are immutable, so every
+  -- governance change ships as a new contract id, and the old one keeps its
+  -- history. Carrying the id per row lets a redeploy land without truncating
+  -- the feed: past cycles stay readable, queries scope to the active contract,
+  -- and a migration is a constant change rather than a data wipe. Adding this
+  -- column later would mean backfilling rows whose origin is unrecoverable.
+  contract_id   TEXT NOT NULL,
+  block_height  INTEGER NOT NULL,
+  block_time    INTEGER,
+  event         TEXT NOT NULL,
+  brief_date    TEXT,
+  actor         TEXT,
+  payload       TEXT NOT NULL,
+  recorded_at   INTEGER NOT NULL,
+  PRIMARY KEY (txid, event_index)
+);
+
+-- The page's primary read: newest-first activity for one week of one deployment.
+CREATE INDEX IF NOT EXISTS idx_legion_events_brief
+  ON legion_events(contract_id, brief_date, block_height DESC);
+
+-- Global feed and the "what have we indexed through" watermark.
+CREATE INDEX IF NOT EXISTS idx_legion_events_height
+  ON legion_events(contract_id, block_height DESC);
+
+-- Singleton snapshot of read-only chain state, refreshed by the cron poller.
+-- Holds the height-derived facts that emit no event and so can never arrive
+-- over the chainhook: current tip, and the vote/veto window boundaries the
+-- phase calculation compares against.
+CREATE TABLE IF NOT EXISTS legion_chain_state (
+  id               INTEGER PRIMARY KEY CHECK (id = 1),
+  tip_height       INTEGER NOT NULL,
+  brief_date       TEXT,
+  status           INTEGER,
+  vote_end         INTEGER,
+  yes_weight       INTEGER,
+  no_weight        INTEGER,
+  veto_weight      INTEGER,
+  voter_count      INTEGER,
+  entry_count      INTEGER,
+  total_signals    INTEGER,
+  total_weight     INTEGER,
+  treasury_balance INTEGER,
+  quote_draw       INTEGER,
+  next_propose_height INTEGER,
+  title            TEXT,
+  refreshed_at     INTEGER NOT NULL,
+  refresh_error    TEXT
+);
+`;

--- a/src/routes/legion.ts
+++ b/src/routes/legion.ts
@@ -1,0 +1,366 @@
+/**
+ * Legion governance routes.
+ *
+ *   POST /api/legion/chainhook — inbound Chainhooks webhook (event ingest)
+ *   GET  /api/legion/state     — merged chain + indexed state for the UI
+ *
+ * Split of responsibility between the two:
+ *
+ *   The webhook carries everything that *happened* — contributions, proposals,
+ *   votes, vetoes, conclusions. Each is a transaction, so each emits an event.
+ *
+ *   The state endpoint additionally reads `get-phase`, because a week crosses
+ *   from voting into its veto window, and from there into concludable, purely
+ *   because blocks passed. No transaction, no event, nothing to push. Reading
+ *   that per request is why there is no cron in this design.
+ */
+
+import { Hono } from "hono";
+import type { Env, AppVariables } from "../lib/types";
+import { edgeCacheMatch, edgeCachePut, edgeCacheDelete } from "../lib/edge-cache";
+import {
+  LEGION_GOV_CONTRACT,
+  LEGION_NETWORK,
+  TESTNET_BLOCK_SECONDS,
+} from "../lib/legion-constants";
+import {
+  getTipHeight,
+  getBrief,
+  getBriefMeta,
+  getPhase,
+  getParams,
+  getPoolStats,
+  blocksRemaining,
+  nextBoundaryHeight,
+  predictOutcome,
+} from "../services/legion-chain";
+import type { LegionEventRow } from "../objects/legion-do";
+
+const legionRouter = new Hono<{ Bindings: Env; Variables: AppVariables }>();
+
+const DO_ID_NAME = "legion-singleton";
+
+function getLegionStub(env: Env): DurableObjectStub {
+  const id = env.LEGION_DO.idFromName(DO_ID_NAME);
+  return env.LEGION_DO.get(id);
+}
+
+// ── Webhook auth ──
+
+/**
+ * Chainhooks 2.0 has no per-hook `authorization_header` field — the action
+ * schema is exactly `{type, url}`. Authentication is an account-wide consumer
+ * secret instead, and the delivery-side header carrying it is not described in
+ * the SDK types.
+ *
+ * So this accepts the secret from any of the plausible carriers, including a
+ * query token, since the destination URL is the one part of the hook we fully
+ * control. It fails closed: an unrecognised request is rejected and the header
+ * *names* (never values) are logged, so the real carrier can be pinned from
+ * the first live delivery and this list narrowed to one.
+ */
+const SECRET_HEADERS = [
+  "x-chainhook-secret",
+  "x-consumer-secret",
+  "x-hiro-signature",
+  "authorization",
+];
+
+/** Constant-time compare so a rejected probe cannot be timed to leak the secret. */
+function safeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}
+
+function isAuthorised(request: Request, secret: string): boolean {
+  for (const name of SECRET_HEADERS) {
+    const raw = request.headers.get(name);
+    if (!raw) continue;
+    const value = raw.startsWith("Bearer ") ? raw.slice(7) : raw;
+    if (safeEqual(value, secret)) return true;
+  }
+  const token = new URL(request.url).searchParams.get("t");
+  return token ? safeEqual(token, secret) : false;
+}
+
+// ── Payload normalisation ──
+
+interface ChainhookOccurrence {
+  apply?: ChainhookBlock[];
+  rollback?: ChainhookBlock[];
+}
+
+interface ChainhookBlock {
+  block_identifier?: { index?: number };
+  timestamp?: number;
+  metadata?: { block_time?: number };
+  transactions?: ChainhookTransaction[];
+}
+
+interface ChainhookTransaction {
+  transaction_identifier?: { hash?: string };
+  metadata?: {
+    success?: boolean;
+    receipt?: { events?: ChainhookEvent[] };
+  };
+}
+
+interface ChainhookEvent {
+  type?: string;
+  position?: { index?: number };
+  data?: {
+    contract_identifier?: string;
+    topic?: string;
+    value?: unknown;
+    raw_value?: string;
+  };
+}
+
+/**
+ * Flatten a chainhook payload into rows.
+ *
+ * Only `print` events from the governance contract are kept, and only from
+ * successful transactions — v1's history already contained a `settle` that hit
+ * `abort_by_post_condition`, and indexing a failed call would show a
+ * conclusion on the page that never happened.
+ */
+function extractEvents(blocks: ChainhookBlock[], contractId: string): LegionEventRow[] {
+  const out: LegionEventRow[] = [];
+
+  for (const block of blocks) {
+    const height = block.block_identifier?.index;
+    if (typeof height !== "number") continue;
+    const blockTime = block.metadata?.block_time ?? block.timestamp ?? null;
+
+    for (const tx of block.transactions ?? []) {
+      if (tx.metadata?.success === false) continue;
+      const txid = tx.transaction_identifier?.hash;
+      if (!txid) continue;
+
+      const events = tx.metadata?.receipt?.events ?? [];
+      events.forEach((ev, i) => {
+        if (ev.type !== "SmartContractEvent" && ev.type !== "print") return;
+        if (ev.data?.contract_identifier !== contractId) return;
+
+        // With decode_clarity_values enabled the tuple arrives as JSON.
+        const value = ev.data?.value;
+        if (!value || typeof value !== "object") return;
+        const data = value as Record<string, unknown>;
+        const name = typeof data.event === "string" ? data.event : null;
+        if (!name) return;
+
+        out.push({
+          txid,
+          event_index: ev.position?.index ?? i,
+          contract_id: contractId,
+          block_height: height,
+          block_time: blockTime,
+          event: name,
+          brief_date: typeof data.briefDate === "string" ? data.briefDate : null,
+          actor: null, // normalised inside the DO from who/proposer/voter
+          data,
+        });
+      });
+    }
+  }
+
+  return out;
+}
+
+function rollbackTxids(blocks: ChainhookBlock[]): string[] {
+  const ids: string[] = [];
+  for (const block of blocks) {
+    for (const tx of block.transactions ?? []) {
+      const hash = tx.transaction_identifier?.hash;
+      if (hash) ids.push(hash);
+    }
+  }
+  return ids;
+}
+
+// ── POST /api/legion/chainhook ──
+
+legionRouter.post("/api/legion/chainhook", async (c) => {
+  const logger = c.get("logger");
+  const secret = c.env.CHAINHOOK_CONSUMER_SECRET;
+
+  // No secret configured means the endpoint cannot authenticate anything.
+  // Refuse rather than accept unauthenticated writes to the event store.
+  if (!secret) {
+    logger?.error?.("[legion] CHAINHOOK_CONSUMER_SECRET is not set; rejecting webhook");
+    return c.json({ error: "Webhook not configured" }, 503);
+  }
+
+  if (!isAuthorised(c.req.raw, secret)) {
+    logger?.warn?.("[legion] unauthorised chainhook delivery", {
+      // Names only — never values, which would log the secret on a near-miss.
+      headers: [...c.req.raw.headers.keys()].join(","),
+    });
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  let payload: ChainhookOccurrence;
+  try {
+    payload = await c.req.json<ChainhookOccurrence>();
+  } catch {
+    return c.json({ error: "Invalid JSON body" }, 400);
+  }
+
+  const applied = extractEvents(payload.apply ?? [], LEGION_GOV_CONTRACT);
+  const rolled = rollbackTxids(payload.rollback ?? []);
+
+  const stub = getLegionStub(c.env);
+  let inserted = 0;
+  let removed = 0;
+
+  try {
+    if (rolled.length > 0) {
+      const res = await stub.fetch("https://legion/rollback", {
+        method: "POST",
+        body: JSON.stringify({ txids: rolled }),
+      });
+      removed = ((await res.json()) as { removed: number }).removed;
+    }
+    if (applied.length > 0) {
+      const res = await stub.fetch("https://legion/record", {
+        method: "POST",
+        body: JSON.stringify({ events: applied }),
+      });
+      inserted = ((await res.json()) as { inserted: number }).inserted;
+    }
+  } catch (err) {
+    // Return 500 so Chainhooks retries rather than dropping the delivery.
+    // recordEvents is idempotent by (txid, event_index), so a redelivery of a
+    // partially-applied batch cannot duplicate rows.
+    logger?.error?.("[legion] failed to persist chainhook payload", { err: String(err) });
+    return c.json({ error: "Failed to persist events" }, 500);
+  }
+
+  // Only purge when something actually changed. A redelivery that inserts
+  // nothing should not evict a warm cache entry.
+  if (inserted > 0 || removed > 0) {
+    edgeCacheDelete(c, ["/api/legion/state"]);
+  }
+
+  logger?.info?.("[legion] chainhook processed", {
+    applied: applied.length,
+    inserted,
+    removed,
+  });
+
+  return c.json({ ok: true, inserted, removed, received: applied.length });
+});
+
+// ── GET /api/legion/state ──
+
+legionRouter.get("/api/legion/state", async (c) => {
+  const cached = await edgeCacheMatch(c);
+  if (cached) return cached;
+
+  const logger = c.get("logger");
+  const apiKey = c.env.HIRO_API_KEY;
+  const opts = apiKey ? { apiKey } : {};
+
+  try {
+    const stub = getLegionStub(c.env);
+    const indexed = await stub
+      .fetch(
+        `https://legion/events?contract_id=${encodeURIComponent(LEGION_GOV_CONTRACT)}&limit=50`
+      )
+      .then(
+        (r) =>
+          r.json() as Promise<{
+            events: LegionEventRow[];
+            latest_brief_date: string | null;
+            watermark: number | null;
+          }>
+      );
+
+    // Which week to show comes from the chain, not the calendar — a brief can
+    // be proposed late, and readers care about the newest proposed week rather
+    // than whichever week today happens to fall in.
+    const briefDate = c.req.query("week") ?? indexed.latest_brief_date;
+
+    const [tipHeight, params, pool, brief, meta, phase] = await Promise.all([
+      getTipHeight(opts),
+      getParams(opts),
+      getPoolStats(opts),
+      briefDate ? getBrief(briefDate, opts) : Promise.resolve(null),
+      briefDate ? getBriefMeta(briefDate, opts) : Promise.resolve(null),
+      briefDate ? getPhase(briefDate, opts) : Promise.resolve("none" as const),
+    ]);
+
+    // Predicted only while the outcome is still undecided. Once the contract
+    // has written a terminal status, `reason` is the truth and a prediction
+    // alongside it would just invite disagreement.
+    const prediction =
+      brief && (phase === "voting" || phase === "veto" || phase === "concludable" || phase === "lapsed")
+        ? predictOutcome(brief, params, pool.treasuryBalance, phase === "lapsed")
+        : null;
+
+    const payload = {
+      network: LEGION_NETWORK,
+      contract: LEGION_GOV_CONTRACT,
+      tip_height: tipHeight,
+      block_seconds: TESTNET_BLOCK_SECONDS,
+      phase,
+      blocks_remaining: blocksRemaining(
+        brief, phase, tipHeight, params.vetoWindow, params.concludeWindow
+      ),
+      next_boundary_height: nextBoundaryHeight(
+        brief, phase, params.vetoWindow, params.concludeWindow
+      ),
+      brief: brief
+        ? {
+            brief_date: brief.briefDate,
+            title: meta?.title ?? "",
+            description: meta?.description ?? "",
+            status: brief.status,
+            reason: brief.reason,
+            created_at_height: brief.createdAt,
+            vote_end: brief.voteEnd,
+            veto_end: brief.voteEnd + params.vetoWindow,
+            conclude_end: brief.voteEnd + params.vetoWindow + params.concludeWindow,
+            // Fixed at propose time — concluding later pays exactly this.
+            draw: brief.draw,
+            yes_weight: brief.yesWeight,
+            no_weight: brief.noWeight,
+            veto_weight: brief.vetoWeight,
+            voter_count: brief.voterCount,
+            entry_count: brief.entryCount,
+            total_signals: brief.totalSignals,
+            bond: brief.bond,
+            eligible_snapshot: brief.eligibleSnapshot,
+          }
+        : null,
+      prediction,
+      pool: {
+        total_weight: pool.totalWeight,
+        treasury_balance: pool.treasuryBalance,
+        quote_draw: pool.quoteDraw,
+        next_propose_height: pool.nextProposeHeight,
+      },
+      // Straight from get-params, so the UI can never quote a threshold the
+      // contract no longer enforces.
+      rules: params,
+      events: indexed.events,
+      indexed_through: indexed.watermark,
+    };
+
+    // Short TTL, and the webhook purges on write — so a new event shows up
+    // immediately rather than waiting out the TTL. The TTL only bounds how
+    // stale the *height-derived* phase can get, which nothing can purge
+    // because no event fires when a window elapses.
+    c.header("Cache-Control", "public, max-age=5, s-maxage=10");
+    const response = c.json(payload);
+    edgeCachePut(c, response);
+    return response;
+  } catch (err) {
+    logger?.error?.("[legion] failed to build state", { err: String(err) });
+    return c.json({ error: "Failed to read chain state" }, 502);
+  }
+});
+
+export { legionRouter };

--- a/src/services/legion-chain.ts
+++ b/src/services/legion-chain.ts
@@ -1,0 +1,405 @@
+/**
+ * Read-only chain access for the Legion (v2).
+ *
+ * This is the half of the pipeline chainhooks structurally cannot cover. A week
+ * moves voting → veto → concludable purely because the tip passed `voteEnd` and
+ * `voteEnd + vetoWindow`, with no transaction and therefore no event to push. A
+ * webhook-only page would sit on "voting" long after voting closed.
+ *
+ * v2 exposes `get-phase` and `get-params`, so both the phase and the governance
+ * thresholds are now read from the contract rather than recomputed here. The
+ * tip is still fetched, but only to render a countdown — never to decide a
+ * phase, which keeps this module from disagreeing with the contract.
+ *
+ * Everything here is a plain HTTP read against the Hiro API — no signing, no
+ * keys.
+ */
+
+import {
+  HIRO_API_BASE,
+  LEGION_GOV_CONTRACT,
+  LEGION_TREASURY_CONTRACT,
+  LEGION_DEPLOYER,
+  type BriefReason,
+  type LegionPhase,
+  type PredictedOutcome,
+} from "../lib/legion-constants";
+import {
+  decodeClarityHex,
+  unwrapOptional,
+  unwrapResponse,
+  asNumber,
+  tupleField,
+  type ClarityValue,
+} from "../lib/clarity";
+
+const FETCH_TIMEOUT_MS = 8_000;
+
+export interface ChainReadOptions {
+  fetchImpl?: typeof fetch;
+  /** Hiro API key, lifts the anonymous rate limit. Optional. */
+  apiKey?: string;
+}
+
+async function hiroFetch(
+  path: string,
+  init: RequestInit,
+  opts: ChainReadOptions
+): Promise<Response> {
+  const doFetch = opts.fetchImpl ?? fetch;
+  const headers = new Headers(init.headers);
+  if (opts.apiKey) headers.set("x-api-key", opts.apiKey);
+
+  // AbortSignal.timeout keeps a hung upstream from pinning the cron invocation.
+  const res = await doFetch(`${HIRO_API_BASE}${path}`, {
+    ...init,
+    headers,
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    throw new Error(`Hiro ${path} returned ${res.status}`);
+  }
+  return res;
+}
+
+/** Serialise a `string-ascii` argument: type byte, u32 length, then the bytes. */
+export function encodeStringAscii(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  const len = bytes.length.toString(16).padStart(8, "0");
+  let body = "";
+  for (const b of bytes) body += b.toString(16).padStart(2, "0");
+  return `0x0d${len}${body}`;
+}
+
+/**
+ * Invoke a read-only function and decode the result.
+ *
+ * `sender` is required by the node but has no effect on any Legion read — none
+ * of them branch on tx-sender — so the deployer address is used as a constant.
+ */
+export async function callReadOnly(
+  contract: string,
+  functionName: string,
+  functionArgs: string[] = [],
+  opts: ChainReadOptions = {}
+): Promise<ClarityValue> {
+  const [address, name] = contract.split(".");
+  const res = await hiroFetch(
+    `/v2/contracts/call-read/${address}/${name}/${functionName}`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ sender: LEGION_DEPLOYER, arguments: functionArgs }),
+    },
+    opts
+  );
+
+  const body = (await res.json()) as { okay: boolean; result?: string; cause?: string };
+  if (!body.okay || !body.result) {
+    throw new Error(`${contract}.${functionName} failed: ${body.cause ?? "unknown cause"}`);
+  }
+  return unwrapResponse(decodeClarityHex(body.result));
+}
+
+/** Current Stacks tip height. */
+export async function getTipHeight(opts: ChainReadOptions = {}): Promise<number> {
+  const res = await hiroFetch("/v2/info", { method: "GET" }, opts);
+  const body = (await res.json()) as { stacks_tip_height?: number };
+  if (typeof body.stacks_tip_height !== "number") {
+    throw new Error("Hiro /v2/info returned no stacks_tip_height");
+  }
+  return body.stacks_tip_height;
+}
+
+export interface BriefRecord {
+  briefDate: string;
+  status: number;
+  reason: BriefReason;
+  /** Payout fixed at propose time. v2 snapshots this so a late conclude pays the same. */
+  draw: number;
+  voteEnd: number;
+  createdAt: number;
+  yesWeight: number;
+  noWeight: number;
+  vetoWeight: number;
+  voterCount: number;
+  entryCount: number;
+  totalSignals: number;
+  bond: number;
+  eligibleSnapshot: number;
+}
+
+/** Fetch one week's on-chain record, or null if never proposed. */
+export async function getBrief(
+  briefDate: string,
+  opts: ChainReadOptions = {}
+): Promise<BriefRecord | null> {
+  const raw = await callReadOnly(
+    LEGION_GOV_CONTRACT,
+    "get-brief",
+    [encodeStringAscii(briefDate)],
+    opts
+  );
+  const brief = unwrapOptional(raw);
+  if (!brief || brief.type !== "tuple") return null;
+
+  const reason = tupleField(brief, "reason");
+  return {
+    briefDate,
+    status: asNumber(tupleField(brief, "status")),
+    reason: (reason?.type === "string" ? reason.value : "") as BriefReason,
+    draw: asNumber(tupleField(brief, "draw")),
+    voteEnd: asNumber(tupleField(brief, "voteEnd")),
+    createdAt: asNumber(tupleField(brief, "createdAt")),
+    yesWeight: asNumber(tupleField(brief, "yesWeight")),
+    noWeight: asNumber(tupleField(brief, "noWeight")),
+    vetoWeight: asNumber(tupleField(brief, "vetoWeight")),
+    voterCount: asNumber(tupleField(brief, "voterCount")),
+    entryCount: asNumber(tupleField(brief, "entryCount")),
+    totalSignals: asNumber(tupleField(brief, "totalSignals")),
+    bond: asNumber(tupleField(brief, "bond")),
+    eligibleSnapshot: asNumber(tupleField(brief, "eligibleSnapshot")),
+  };
+}
+
+/** Brief title/description. Separate call because it lives on a separate getter. */
+export async function getBriefMeta(
+  briefDate: string,
+  opts: ChainReadOptions = {}
+): Promise<{ title: string; description: string } | null> {
+  const raw = await callReadOnly(
+    LEGION_GOV_CONTRACT,
+    "get-brief-meta",
+    [encodeStringAscii(briefDate)],
+    opts
+  );
+  const meta = unwrapOptional(raw);
+  if (!meta || meta.type !== "tuple") return null;
+
+  const title = tupleField(meta, "title");
+  const description = tupleField(meta, "description");
+  return {
+    title: title?.type === "string" ? title.value : "",
+    description: description?.type === "string" ? description.value : "",
+  };
+}
+
+/**
+ * Lifecycle phase, straight from the contract.
+ *
+ * v2 exposes `get-phase`, so this is read rather than derived. Deriving it
+ * locally would mean re-implementing window arithmetic that the contract
+ * already owns, and any drift between the two would show users a phase the
+ * contract disagrees with.
+ */
+export async function getPhase(
+  briefDate: string,
+  opts: ChainReadOptions = {}
+): Promise<LegionPhase> {
+  const raw = await callReadOnly(
+    LEGION_GOV_CONTRACT,
+    "get-phase",
+    [encodeStringAscii(briefDate)],
+    opts
+  );
+  const phase = raw.type === "string" ? raw.value : "none";
+  return (VALID_PHASES.has(phase) ? phase : "none") as LegionPhase;
+}
+
+const VALID_PHASES = new Set([
+  "none",
+  "voting",
+  "veto",
+  "concludable",
+  "lapsed",
+  "passed",
+  "failed",
+]);
+
+export interface LegionParams {
+  votingQuorum: number;
+  votingThreshold: number;
+  vetoQuorum: number;
+  minParticipants: number;
+  minWeight: number;
+  drawBps: number;
+  bondBps: number;
+  minBond: number;
+  voteWindow: number;
+  vetoWindow: number;
+  concludeWindow: number;
+  proposeInterval: number;
+}
+
+/**
+ * Governance parameters, read from the contract.
+ *
+ * v2 added `get-params` specifically so a UI stops hardcoding thresholds that
+ * drift from the deployed code. Everything downstream takes these as input
+ * rather than importing constants.
+ */
+export async function getParams(opts: ChainReadOptions = {}): Promise<LegionParams> {
+  const raw = await callReadOnly(LEGION_GOV_CONTRACT, "get-params", [], opts);
+  const num = (k: string) => asNumber(tupleField(raw, k));
+  return {
+    votingQuorum: num("votingQuorum"),
+    votingThreshold: num("votingThreshold"),
+    vetoQuorum: num("vetoQuorum"),
+    minParticipants: num("minParticipants"),
+    minWeight: num("minWeight"),
+    drawBps: num("drawBps"),
+    bondBps: num("bondBps"),
+    minBond: num("minBond"),
+    voteWindow: num("voteWindow"),
+    vetoWindow: num("vetoWindow"),
+    concludeWindow: num("concludeWindow"),
+    proposeInterval: num("proposeInterval"),
+  };
+}
+
+/** Pool-level scalars, fetched together since the page shows them as a unit. */
+export async function getPoolStats(opts: ChainReadOptions = {}): Promise<{
+  totalWeight: number;
+  quoteDraw: number;
+  nextProposeHeight: number;
+  treasuryBalance: number;
+}> {
+  const [totalWeight, quoteDraw, nextProposeHeight, treasuryBalance] = await Promise.all([
+    callReadOnly(LEGION_GOV_CONTRACT, "get-total-weight", [], opts),
+    callReadOnly(LEGION_GOV_CONTRACT, "quote-draw", [], opts),
+    callReadOnly(LEGION_GOV_CONTRACT, "get-next-propose-height", [], opts),
+    callReadOnly(LEGION_TREASURY_CONTRACT, "get-balance", [], opts),
+  ]);
+
+  return {
+    totalWeight: asNumber(totalWeight),
+    quoteDraw: asNumber(quoteDraw),
+    nextProposeHeight: asNumber(nextProposeHeight),
+    treasuryBalance: asNumber(unwrapOptional(treasuryBalance) ?? treasuryBalance),
+  };
+}
+
+export interface OutcomePrediction {
+  outcome: PredictedOutcome;
+  quorumMet: boolean;
+  thresholdMet: boolean;
+  vetoed: boolean;
+  poolShort: boolean;
+  /** Weight actually cast (yes + no); excludes vetoes, counted separately. */
+  cast: number;
+  turnoutPct: number;
+  approvalPct: number;
+  vetoPct: number;
+  /** What each signal would earn. Zero means the dust guard would bite. */
+  perSignal: number;
+}
+
+/**
+ * Compute the verdict `conclude` would write right now.
+ *
+ * Mirrors the contract's branch order exactly, and the order is load-bearing:
+ * lapsed → veto → quorum → threshold → pool-short → passed. A week that is both
+ * vetoed and short of quorum resolves as vetoed, a week that lost its vote
+ * reports that rather than a pool problem, and past the conclude window nothing
+ * else is reachable at all.
+ *
+ * Integer division matches Clarity's truncation. Floating-point percentages
+ * would let a brief sitting exactly on a boundary predict differently from how
+ * it actually concludes.
+ *
+ * `treasuryBalance` is compared against the real disbursement
+ * (`perSignal × totalSignals`), not the snapshotted draw, because floor
+ * truncation makes the actual spend up to `totalSignals - 1` sats lower.
+ */
+export function predictOutcome(
+  brief: Pick<
+    BriefRecord,
+    | "yesWeight"
+    | "noWeight"
+    | "vetoWeight"
+    | "voterCount"
+    | "eligibleSnapshot"
+    | "draw"
+    | "totalSignals"
+  >,
+  params: Pick<
+    LegionParams,
+    "votingQuorum" | "votingThreshold" | "vetoQuorum" | "minParticipants"
+  >,
+  treasuryBalance: number,
+  /** True once the conclude window has closed. Short-circuits every other branch. */
+  lapsed = false
+): OutcomePrediction {
+  const eligible = brief.eligibleSnapshot;
+  const cast = brief.yesWeight + brief.noWeight;
+
+  const turnoutPct = eligible > 0 ? Math.floor((cast * 100) / eligible) : 0;
+  const approvalPct = cast > 0 ? Math.floor((brief.yesWeight * 100) / cast) : 0;
+  const vetoPct = eligible > 0 ? Math.floor((brief.vetoWeight * 100) / eligible) : 0;
+
+  const vetoed = eligible > 0 && vetoPct >= params.vetoQuorum;
+  const quorumMet =
+    eligible > 0 &&
+    brief.voterCount >= params.minParticipants &&
+    turnoutPct >= params.votingQuorum;
+  const thresholdMet = cast > 0 && approvalPct >= params.votingThreshold;
+
+  const perSignal =
+    brief.totalSignals > 0 ? Math.floor(brief.draw / brief.totalSignals) : 0;
+  const poolShort = perSignal * brief.totalSignals > treasuryBalance;
+
+  let outcome: PredictedOutcome;
+  // The contract tests lapsed before anything else: past the window a week can
+  // only fail, however its vote went.
+  if (lapsed) outcome = "NOT_CONCLUDED";
+  else if (vetoed) outcome = "VETOED";
+  else if (!quorumMet) outcome = "NO_QUORUM";
+  else if (!thresholdMet) outcome = "VOTED_DOWN";
+  else if (poolShort) outcome = "POOL_SHORT";
+  else outcome = "PASSED";
+
+  return {
+    outcome,
+    quorumMet,
+    thresholdMet,
+    vetoed,
+    poolShort,
+    cast,
+    turnoutPct,
+    approvalPct,
+    vetoPct,
+    perSignal,
+  };
+}
+
+/**
+ * Blocks until the current phase ends, or null when there is no next boundary.
+ *
+ * Three phases are timed: voting, veto, and concludable. The last is the one
+ * worth surfacing loudest — when it runs out the week can no longer pay.
+ */
+export function blocksRemaining(
+  brief: Pick<BriefRecord, "voteEnd"> | null,
+  phase: LegionPhase,
+  tipHeight: number,
+  vetoWindow: number,
+  concludeWindow: number
+): number | null {
+  const end = nextBoundaryHeight(brief, phase, vetoWindow, concludeWindow);
+  return end === null ? null : Math.max(0, end - tipHeight);
+}
+
+/** Height at which the current phase ends, or null when it has no deadline. */
+export function nextBoundaryHeight(
+  brief: Pick<BriefRecord, "voteEnd"> | null,
+  phase: LegionPhase,
+  vetoWindow: number,
+  concludeWindow: number
+): number | null {
+  if (!brief) return null;
+  if (phase === "voting") return brief.voteEnd;
+  if (phase === "veto") return brief.voteEnd + vetoWindow;
+  // The window that matters most: past it the payout is gone, not merely late.
+  if (phase === "concludable") return brief.voteEnd + vetoWindow + concludeWindow;
+  return null;
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -35,13 +35,15 @@
   // Durable Object binding — primary storage engine (SQLite)
   "durable_objects": {
     "bindings": [
-      { "name": "NEWS_DO", "class_name": "NewsDO" }
+      { "name": "NEWS_DO", "class_name": "NewsDO" },
+        { "name": "LEGION_DO", "class_name": "LegionDO" }
     ]
   },
 
   // DO migrations — use new_sqlite_classes for SQLite-backed DOs
   "migrations": [
-    { "tag": "v1", "new_sqlite_classes": ["NewsDO"] }
+    { "tag": "v1", "new_sqlite_classes": ["NewsDO"] },
+    { "tag": "v2", "new_sqlite_classes": ["LegionDO"] }
   ],
 
   // Service bindings: worker-logs (RPC) and x402-sponsor-relay (RPC)
@@ -114,13 +116,15 @@
 
       "durable_objects": {
         "bindings": [
-          { "name": "NEWS_DO", "class_name": "NewsDO" }
+          { "name": "NEWS_DO", "class_name": "NewsDO" },
+        { "name": "LEGION_DO", "class_name": "LegionDO" }
         ]
       },
 
       // Separate migration tag keeps staging DO independent of production
       "migrations": [
-        { "tag": "v1-staging", "new_sqlite_classes": ["NewsDO"] }
+        { "tag": "v1-staging", "new_sqlite_classes": ["NewsDO"] },
+        { "tag": "v2-staging", "new_sqlite_classes": ["LegionDO"] }
       ],
 
       "services": [
@@ -164,12 +168,14 @@
 
       "durable_objects": {
         "bindings": [
-          { "name": "NEWS_DO", "class_name": "NewsDO" }
+          { "name": "NEWS_DO", "class_name": "NewsDO" },
+        { "name": "LEGION_DO", "class_name": "LegionDO" }
         ]
       },
 
       "migrations": [
-        { "tag": "v1", "new_sqlite_classes": ["NewsDO"] }
+        { "tag": "v1", "new_sqlite_classes": ["NewsDO"] },
+    { "tag": "v2", "new_sqlite_classes": ["LegionDO"] }
       ],
 
       "services": [


### PR DESCRIPTION
Adds `aibtc.news/legions` — a live view of the Legion, the contributor-funded pool where agents vote each week on which reporting gets paid.

Contracts are `STGX5YP51NKM69ZMP6DVB6GAJAANCG5WB3718KD9.news-gov` / `news-treasury` on Stacks testnet, deployed at block 4049423.

## How it updates

Two paths, deliberately split:

```
chainhook ──▶ LegionDO (SQLite)  ──▶ purge /api/legion/state
              contribute, propose, vote, veto, conclude

GET /api/legion/state
   ├─ read DO          indexed event feed
   ├─ read get-phase   authoritative lifecycle position
   ├─ read get-params  live governance thresholds
   └─ tip height       countdown only, never a phase decision
```

Events are pushed; the phase is read. That split exists because three lifecycle transitions emit **nothing at all** — a week moves `voting → veto → concludable → lapsed` purely because blocks passed, with no transaction to hook. A webhook-only page would sit on "voting open" long after voting closed. There is no cron: the phase is computed per request from the contract's own `get-phase`.

Thresholds come from `get-params` rather than being mirrored in constants, so a governance redeploy cannot silently mispredict.

## Storage

`LegionDO` is separate from `NewsDO` on purpose:

- its write path is a **public third-party webhook**; a malformed payload that wedges the handler shouldn't wedge the primary datastore
- it has **no keep-alive alarm**, so it hibernates between requests instead of inheriting the news singleton's always-on duration and manual-`wrangler deploy` cycle

A DO rather than KV because the requirement is immediate visibility, and KV is eventually consistent with propagation up to a minute. Cost difference measured at **~$0.01–0.04/month** — not a factor either way.

Events carry `contract_id`, so the next governance redeploy lands without truncating the feed.

## UI

Every state shows the same three things together — where we are, what block it is, what block the next change happens at — so nothing has to be inferred.

Two treatments carry the most weight:

- **`concludable`** — the payout can't grow by waiting (the draw is snapshotted at propose), but it must be concluded by block N or the week closes unpaid. Live countdown.
- **`lapsed`** — the inverse. Concluding now records `not-concluded` and **pays nobody**; the action shifts from releasing the draw to releasing the proposer's bond and reopening the week.

Failure states name their cause rather than saying "failed", because three of the four reopen the week and a bare "failed" reads as terminal.

## Security

- Webhook fails closed: no `CHAINHOOK_CONSUMER_SECRET`, no deliveries accepted
- Constant-time secret compare; rejections log header *names*, never values
- Idempotent by `(txid, event_index)`; 500 on persist failure so Chainhooks retries rather than dropping
- `rollback` handled, so a reorged vote doesn't linger
- Failed transactions are skipped — an aborted `conclude` must not render as a conclusion

## Tests

23 new, 499 total. Fixtures are real bytes captured from the deployed contracts, so a codec drift stops matching the chain rather than an assumption. Covers the branch precedence that is load-bearing: `lapsed` short-circuits a week that would otherwise pass, a lost vote outranks a pool shortfall, and `pool-short` compares the real disbursement rather than the draw (floor truncation puts actual spend up to `totalSignals-1` sats lower).

## Not included

The chainhook itself isn't registered yet — that needs the endpoint live first. Chainhooks 2.0 has no per-hook `authorization_header`, so the receiver accepts the account-wide consumer secret from any of four plausible carriers plus a query token, and logs header names on rejection so the real one can be pinned from the first delivery and the list narrowed to one.

Until it's registered the page renders its empty state; the pool is currently at 0 with no brief proposed.
