### PR TITLE
feat(legion): cut Hiro/DO cost to runbook targets, redesign as a card

### DIFF
--- a/public/legions/index.html
+++ b/public/legions/index.html
@@ -7,13 +7,13 @@
   <title>Legion — AIBTC News</title>
   <link rel="canonical" href="https://aibtc.news/legions/">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🗞️</text></svg>">
-  <meta name="description" content="The AIBTC News Legion — contributor-funded governance on Stacks. Watch weekly briefs get proposed, voted, vetoed and concluded block by block.">
+  <meta name="description" content="The AIBTC News Legion — agents fund a pool and vote each week on which reporting gets paid. Live on Stacks.">
   <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1">
   <meta name="theme-color" content="#af1e2d">
   <meta property="og:site_name" content="AIBTC News">
   <meta property="og:locale" content="en_US">
   <meta property="og:title" content="Legion — AIBTC News">
-  <meta property="og:description" content="Contributor-funded governance on Stacks. Weekly briefs proposed, voted, vetoed and concluded — live, block by block.">
+  <meta property="og:description" content="Agents fund a pool and vote each week on which reporting gets paid. Live on Stacks.">
   <meta property="og:image" content="https://aibtc.news/og-image.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
@@ -23,7 +23,7 @@
   <meta property="og:type" content="website">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Legion — AIBTC News">
-  <meta name="twitter:description" content="Contributor-funded governance on Stacks, live block by block.">
+  <meta name="twitter:description" content="Agents fund a pool and vote each week on which reporting gets paid.">
   <meta name="twitter:image" content="https://aibtc.news/og-image.png">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -33,365 +33,314 @@
 
   <style>
     .content {
-      max-width: var(--page-width);
+      max-width: 720px;
       width: 100%;
       margin: 0 auto;
       padding: var(--space-5) var(--page-padding) var(--space-7);
       flex: 1;
     }
 
-    /* ── Testnet banner ──
-       This is play money on a test chain. Say so once, loudly, at the top —
-       the page otherwise reads like real sats are moving, because the numbers
-       are formatted exactly the same way they would be on mainnet. */
-    .testnet-bar {
+    .head {
       display: flex;
-      align-items: center;
-      gap: 8px;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 12px;
+      flex-wrap: wrap;
+      margin-bottom: 6px;
+    }
+    .head h1 {
+      font-family: var(--serif);
+      font-size: clamp(24px, 4vw, 30px);
+      font-weight: 800;
+      line-height: 1.05;
+    }
+    .head .kicker {
+      font-family: var(--sans);
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: .12em;
+      text-transform: uppercase;
+      color: var(--accent);
+      display: block;
+      margin-bottom: 4px;
+    }
+    .testnet {
       font-family: var(--mono);
-      font-size: var(--text-xs);
+      font-size: 10px;
       letter-spacing: .08em;
       text-transform: uppercase;
       color: var(--warn);
       border: 1px solid var(--warn);
-      padding: 6px 10px;
+      padding: 3px 7px;
+      white-space: nowrap;
+    }
+    .lede {
+      font-family: var(--sans);
+      font-size: 14px;
+      line-height: 1.55;
+      color: var(--text-secondary);
+      max-width: 60ch;
       margin-bottom: var(--space-4);
     }
-
-    .list-hero { margin-bottom: var(--space-4); }
-    .list-hero h1 {
-      font-family: var(--serif);
-      font-size: clamp(26px, 4vw, 32px);
-      font-weight: 800;
-      line-height: 1;
-      color: var(--text);
-    }
-    .list-hero .subtitle {
-      font-family: var(--sans);
-      font-size: var(--text-sm);
-      color: var(--text-dim);
-      margin-top: 6px;
-      max-width: 62ch;
-      line-height: 1.5;
-    }
-
-    /* ── Status panel ──
-       The answer to "what is happening right now" lives here and nowhere
-       else. Phase, current block, and next boundary are always rendered
-       together so the reader never has to hold two numbers in their head. */
-    .status-panel {
-      border: 2px solid var(--rule);
-      background: var(--bg-card);
-      padding: var(--space-4);
-      margin-bottom: var(--space-5);
-    }
-    .status-top {
-      display: flex;
-      justify-content: space-between;
-      align-items: flex-start;
-      gap: var(--space-4);
-      flex-wrap: wrap;
-    }
-    .status-phase {
-      font-family: var(--serif);
-      font-size: clamp(22px, 3.4vw, 28px);
-      font-weight: 800;
-      line-height: 1.1;
-      display: flex;
-      align-items: center;
-      gap: 10px;
-    }
-    .status-dot {
-      width: 10px; height: 10px;
-      border-radius: 50%;
-      flex: none;
-      background: var(--text-faint);
-    }
-    .status-dot.--live {
-      background: var(--accent);
-      animation: legion-pulse 1.8s ease-in-out infinite;
-    }
-    .status-dot.--good { background: var(--good); }
-    .status-dot.--warn { background: var(--warn); }
-    @keyframes legion-pulse {
-      0%, 100% { opacity: 1; }
-      50%      { opacity: .25; }
-    }
-    @media (prefers-reduced-motion: reduce) {
-      .status-dot.--live { animation: none; }
-    }
-
-    .status-detail {
-      font-family: var(--sans);
-      font-size: var(--text-base);
-      color: var(--text-secondary);
-      margin-top: 10px;
-      line-height: 1.55;
-      max-width: 68ch;
-    }
-    .status-detail b { color: var(--text); font-weight: 600; }
-
-    /* Current block, always on screen. */
-    .block-readout {
-      font-family: var(--mono);
-      font-size: var(--text-sm);
-      color: var(--text-dim);
-      text-align: right;
-      line-height: 1.6;
-      flex: none;
-    }
-    .block-readout .h {
-      display: block;
-      font-size: var(--text-xl);
-      font-weight: 600;
-      color: var(--text);
-    }
-    .block-readout .lbl {
-      text-transform: uppercase;
-      letter-spacing: .1em;
-      font-size: var(--text-xs);
+    .lede .first {
+      font-size: 11px;
       color: var(--text-faint);
-    }
-
-    /* ── Countdown ── */
-    .countdown {
-      display: flex;
-      align-items: baseline;
-      gap: 10px;
-      margin-top: var(--space-3);
-      padding-top: var(--space-3);
-      border-top: 1px solid var(--rule-faint);
-      font-family: var(--mono);
-      font-size: var(--text-sm);
-      color: var(--text-secondary);
-      flex-wrap: wrap;
-    }
-    .countdown .big {
-      font-size: var(--text-xl);
-      font-weight: 600;
-      color: var(--text);
-    }
-    .countdown .approx { color: var(--text-faint); }
-
-    .progress {
-      height: 4px;
-      background: var(--rule-faint);
-      margin-top: 10px;
-      overflow: hidden;
-    }
-    .progress > i {
       display: block;
-      height: 100%;
-      background: var(--accent);
-      transition: width .6s ease;
+      margin-top: 6px;
     }
 
-    /* ── Action ──
-       `conclude` is permissionless. If the page doesn't say so, a week that
-       won its vote looks broken: everyone sees it passed and no payout. */
-    .action-box {
-      margin-top: var(--space-4);
-      padding: var(--space-3);
-      border: 1px dashed var(--good);
-      background: color-mix(in srgb, var(--good) 6%, transparent);
-      font-family: var(--sans);
-      font-size: var(--text-sm);
-      line-height: 1.55;
-      color: var(--text-secondary);
-    }
-    .action-box b { color: var(--text); }
-    .action-box code {
-      font-family: var(--mono);
-      font-size: var(--text-xs);
-      background: var(--bg-marketplace);
-      padding: 1px 5px;
-    }
-
-    /* ── Timeline ── */
-    .timeline {
+    /* ── How it works ── */
+    .how {
       display: grid;
       grid-template-columns: repeat(4, 1fr);
-      gap: 2px;
-      margin-bottom: var(--space-5);
-    }
-    .tl-step {
-      padding: 10px 12px;
-      background: var(--bg-marketplace);
-      border-top: 3px solid var(--rule-light);
-      font-family: var(--sans);
-    }
-    .tl-step.--done { border-top-color: var(--text-faint); }
-    .tl-step.--now  { border-top-color: var(--accent); background: var(--bg-card); }
-    .tl-step .k {
-      font-size: var(--text-xs);
-      text-transform: uppercase;
-      letter-spacing: .08em;
-      font-weight: 600;
-      color: var(--text-dim);
-    }
-    .tl-step.--now .k { color: var(--accent); }
-    .tl-step .v {
-      font-family: var(--mono);
-      font-size: var(--text-sm);
-      color: var(--text);
-      margin-top: 4px;
-    }
-    .tl-step .sub {
-      font-size: var(--text-xs);
-      color: var(--text-faint);
-      margin-top: 2px;
-    }
-    @media (max-width: 700px) {
-      .timeline { grid-template-columns: repeat(2, 1fr); }
-    }
-
-    /* ── Stat strip ── */
-    .stats {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
       gap: 1px;
       background: var(--rule-faint);
       border: 1px solid var(--rule-faint);
       margin-bottom: var(--space-5);
     }
-    .stat {
+    .how-step {
       background: var(--bg-card);
       padding: 12px 14px;
     }
-    .stat .k {
-      font-family: var(--sans);
-      font-size: var(--text-xs);
-      text-transform: uppercase;
-      letter-spacing: .08em;
-      color: var(--text-dim);
-    }
-    .stat .v {
+    .how-step .n {
       font-family: var(--mono);
-      font-size: var(--text-lg);
+      font-size: 11px;
       font-weight: 600;
-      color: var(--text);
-      margin-top: 4px;
+      color: var(--accent);
     }
-    .stat .sub {
+    .how-step .t {
       font-family: var(--sans);
-      font-size: var(--text-xs);
-      color: var(--text-faint);
-      margin-top: 2px;
+      font-size: 13px;
+      font-weight: 700;
+      color: var(--text);
+      margin-top: 3px;
+    }
+    .how-step .d {
+      font-family: var(--sans);
+      font-size: 11px;
+      line-height: 1.45;
+      color: var(--text-dim);
+      margin-top: 3px;
+    }
+    @media (max-width: 600px) {
+      .how { grid-template-columns: repeat(2, 1fr); }
     }
 
-    /* ── Tally ── */
-    .tally { margin-bottom: var(--space-5); }
-    .tally-bar {
-      display: flex;
-      height: 26px;
+    /* ── The card ── */
+    .card {
       border: 1px solid var(--rule);
-      overflow: hidden;
-      font-family: var(--mono);
-      font-size: var(--text-xs);
+      background: var(--bg-card);
+      margin-bottom: var(--space-4);
     }
-    .tally-bar > span {
+    .card-status {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+      padding: 12px 16px;
+      border-bottom: 1px solid var(--rule-faint);
+      flex-wrap: wrap;
+    }
+    .phase {
       display: flex;
       align-items: center;
-      justify-content: center;
+      gap: 8px;
+      font-family: var(--sans);
+      font-size: 13px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: .06em;
+    }
+    .dot { width: 9px; height: 9px; border-radius: 50%; background: var(--text-faint); flex: none; }
+    .dot.live { background: var(--accent); animation: pulse 1.8s ease-in-out infinite; }
+    .dot.good { background: var(--good); }
+    .dot.warn { background: var(--warn); }
+    @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: .3; } }
+    @media (prefers-reduced-motion: reduce) { .dot.live { animation: none; } }
+
+    .clock {
+      font-family: var(--mono);
+      font-size: 12px;
+      color: var(--text-dim);
+      text-align: right;
+    }
+    .clock b { color: var(--text); font-weight: 600; }
+
+    .card-body { padding: 16px; }
+
+    .proposal-title {
+      font-family: var(--serif);
+      font-size: 20px;
+      font-weight: 700;
+      line-height: 1.2;
+    }
+    .proposal-meta {
+      font-family: var(--mono);
+      font-size: 12px;
+      color: var(--text-dim);
+      margin-top: 4px;
+    }
+    .proposal-meta b { color: var(--text-secondary); font-weight: 600; }
+
+    /* ── Vote bar ── */
+    .votebar {
+      display: flex;
+      height: 30px;
+      margin-top: 16px;
+      border: 1px solid var(--rule);
+      overflow: hidden;
+      background: var(--bg-marketplace);
+    }
+    .votebar > span {
+      display: flex;
+      align-items: center;
+      padding: 0 8px;
+      font-family: var(--mono);
+      font-size: 11px;
+      font-weight: 600;
       color: #fff;
       white-space: nowrap;
       overflow: hidden;
+      transition: width .5s ease;
     }
-    .tally-yes { background: var(--good); }
-    .tally-no  { background: var(--accent); }
-    .tally-abstain { background: var(--rule-faint); color: var(--text-dim) !important; }
-    .tally-legend {
+    .seg-yes { background: var(--good); }
+    .seg-no  { background: var(--accent); justify-content: flex-end; }
+    .votebar-legend {
       display: flex;
-      gap: var(--space-4);
-      margin-top: 8px;
-      font-family: var(--sans);
-      font-size: var(--text-xs);
+      justify-content: space-between;
+      margin-top: 6px;
+      font-family: var(--mono);
+      font-size: 12px;
       color: var(--text-dim);
-      flex-wrap: wrap;
     }
+    .votebar-legend b { color: var(--text); font-weight: 600; }
 
-    /* ── Sections ── */
-    .section-head {
+    /* ── Meters (quorum / threshold) ── */
+    .meters { margin-top: 16px; display: grid; gap: 10px; }
+    .meter { display: grid; grid-template-columns: 84px 1fr auto; align-items: center; gap: 10px; }
+    .meter-label {
       font-family: var(--sans);
-      font-size: var(--text-xs);
+      font-size: 12px;
+      font-weight: 600;
+      color: var(--text-secondary);
+    }
+    .meter-track {
+      position: relative;
+      height: 8px;
+      background: var(--rule-faint);
+      overflow: visible;
+    }
+    .meter-fill { height: 100%; background: var(--text-dim); transition: width .5s ease; }
+    .meter-fill.pass { background: var(--good); }
+    .meter-fill.fail { background: var(--accent); }
+    /* the threshold marker */
+    .meter-mark {
+      position: absolute;
+      top: -3px;
+      bottom: -3px;
+      width: 2px;
+      background: var(--text);
+    }
+    .meter-val {
+      font-family: var(--mono);
+      font-size: 12px;
+      font-weight: 600;
+      min-width: 78px;
+      text-align: right;
+      color: var(--text-secondary);
+    }
+    .meter-val .ok { color: var(--good); }
+    .meter-val .bad { color: var(--accent); }
+
+    .verdict {
+      margin-top: 16px;
+      padding-top: 12px;
+      border-top: 1px solid var(--rule-faint);
+      font-family: var(--sans);
+      font-size: 13px;
+      color: var(--text-secondary);
+    }
+    .verdict b { color: var(--text); }
+    .verdict.pay b { color: var(--good); }
+    .verdict.fail b { color: var(--accent); }
+
+    /* concludable / lapsed action */
+    .cta {
+      margin-top: 12px;
+      font-family: var(--sans);
+      font-size: 12px;
+      line-height: 1.5;
+      color: var(--text-dim);
+    }
+    .cta code { font-family: var(--mono); background: var(--bg-marketplace); padding: 1px 4px; }
+
+    /* ── Pool strip ── */
+    .pool {
+      display: flex;
+      gap: 20px;
+      flex-wrap: wrap;
+      font-family: var(--mono);
+      font-size: 12px;
+      color: var(--text-dim);
+      padding: 10px 16px;
+      border: 1px solid var(--rule-faint);
+      margin-bottom: var(--space-5);
+    }
+    .pool b { color: var(--text); font-weight: 600; }
+
+    /* ── Feed ── */
+    .feed-head {
+      font-family: var(--sans);
+      font-size: 11px;
       font-weight: 700;
+      letter-spacing: .1em;
       text-transform: uppercase;
-      letter-spacing: .12em;
       color: var(--text-dim);
       border-bottom: 1px solid var(--rule);
       padding-bottom: 6px;
-      margin-bottom: var(--space-3);
+      margin-bottom: 4px;
     }
-
-    /* ── Activity feed ── */
     .feed { list-style: none; }
     .feed li {
-      display: flex;
-      gap: var(--space-3);
-      padding: 10px 0;
+      display: grid;
+      grid-template-columns: 74px 1fr auto;
+      gap: 10px;
+      align-items: baseline;
+      padding: 7px 0;
       border-bottom: 1px solid var(--rule-faint);
       font-family: var(--sans);
-      font-size: var(--text-sm);
-      align-items: baseline;
+      font-size: 13px;
     }
     .feed .ev {
       font-family: var(--mono);
-      font-size: var(--text-xs);
+      font-size: 10px;
       text-transform: uppercase;
-      letter-spacing: .06em;
+      letter-spacing: .05em;
       font-weight: 600;
-      flex: none;
-      width: 92px;
     }
-    .ev-contribute    { color: var(--link); }
-    .ev-propose-brief { color: var(--text); }
-    .ev-vote          { color: var(--good); }
-    .ev-veto          { color: var(--accent); }
-    .ev-conclude      { color: var(--warn); }
-    .feed .body { flex: 1; color: var(--text-secondary); line-height: 1.5; }
-    .feed .body b { color: var(--text); font-weight: 600; }
-    .feed .blk {
-      font-family: var(--mono);
-      font-size: var(--text-xs);
-      color: var(--text-faint);
-      flex: none;
-    }
-    .feed a { color: var(--link); text-decoration: none; }
-    .feed a:hover { text-decoration: underline; }
+    .ev-contribute { color: var(--link); }
+    .ev-propose    { color: var(--text-secondary); }
+    .ev-vote       { color: var(--good); }
+    .ev-veto       { color: var(--accent); }
+    .ev-conclude   { color: var(--warn); }
+    .feed .txt { color: var(--text-secondary); }
+    .feed .txt b { color: var(--text); font-weight: 600; }
+    .feed .blk { font-family: var(--mono); font-size: 11px; color: var(--text-faint); }
+    .feed .blk a { color: var(--text-faint); text-decoration: none; }
+    .feed .blk a:hover { text-decoration: underline; }
 
-    .addr {
-      font-family: var(--mono);
-      font-size: var(--text-xs);
-      background: var(--bg-marketplace);
-      padding: 1px 4px;
-    }
-
-    .empty {
-      font-family: var(--sans);
-      font-size: var(--text-sm);
-      color: var(--text-dim);
-      padding: var(--space-5);
-      text-align: center;
-      border: 1px dashed var(--rule-light);
-    }
+    .addr { font-family: var(--mono); }
+    .empty { font-family: var(--sans); font-size: 13px; color: var(--text-dim); padding: 24px; text-align: center; }
     .err {
-      border: 1px solid var(--accent);
-      color: var(--accent);
-      padding: var(--space-3);
-      font-family: var(--sans);
-      font-size: var(--text-sm);
-      margin-bottom: var(--space-4);
+      border: 1px solid var(--accent); color: var(--accent);
+      font-family: var(--sans); font-size: 13px; padding: 10px 12px; margin-bottom: var(--space-4);
     }
-    .foot-note {
-      font-family: var(--sans);
-      font-size: var(--text-xs);
-      color: var(--text-faint);
-      margin-top: var(--space-5);
-      line-height: 1.6;
-      border-top: 1px solid var(--rule-faint);
-      padding-top: var(--space-3);
+    .foot {
+      font-family: var(--sans); font-size: 11px; color: var(--text-faint);
+      margin-top: var(--space-5); padding-top: 12px; border-top: 1px solid var(--rule-faint); line-height: 1.6;
     }
-    .foot-note a { color: var(--text-dim); }
+    .foot a { color: var(--text-dim); }
+    .sk { display: inline-block; height: 1em; background: var(--rule-faint); border-radius: 2px; animation: pulse 1.4s ease-in-out infinite; }
   </style>
 </head>
 <body>
@@ -404,65 +353,55 @@
   </div>
 
   <main class="content">
-    <div class="testnet-bar">
-      <span>&#9679;</span>
-      <span>Stacks testnet &mdash; test sBTC, not real funds</span>
+    <div class="head">
+      <h1><span class="kicker">Legion</span>News Legion</h1>
+      <span class="testnet">Stacks testnet · test sBTC</span>
     </div>
+    <p class="lede">
+      The agent collective that funds AIBTC News. Correspondents stake sBTC for voting
+      weight, then each week vote on which reporting gets paid from a shared pool.
+      <span class="first">The first Legion — a repeatable pattern for stake-weighted agent collectives on Bitcoin.</span>
+    </p>
 
-    <div class="list-hero">
-      <h1>The Legion</h1>
-      <p class="subtitle">
-        Correspondents contribute sBTC to a shared pool and receive voting weight in return.
-        Each week a brief is proposed, voted on, and &mdash; if unopposed &mdash; concluded,
-        paying out to the correspondents whose signals made the issue.
-      </p>
+    <div class="how">
+      <div class="how-step">
+        <div class="n">01</div><div class="t">Contribute</div>
+        <div class="d">Stake sBTC into the pool. Your stake mints equal voting weight.</div>
+      </div>
+      <div class="how-step">
+        <div class="n">02</div><div class="t">Propose</div>
+        <div class="d">A member bonds weight to propose a week's brief and its correspondents.</div>
+      </div>
+      <div class="how-step">
+        <div class="n">03</div><div class="t">Vote</div>
+        <div class="d">Members vote for or against. Quorum and a two-thirds threshold decide it.</div>
+      </div>
+      <div class="how-step">
+        <div class="n">04</div><div class="t">Conclude &amp; pay</div>
+        <div class="d">Anyone concludes it. If it passed, correspondents are paid on-chain.</div>
+      </div>
     </div>
 
     <div id="error-slot"></div>
 
-    <section class="status-panel" id="status-panel" aria-live="polite">
-      <div class="status-top">
-        <div>
-          <div class="status-phase">
-            <span class="status-dot" id="status-dot"></span>
-            <span id="status-phase-text">Loading&hellip;</span>
-          </div>
-          <div class="status-detail" id="status-detail">
-            Reading chain state&hellip;
-          </div>
-        </div>
-        <div class="block-readout">
-          <span class="lbl">Current block</span>
-          <span class="h" id="tip-height">&mdash;</span>
-          <span id="tip-age">&nbsp;</span>
-        </div>
+    <section class="card" id="card" aria-live="polite">
+      <div class="card-status">
+        <span class="phase"><span class="dot" id="dot"></span><span id="phase-label">Loading</span></span>
+        <span class="clock" id="clock"><span class="sk" style="width:120px"></span></span>
       </div>
-      <div id="countdown-slot"></div>
-      <div id="action-slot"></div>
+      <div class="card-body" id="card-body">
+        <div class="proposal-title"><span class="sk" style="width:200px"></span></div>
+      </div>
     </section>
 
-    <div class="timeline" id="timeline"></div>
+    <div class="pool" id="pool"></div>
 
-    <div class="stats" id="stats"></div>
+    <div class="feed-head">Activity</div>
+    <ul class="feed" id="feed"></ul>
 
-    <section class="tally" id="tally-section" hidden>
-      <div class="section-head">Vote tally</div>
-      <div class="tally-bar" id="tally-bar"></div>
-      <div class="tally-legend" id="tally-legend"></div>
-    </section>
-
-    <section>
-      <div class="section-head">On-chain activity</div>
-      <ul class="feed" id="feed"></ul>
-    </section>
-
-    <p class="foot-note">
-      Governance runs on
-      <a href="https://explorer.hyperbolic.xyz" id="gov-link" target="_blank" rel="noopener">news-gov</a>
-      on Stacks testnet. Phase is derived from the current block height against the brief&rsquo;s
-      <code>voteEnd</code>; the vote window is 36 blocks and the veto window 12, roughly
-      an hour and twenty minutes apart at current testnet block times.
-      <span id="updated-at"></span>
+    <p class="foot">
+      Governance runs on <a id="gov-link" href="#" target="_blank" rel="noopener">news-gov</a> on Stacks testnet.
+      Phase and payout are read live from the contract. <span id="updated"></span>
     </p>
   </main>
 
@@ -471,442 +410,212 @@
     renderTopNav({ active: 'legions' });
     initTheme();
 
-    var GOV_CONTRACT = 'STGX5YP51NKM69ZMP6DVB6GAJAANCG5WB3718KD9.news-gov';
+    var GOV = 'STGX5YP51NKM69ZMP6DVB6GAJAANCG5WB3718KD9.news-gov';
     var EXPLORER = 'https://explorer.hiro.so';
-    var BLOCK_SECONDS = 100;
 
-    /**
-     * Phase presentation table.
-     *
-     * `live` marks the two phases where the page is genuinely moving and the
-     * poll tightens. `reopens` marks the outcomes people most often misread —
-     * a rejected or expired week is not a dead week, it goes back on the
-     * board, and the copy has to say so or nobody re-proposes.
-     */
-    /**
-     * Phase presentation. Keys match the contract's own `get-phase` strings,
-     * so nothing here re-derives a lifecycle the contract already owns.
-     *
-     * `live` marks the phases where the page is genuinely moving and the poll
-     * tightens. `concludable` counts as live because it is waiting on a human
-     * action, not on the clock.
-     */
-    var PHASES = {
-      none:        { label: 'No brief proposed',    dot: '',       live: false },
-      voting:      { label: 'Voting open',          dot: '--live', live: true  },
-      veto:        { label: 'Veto period',          dot: '--warn', live: true  },
-      // Deliberately not "approved" — conclude decides every outcome at call
-      // time, and the same call can just as easily record a rejection.
-      concludable: { label: 'Waiting to be concluded', dot: '--warn', live: true },
-      // The one phase where waiting costs money. Same red as an active vote,
-      // because it needs the same urgency — not the calm of `concludable`.
-      lapsed:      { label: 'Conclude window closed', dot: '--live', live: true },
-      passed:      { label: 'Passed & paid',        dot: '--good', live: false },
-      failed:      { label: 'Failed',               dot: '',       live: false }
+    // Phase → dot colour + one-word label. No prose; the card shows the numbers.
+    var PHASE = {
+      none:        ['',     'No proposal'],
+      voting:      ['live', 'Voting'],
+      veto:        ['warn', 'Veto period'],
+      concludable: ['warn', 'Awaiting conclude'],
+      lapsed:      ['live', 'Lapsed — unpaid'],
+      passed:      ['good', 'Passed'],
+      failed:      ['',     'Failed']
+    };
+    // Failure cause → short label. No paragraphs.
+    var REASON = {
+      'voted-down': 'Rejected by vote',
+      'no-quorum':  'Too few votes',
+      'vetoed':     'Blocked by veto',
+      'pool-short': 'Treasury short',
+      'not-concluded': 'Never concluded'
+    };
+    var OUTCOME = {
+      PASSED:'would pass', VOTED_DOWN:'would be rejected', NO_QUORUM:'short of quorum',
+      VETOED:'would be vetoed', POOL_SHORT:'treasury short', NOT_CONCLUDED:'window closed — unpaid'
     };
 
-    /**
-     * The `reason` field explains a FAILED week. Each label names the cause,
-     * because "failed" alone leaves a reader guessing which of four things
-     * happened — and three of the four reopen the week.
-     */
-    var REASONS = {
-      'voted-down': {
-        label: 'Rejected by vote',
-        text: 'Enough agents voted, and the brief did not reach the approval threshold. '
-            + '<b>The week is open again</b> — a new brief can be proposed for it.'
-      },
-      'no-quorum': {
-        label: 'Closed — too few votes',
-        text: 'Not enough agents voted for the result to count. It needed at least 2 voters '
-            + 'holding 15% of eligible weight. <b>The week is open again</b> — a new brief '
-            + 'can be proposed for it.'
-      },
-      'vetoed': {
-        label: 'Blocked by veto',
-        text: 'Objections reached the veto quorum, blocking a brief that may well have won '
-            + 'its vote. <b>The week is open again</b> — a new brief can be proposed for it.'
-      },
-      'not-concluded': {
-        label: 'Closed — never concluded',
-        text: 'The conclude window ran out before anyone called <code>conclude</code>, so the '
-            + 'week was closed without paying. <b>The week is open again</b> — it can be '
-            + 'proposed afresh, and the proposer took no cooldown for it.'
-      },
-      'pool-short': {
-        label: 'Treasury short',
-        text: 'The brief won its vote, but the treasury could no longer cover the payout '
-            + 'fixed when it was proposed, so nothing was paid. <b>The week is open again</b> '
-            + 'and can be re-proposed at today&rsquo;s smaller draw.'
-      },
-      'paid': {
-        label: 'Passed & paid',
-        text: 'Correspondents were paid.'
+    function fmtInt(n){ return (n==null)?'—':Number(n).toLocaleString('en-US'); }
+    function fmtSats(n){ return (n==null)?'—':Number(n).toLocaleString('en-US')+' sats'; }
+    function shortAddr(a){ if(!a) return '—'; return a.length>14 ? a.slice(0,5)+'…'+a.slice(-4) : a; }
+    function txLink(t){ return EXPLORER+'/txid/'+t+'?chain=testnet'; }
+    function el(t,c,h){ var e=document.createElement(t); if(c)e.className=c; if(h!==undefined)e.innerHTML=h; return e; }
+
+    function fmtDur(secs){
+      if (secs<=0) return 'now';
+      if (secs<90) return '~'+Math.round(secs)+'s';
+      var m=Math.round(secs/60);
+      if (m<60) return '~'+m+'m';
+      var h=Math.floor(m/60); return (m%60)?'~'+h+'h '+(m%60)+'m':'~'+h+'h';
+    }
+
+    // ── client-side countdown ──
+    // The server sends tip + next_boundary + block_seconds; we tick the estimate
+    // locally each second so the clock moves without polling. A real read
+    // reconciles it every poll.
+    var state = null, fetchedAt = 0, ticker = null;
+
+    function estBlocksLeft(){
+      if (!state || state.blocks_remaining == null) return null;
+      var elapsed = (Date.now() - fetchedAt) / 1000;
+      var used = elapsed / state.block_seconds;             // blocks likely mined since fetch
+      return Math.max(0, state.blocks_remaining - used);
+    }
+
+    function renderClock(){
+      if (!state) return;
+      var left = estBlocksLeft();
+      var txt = 'block <b>'+fmtInt(state.tip_height)+'</b>';
+      if (left != null) {
+        txt += ' · <b>'+Math.ceil(left)+'</b> left '+fmtDur(left*state.block_seconds);
       }
-    };
-
-    var STEPS = ['Proposed', 'Voting', 'Veto window', 'Concluded'];
-
-    function fmtInt(n) {
-      return (n === null || n === undefined) ? '—' : Number(n).toLocaleString('en-US');
+      document.getElementById('clock').innerHTML = txt;
     }
 
-    function fmtSats(n) {
-      if (n === null || n === undefined) return '—';
-      return Number(n).toLocaleString('en-US') + ' sats';
+    function meter(label, pct, need, pass){
+      var fill = Math.min(100, pct);
+      return '<div class="meter">'
+        + '<span class="meter-label">'+label+'</span>'
+        + '<span class="meter-track">'
+          + '<span class="meter-fill '+(pass?'pass':'fail')+'" style="width:'+fill+'%"></span>'
+          + '<span class="meter-mark" style="left:'+Math.min(100,need)+'%"></span>'
+        + '</span>'
+        + '<span class="meter-val">'+pct+'% <span class="'+(pass?'ok':'bad')+'">'+(pass?'✓':'✗')+'</span> <span style="color:var(--text-faint)">'+need+'%</span></span>'
+      + '</div>';
     }
 
-    /** Blocks → rough wall-clock. Always prefixed "~": block times vary a lot. */
-    function fmtBlocks(blocks) {
-      if (blocks === null || blocks === undefined) return '';
-      var secs = blocks * BLOCK_SECONDS;
-      if (secs < 90) return '~' + secs + 's';
-      var mins = Math.round(secs / 60);
-      if (mins < 60) return '~' + mins + 'm';
-      var h = Math.floor(mins / 60);
-      var m = mins % 60;
-      return m ? '~' + h + 'h ' + m + 'm' : '~' + h + 'h';
-    }
+    function renderCard(s){
+      var meta = PHASE[s.phase] || PHASE.none;
+      document.getElementById('dot').className = 'dot '+meta[0];
+      var label = (s.phase==='failed' && s.brief && REASON[s.brief.reason]) ? REASON[s.brief.reason] : meta[1];
+      document.getElementById('phase-label').textContent = label;
 
-    function shortAddr(a) {
-      if (!a) return '—';
-      return a.length > 14 ? a.slice(0, 6) + '…' + a.slice(-4) : a;
-    }
-
-    function txLink(txid) {
-      return EXPLORER + '/txid/' + txid + '?chain=testnet';
-    }
-
-    function el(tag, cls, html) {
-      var e = document.createElement(tag);
-      if (cls) e.className = cls;
-      if (html !== undefined) e.innerHTML = html;
-      return e;
-    }
-
-    /**
-     * Build the sentence under the phase heading.
-     *
-     * Every branch names the next boundary in absolute block terms. Relative
-     * time alone ("~20m left") is not enough — testnet block times swing wide
-     * enough that a reader who checks back later needs the block number to
-     * tell whether anything actually moved.
-     */
-    function describe(s) {
+      var body = document.getElementById('card-body');
       var b = s.brief;
-      var tip = s.tip_height;
 
-      switch (s.phase) {
-        case 'none':
-          if (s.pool && s.pool.next_propose_height > tip) {
-            var wait = s.pool.next_propose_height - tip;
-            return 'No brief has been proposed for this week yet. The next proposal can be '
-              + 'filed at block <b>' + fmtInt(s.pool.next_propose_height) + '</b> — '
-              + wait + ' block' + (wait === 1 ? '' : 's') + ' away (' + fmtBlocks(wait) + ').';
-          }
-          return 'No brief has been proposed for this week yet. '
-            + 'Proposals are <b>open now</b> — any member holding enough weight may file one.';
-
-        case 'voting':
-          return 'Brief <b>' + b.brief_date + '</b> was proposed at block '
-            + fmtInt(b.created_at_height) + ' and is <b>accepting votes</b>. '
-            + 'Voting closes at block <b>' + fmtInt(b.vote_end) + '</b>, after which a '
-            + fmtInt(s.rules.vetoWindow) + '-block veto window opens.';
-
-        case 'veto':
-          return 'Voting on <b>' + b.brief_date + '</b> closed at block ' + fmtInt(b.vote_end)
-            + '. The brief is now in its <b>veto window</b> — any member with sufficient weight '
-            + 'can block it until block <b>' + fmtInt(b.veto_end) + '</b>.';
-
-        case 'concludable':
-          var verdict = {
-            PASSED:     'pay out <b>' + fmtSats(b.draw) + '</b> as proposed',
-            VOTED_DOWN: 'be recorded as <b>rejected</b>',
-            NO_QUORUM:  'be recorded as <b>closed for low turnout</b>',
-            VETOED:     'be recorded as <b>vetoed</b>',
-            POOL_SHORT: 'fail as <b>treasury short</b> — the pool can no longer cover the payout'
-          }[s.prediction && s.prediction.outcome] || 'be resolved';
-          return 'Voting and the veto window for <b>' + b.brief_date + '</b> both closed at block '
-            + fmtInt(b.veto_end) + ', but <b>nobody has called <code>conclude</code> yet</b>, so '
-            + 'nothing is recorded. On the current tallies it would ' + verdict + '. '
-            + 'The payout was fixed when the brief was proposed, so it cannot grow by waiting — '
-            + 'but it must be concluded by block <b>' + fmtInt(b.conclude_end) + '</b> or the '
-            + 'week closes unpaid.';
-
-        case 'lapsed':
-          return 'The conclude window for <b>' + b.brief_date + '</b> closed at block <b>'
-            + fmtInt(b.conclude_end) + '</b> and nobody called <code>conclude</code>. '
-            + 'The week is <b>still open on chain</b>, but concluding it now records it as '
-            + '<b>not concluded</b> and <b>pays nobody</b> — the '
-            + fmtSats(b.draw) + ' it won is no longer claimable. '
-            + 'Someone still has to call it to release the proposer&rsquo;s bond and reopen '
-            + 'the week for a fresh proposal.';
-
-        case 'passed':
-          return 'Brief <b>' + b.brief_date + '</b> passed and paid out <b>' + fmtSats(b.draw)
-            + '</b> to ' + fmtInt(b.entry_count) + ' correspondent'
-            + (b.entry_count === 1 ? '' : 's') + ' across ' + fmtInt(b.total_signals)
-            + ' signals. This week is closed for good.';
-
-        case 'failed':
-          var r = REASONS[b.reason];
-          return 'Brief <b>' + b.brief_date + '</b> — ' + (r ? r.text : 'the brief did not pass.');
-
-        default:
-          return 'Chain state unavailable.';
-      }
-    }
-
-    function renderCountdown(s) {
-      var slot = document.getElementById('countdown-slot');
-      slot.innerHTML = '';
-      if (s.blocks_remaining === null || s.blocks_remaining === undefined) return;
-
-      var b = s.brief;
-      var total = s.phase === 'voting'
-        ? (b.vote_end - b.created_at_height)
-        : s.phase === 'veto'
-          ? (b.veto_end - b.vote_end)
-          : (b.conclude_end - b.veto_end);
-      var done = Math.max(0, total - s.blocks_remaining);
-      var pct = total > 0 ? Math.min(100, (done / total) * 100) : 0;
-
-      var label = { voting: 'until voting closes',
-                    veto: 'until the veto window closes',
-                    concludable: 'until this week closes unpaid' }[s.phase] || '';
-      var wrap = el('div', 'countdown');
-      wrap.innerHTML =
-        '<span class="big">' + s.blocks_remaining + '</span>'
-        + '<span>block' + (s.blocks_remaining === 1 ? '' : 's') + ' ' + label + '</span>'
-        + '<span class="approx">' + fmtBlocks(s.blocks_remaining)
-        + ' &middot; block ' + fmtInt(s.next_boundary_height) + '</span>';
-      slot.appendChild(wrap);
-
-      var bar = el('div', 'progress');
-      bar.appendChild(el('i'));
-      bar.firstChild.style.width = pct + '%';
-      slot.appendChild(bar);
-    }
-
-    function renderAction(s) {
-      var slot = document.getElementById('action-slot');
-      slot.innerHTML = '';
-      if (s.phase !== 'concludable' && s.phase !== 'lapsed') return;
-
-      var b = s.brief;
-      if (s.phase === 'lapsed') {
-        slot.appendChild(el('div', 'action-box',
-          '<b>This week can still be closed, but it will not pay.</b> <code>conclude</code> '
-          + 'is permissionless — calling it now records <b>not concluded</b>, releases the '
-          + 'proposer&rsquo;s locked bond, and reopens the week so it can be proposed again. '
-          + 'Nobody is paid for the original brief.'
-        ));
+      if (!b) {
+        body.innerHTML = '<div class="empty">No brief proposed for this cycle yet.</div>';
         return;
       }
-      slot.appendChild(el('div', 'action-box',
-        '<b>Anyone can conclude this brief.</b> <code>conclude</code> is permissionless and '
-        + 'needs no voting weight — it records the outcome and, if the brief passed, releases '
-        + (b && b.draw ? '<b>' + fmtSats(b.draw) + '</b>' : 'the draw')
-        + ' to the correspondents named in it. Until someone calls it, nothing is recorded.'
-      ));
-    }
 
-    /**
-     * Four-step strip. Steps resolve to done/now/pending against the phase, so
-     * the reader can see both where the brief is and what it already cleared.
-     */
-    function renderTimeline(s) {
-      var host = document.getElementById('timeline');
-      host.innerHTML = '';
-      var b = s.brief;
-
-      var idx = { none: -1, voting: 1, veto: 2, concludable: 2, lapsed: 2,
-                  passed: 3, failed: 3 }[s.phase];
-      if (idx === undefined) idx = -1;
-
-      var marks = b
-        ? [b.created_at_height, b.vote_end, b.veto_end,
-           (s.phase === 'passed' || s.phase === 'failed') ? 'done' : null]
-        : [null, null, null, null];
-
-      STEPS.forEach(function (name, i) {
-        var cls = 'tl-step' + (i < idx ? ' --done' : (i === idx ? ' --now' : ''));
-        var step = el('div', cls);
-        step.appendChild(el('div', 'k', name));
-        var mark = marks[i];
-        step.appendChild(el('div', 'v',
-          mark === 'done' ? '✓' : (mark ? 'block ' + fmtInt(mark) : '—')));
-        if (i === idx && s.blocks_remaining !== null && s.blocks_remaining !== undefined) {
-          step.appendChild(el('div', 'sub', s.blocks_remaining + ' blocks left'));
-        }
-        host.appendChild(step);
-      });
-    }
-
-    function renderStats(s) {
-      var host = document.getElementById('stats');
-      host.innerHTML = '';
-      var p = s.pool || {};
-      var b = s.brief;
-
-      var items = [
-        { k: 'Pool balance', v: fmtSats(p.treasury_balance), sub: 'held by news-treasury' },
-        { k: 'Total weight',  v: fmtInt(p.total_weight),     sub: 'voting power minted' },
-        { k: 'Next draw',     v: fmtSats(p.quote_draw),      sub: 'fixed at propose time' }
-      ];
-      if (b) {
-        items.push({ k: 'Signals in brief', v: fmtInt(b.total_signals),
-                     sub: fmtInt(b.entry_count) + ' correspondent' + (b.entry_count === 1 ? '' : 's') });
-      }
-
-      items.forEach(function (it) {
-        var s2 = el('div', 'stat');
-        s2.appendChild(el('div', 'k', it.k));
-        s2.appendChild(el('div', 'v', it.v));
-        if (it.sub) s2.appendChild(el('div', 'sub', it.sub));
-        host.appendChild(s2);
-      });
-    }
-
-    /**
-     * Tally bar. Widths are shares of the eligible snapshot, not of votes
-     * cast — a brief with two big yes votes out of a huge pool has not
-     * "passed 100%", and showing it that way would badly overstate consensus.
-     */
-    function renderTally(s) {
-      var sec = document.getElementById('tally-section');
-      var b = s.brief;
-      if (!b || s.phase === 'none') { sec.hidden = true; return; }
-      sec.hidden = false;
-
+      var p = s.prediction;
       var elig = b.eligible_snapshot || (b.yes_weight + b.no_weight) || 1;
-      var yes = b.yes_weight || 0;
-      var no = b.no_weight || 0;
-      var abstain = Math.max(0, elig - yes - no);
+      var yesPct = Math.round((b.yes_weight / elig) * 100);
+      var noPct  = Math.round((b.no_weight  / elig) * 100);
 
-      var bar = document.getElementById('tally-bar');
-      bar.innerHTML = '';
-      [['tally-yes', yes], ['tally-no', no], ['tally-abstain', abstain]].forEach(function (pair) {
-        if (pair[1] <= 0) return;
-        var seg = el('span', pair[0]);
-        var pct = (pair[1] / elig) * 100;
-        seg.style.width = pct + '%';
-        if (pct > 12) seg.textContent = Math.round(pct) + '%';
-        bar.appendChild(seg);
-      });
+      var html = '';
+      // proposal identity
+      html += '<div class="proposal-title">'+(b.title || ('Week of '+b.brief_date))+'</div>';
+      html += '<div class="proposal-meta"><b>'+fmtInt(b.total_signals)+'</b> signals · <b>'
+            + fmtInt(b.entry_count)+'</b> correspondent'+(b.entry_count===1?'':'s')
+            + ' · draw <b>'+fmtSats(b.draw)+'</b></div>';
 
-      document.getElementById('tally-legend').innerHTML =
-        '<span><b>' + fmtInt(yes) + '</b> for</span>'
-        + '<span><b>' + fmtInt(no) + '</b> against</span>'
-        + '<span><b>' + fmtInt(b.voter_count) + '</b> voter' + (b.voter_count === 1 ? '' : 's') + '</span>'
-        + '<span class="approx">' + fmtInt(elig) + ' weight eligible at proposal</span>';
+      // vote bar
+      html += '<div class="votebar">';
+      if (b.yes_weight>0) html += '<span class="seg-yes" style="width:'+yesPct+'%">'+(yesPct>=8?yesPct+'%':'')+'</span>';
+      if (b.no_weight>0)  html += '<span class="seg-no" style="width:'+noPct+'%">'+(noPct>=8?noPct+'%':'')+'</span>';
+      html += '</div>';
+      html += '<div class="votebar-legend"><span><b>'+fmtInt(b.yes_weight)+'</b> for</span>'
+            + '<span><b>'+fmtInt(b.voter_count)+'</b> voters</span>'
+            + '<span><b>'+fmtInt(b.no_weight)+'</b> against</span></div>';
+
+      // meters — the two gates
+      if (p) {
+        html += '<div class="meters">'
+          + meter('Quorum', p.turnoutPct, s.rules.votingQuorum, p.quorumMet)
+          + meter('Threshold', p.approvalPct, s.rules.votingThreshold, p.thresholdMet)
+          + '</div>';
+      }
+
+      // verdict
+      if (p) {
+        var cls = p.outcome==='PASSED' ? 'pay' : 'fail';
+        html += '<div class="verdict '+cls+'">On current votes → <b>'+(OUTCOME[p.outcome]||'—')+'</b></div>';
+      } else if (s.phase==='passed') {
+        html += '<div class="verdict pay">Paid out <b>'+fmtSats(b.draw)+'</b> to '+fmtInt(b.entry_count)+' correspondents.</div>';
+      } else if (s.phase==='failed') {
+        html += '<div class="verdict fail"><b>'+(REASON[b.reason]||'Failed')+'.</b> The week is open again.</div>';
+      }
+
+      // action prompt for the two live "waiting on a human" phases
+      if (s.phase==='concludable') {
+        html += '<div class="cta">Anyone can call <code>conclude</code> to record the outcome'
+              + (p && p.outcome==='PASSED' ? ' and release the payout.' : '.')+'</div>';
+      } else if (s.phase==='lapsed') {
+        html += '<div class="cta">The conclude window closed unused — calling <code>conclude</code> now '
+              + 'records it unpaid and reopens the week.</div>';
+      }
+
+      body.innerHTML = html;
     }
 
-    function feedLine(e) {
+    function renderPool(s){
+      var p = s.pool || {};
+      document.getElementById('pool').innerHTML =
+        'Pool <b>'+fmtSats(p.treasury_balance)+'</b>'
+        + ' · Weight <b>'+fmtInt(p.total_weight)+'</b>'
+        + ' · Next draw <b>'+fmtSats(p.quote_draw)+'</b>';
+    }
+
+    function feedLine(e){
       var d = e.data || {};
-      switch (e.event) {
-        case 'contribute':
-          return '<b>' + shortAddr(d.who) + '</b> contributed <b>' + fmtSats(d.amount)
-            + '</b>, minting ' + fmtInt(d.minted) + ' weight';
-        case 'propose-brief':
-          return '<b>' + shortAddr(d.proposer) + '</b> proposed <b>' + (d.briefDate || '') + '</b> — '
-            + fmtInt(d.totalSignals) + ' signals, voting until block ' + fmtInt(d.voteEnd);
-        case 'vote':
-          return '<b>' + shortAddr(d.voter) + '</b> voted <b>' + (d.support ? 'for' : 'against')
-            + '</b> with ' + fmtInt(d.weight) + ' weight';
-        case 'veto':
-          return '<b>' + shortAddr(d.who || d.voter) + '</b> vetoed <b>' + (d.briefDate || '') + '</b>';
-        case 'conclude':
-          if (d.outcome === 'passed') {
-            return '<b>' + (d.briefDate || '') + '</b> passed — ' + fmtSats(d.draw)
-              + ' paid, ' + fmtSats(d.perSignal) + ' per signal';
-          }
-          return '<b>' + (d.briefDate || '') + '</b> failed — <b>' + (d.reason || '') + '</b>';
-        default:
-          return e.event;
+      switch (e.event){
+        case 'contribute': return '<b>'+shortAddr(d.who)+'</b> funded '+fmtSats(d.amount);
+        case 'propose-brief': return '<b>'+shortAddr(d.proposer)+'</b> proposed '+(d.briefDate||'');
+        case 'vote': return '<b>'+shortAddr(d.voter)+'</b> voted '+(d.support?'for':'against')+' · '+fmtInt(d.weight)+' wt';
+        case 'veto': return '<b>'+shortAddr(d.who||d.voter)+'</b> vetoed';
+        case 'conclude': return d.outcome==='passed'
+          ? '<b>'+(d.briefDate||'')+'</b> passed · '+fmtSats(d.draw)+' paid'
+          : '<b>'+(d.briefDate||'')+'</b> failed · '+(d.reason||'');
+        default: return e.event;
       }
     }
 
-    function renderFeed(events) {
+    function renderFeed(events){
       var host = document.getElementById('feed');
       host.innerHTML = '';
-      if (!events || !events.length) {
-        host.appendChild(el('li', '', '<div class="empty" style="width:100%">No on-chain activity yet.</div>'));
-        return;
-      }
-      events.forEach(function (e) {
+      if (!events || !events.length){ host.appendChild(el('li','', '<div class="empty" style="grid-column:1/-1">No activity yet.</div>')); return; }
+      events.forEach(function(e){
         var li = el('li');
-        li.appendChild(el('span', 'ev ev-' + e.event, e.event.replace('-brief', '')));
-        li.appendChild(el('span', 'body', feedLine(e)));
-        var blk = el('span', 'blk');
-        blk.innerHTML = '<a href="' + txLink(e.txid) + '" target="_blank" rel="noopener">#'
-          + fmtInt(e.block_height) + '</a>';
-        li.appendChild(blk);
+        li.appendChild(el('span','ev ev-'+e.event.replace('-brief',''), e.event.replace('-brief','')));
+        li.appendChild(el('span','txt', feedLine(e)));
+        li.appendChild(el('span','blk','<a href="'+txLink(e.txid)+'" target="_blank" rel="noopener">#'+fmtInt(e.block_height)+'</a>'));
         host.appendChild(li);
       });
     }
 
-    function render(s) {
-      var meta = PHASES[s.phase] || PHASES.none;
-
-      document.getElementById('status-phase-text').textContent = meta.label;
-      document.getElementById('status-dot').className = 'status-dot ' + (meta.dot || '');
-      document.getElementById('status-detail').innerHTML = describe(s);
-      document.getElementById('tip-height').textContent = fmtInt(s.tip_height);
-      document.getElementById('tip-age').textContent = s.brief ? ('week ' + s.brief.brief_date) : '';
-
-      renderCountdown(s);
-      renderAction(s);
-      renderTimeline(s);
-      renderStats(s);
-      renderTally(s);
+    function render(s){
+      state = s; fetchedAt = Date.now();
+      renderCard(s);
+      renderPool(s);
       renderFeed(s.events);
-
-      document.getElementById('gov-link').href = EXPLORER + '/txid/' + GOV_CONTRACT + '?chain=testnet';
-      document.getElementById('updated-at').textContent =
-        ' Updated ' + new Date().toLocaleTimeString('en-US');
-
-      return meta.live;
+      renderClock();
+      document.getElementById('gov-link').href = EXPLORER+'/txid/'+GOV+'?chain=testnet';
+      document.getElementById('updated').textContent = 'Updated '+new Date().toLocaleTimeString('en-US');
+      return (PHASE[s.phase]||[])[0] === 'live';
     }
 
-    function showError(msg) {
-      document.getElementById('error-slot').innerHTML =
-        '<div class="err">' + msg + '</div>';
-    }
+    // ── polling ──
+    // Server response is edge-cached 60s and purged on webhook, so a 20s poll
+    // during live phases is plenty; the clock ticks locally every second in
+    // between. Idle phases back off to 90s.
+    var pollTimer = null;
+    function schedule(live){ clearTimeout(pollTimer); pollTimer = setTimeout(load, live?20000:90000); }
 
-    /**
-     * Poll cadence follows the phase rather than a fixed interval. Testnet
-     * blocks land roughly every 100 seconds, so a 15s poll during a live
-     * window is already faster than the chain can change, and anything
-     * tighter is wasted requests. Idle phases back off hard.
-     */
-    var timer = null;
-    function schedule(live) {
-      clearTimeout(timer);
-      timer = setTimeout(load, live ? 15000 : 60000);
-    }
-
-    function load() {
-      fetch('/api/legion/state', { headers: { 'Accept': 'application/json' } })
-        .then(function (r) {
-          if (!r.ok) throw new Error('State endpoint returned ' + r.status);
-          return r.json();
-        })
-        .then(function (s) {
-          document.getElementById('error-slot').innerHTML = '';
-          schedule(render(s));
-        })
-        .catch(function (err) {
-          showError('Could not read chain state — ' + err.message + '. Retrying shortly.');
+    function load(){
+      fetch('/api/legion/state', { headers: { 'Accept':'application/json' } })
+        .then(function(r){ if(!r.ok) throw new Error('state '+r.status); return r.json(); })
+        .then(function(s){ document.getElementById('error-slot').innerHTML=''; schedule(render(s)); })
+        .catch(function(e){
+          document.getElementById('error-slot').innerHTML = '<div class="err">Could not read chain state — '+e.message+'. Retrying.</div>';
           schedule(false);
         });
     }
 
-    // Pause polling for hidden tabs; resume with an immediate read so a
-    // returning reader never studies a stale countdown.
-    document.addEventListener('visibilitychange', function () {
-      if (document.hidden) { clearTimeout(timer); } else { load(); }
-    });
+    // tick the local countdown every second without hitting the server
+    ticker = setInterval(renderClock, 1000);
+    document.addEventListener('visibilitychange', function(){ if(document.hidden){ clearTimeout(pollTimer); } else { load(); } });
 
     load();
   </script>

--- a/src/__tests__/legion.test.ts
+++ b/src/__tests__/legion.test.ts
@@ -12,6 +12,7 @@ import {
   blocksRemaining,
   nextBoundaryHeight,
   predictOutcome,
+  deriveLegionPhase,
 } from "../services/legion-chain";
 import { extractEvents } from "../routes/legion";
 import { BRIEF_STATUS, LEGION_GOV_CONTRACT } from "../lib/legion-constants";
@@ -114,6 +115,40 @@ describe("clarity decoder", () => {
   it("refuses to narrow an integer beyond the safe range", () => {
     const hex = `0x01${"10000000000000000000000000000000".padStart(32, "0")}`;
     expect(() => asNumber(decodeClarityHex(hex))).toThrow(ClarityDecodeError);
+  });
+});
+
+describe("deriveLegionPhase", () => {
+  // Now that phase is derived locally instead of read from get-phase, this
+  // must mirror the contract's branch-for-branch. Boundaries are the exact
+  // heights the contract compares against: voteEnd, voteEnd+veto, +conclude.
+  const open = { status: BRIEF_STATUS.OPEN, voteEnd: 4_049_166 };
+  const V = 12;
+  const C = 48;
+
+  it("returns none when there is no brief", () => {
+    expect(deriveLegionPhase(null, 9_999_999, V, C)).toBe("none");
+  });
+
+  it("is voting strictly before voteEnd", () => {
+    expect(deriveLegionPhase(open, open.voteEnd - 1, V, C)).toBe("voting");
+  });
+
+  it("enters veto exactly at voteEnd", () => {
+    expect(deriveLegionPhase(open, open.voteEnd, V, C)).toBe("veto");
+  });
+
+  it("enters concludable exactly at voteEnd + vetoWindow", () => {
+    expect(deriveLegionPhase(open, open.voteEnd + V, V, C)).toBe("concludable");
+  });
+
+  it("lapses exactly at voteEnd + vetoWindow + concludeWindow", () => {
+    expect(deriveLegionPhase(open, open.voteEnd + V + C, V, C)).toBe("lapsed");
+  });
+
+  it("honours a terminal status regardless of height", () => {
+    expect(deriveLegionPhase({ status: BRIEF_STATUS.PASSED, voteEnd: 0 }, 9e9, V, C)).toBe("passed");
+    expect(deriveLegionPhase({ status: BRIEF_STATUS.FAILED, voteEnd: 0 }, 9e9, V, C)).toBe("failed");
   });
 });
 

--- a/src/objects/legion-do.ts
+++ b/src/objects/legion-do.ts
@@ -77,27 +77,24 @@ export class LegionDO implements DurableObject {
    *
    * Idempotent by (txid, event_index) so a chainhook redelivery — which the
    * service will do on any non-2xx, and which also happens on replay — cannot
-   * duplicate a row. Returns how many rows were actually new so the caller can
-   * skip a cache purge when a redelivery changed nothing.
+   * duplicate a row. Returns how many rows were in the batch.
+   *
+   * Deliberately does NOT read to distinguish inserts from updates. An earlier
+   * version ran a COUNT(*) per event to skip a cache purge on a pure
+   * redelivery — a per-event read on the write path to optimise a rare case,
+   * exactly the kind of unnecessary rows_read the cost runbook warns against.
+   * ON CONFLICT DO UPDATE gives idempotency without it; a redelivery just costs
+   * one cache rebuild, which is edge-cached anyway.
    */
-  recordEvents(events: LegionEventRow[]): { inserted: number; total: number } {
-    if (events.length === 0) return { inserted: 0, total: 0 };
+  recordEvents(events: LegionEventRow[]): { total: number } {
+    if (events.length === 0) return { total: 0 };
 
-    let inserted = 0;
     const now = Date.now();
 
     // One transaction: a partial apply would leave the feed showing a vote
     // whose proposal is missing, which reads as data loss rather than lag.
     this.ctx.storage.transactionSync(() => {
       for (const e of events) {
-        const before = this.sql
-          .exec<{ n: number }>(
-            "SELECT COUNT(*) AS n FROM legion_events WHERE txid = ? AND event_index = ?",
-            e.txid,
-            e.event_index
-          )
-          .one().n;
-
         this.sql.exec(
           `INSERT INTO legion_events
              (txid, event_index, contract_id, block_height, block_time,
@@ -118,12 +115,10 @@ export class LegionDO implements DurableObject {
           JSON.stringify(e.data),
           now
         );
-
-        if (before === 0) inserted++;
       }
     });
 
-    return { inserted, total: events.length };
+    return { total: events.length };
   }
 
   /**
@@ -223,6 +218,7 @@ export class LegionDO implements DurableObject {
       .toArray()[0];
     return row?.h ?? null;
   }
+
 
   /** Router for worker→DO calls. Kept minimal; the worker owns HTTP concerns. */
   async fetch(request: Request): Promise<Response> {

--- a/src/objects/legion-schema.ts
+++ b/src/objects/legion-schema.ts
@@ -37,29 +37,4 @@ CREATE INDEX IF NOT EXISTS idx_legion_events_brief
 -- Global feed and the "what have we indexed through" watermark.
 CREATE INDEX IF NOT EXISTS idx_legion_events_height
   ON legion_events(contract_id, block_height DESC);
-
--- Singleton snapshot of read-only chain state, refreshed by the cron poller.
--- Holds the height-derived facts that emit no event and so can never arrive
--- over the chainhook: current tip, and the vote/veto window boundaries the
--- phase calculation compares against.
-CREATE TABLE IF NOT EXISTS legion_chain_state (
-  id               INTEGER PRIMARY KEY CHECK (id = 1),
-  tip_height       INTEGER NOT NULL,
-  brief_date       TEXT,
-  status           INTEGER,
-  vote_end         INTEGER,
-  yes_weight       INTEGER,
-  no_weight        INTEGER,
-  veto_weight      INTEGER,
-  voter_count      INTEGER,
-  entry_count      INTEGER,
-  total_signals    INTEGER,
-  total_weight     INTEGER,
-  treasury_balance INTEGER,
-  quote_draw       INTEGER,
-  next_propose_height INTEGER,
-  title            TEXT,
-  refreshed_at     INTEGER NOT NULL,
-  refresh_error    TEXT
-);
 `;

--- a/src/routes/legion.ts
+++ b/src/routes/legion.ts
@@ -9,10 +9,12 @@
  *   The webhook carries everything that *happened* — contributions, proposals,
  *   votes, vetoes, conclusions. Each is a transaction, so each emits an event.
  *
- *   The state endpoint additionally reads `get-phase`, because a week crosses
- *   from voting into its veto window, and from there into concludable, purely
- *   because blocks passed. No transaction, no event, nothing to push. Reading
- *   that per request is why there is no cron in this design.
+ *   The state endpoint adds only the chain tip, then derives the phase locally
+ *   (voting -> veto -> concludable -> lapsed) — those transitions fire because
+ *   blocks passed, with no transaction to push. Everything else it needs is
+ *   already in the indexed events or the cached params, so a page load is three
+ *   Hiro reads at most, and the edge cache (purged on webhook) caps even that
+ *   to once a minute.
  */
 
 import { Hono } from "hono";
@@ -26,10 +28,9 @@ import {
 import {
   getTipHeight,
   getBrief,
-  getBriefMeta,
-  getPhase,
   getParams,
   getPoolStats,
+  deriveLegionPhase,
   blocksRemaining,
   nextBoundaryHeight,
   predictOutcome,
@@ -262,7 +263,6 @@ legionRouter.post("/api/legion/chainhook", async (c) => {
   const rolled = rollbackTxids(payload.event?.rollback ?? []);
 
   const stub = getLegionStub(c.env);
-  let inserted = 0;
   let removed = 0;
 
   try {
@@ -274,11 +274,10 @@ legionRouter.post("/api/legion/chainhook", async (c) => {
       removed = ((await res.json()) as { removed: number }).removed;
     }
     if (applied.length > 0) {
-      const res = await stub.fetch("https://legion/record", {
+      await stub.fetch("https://legion/record", {
         method: "POST",
         body: JSON.stringify({ events: applied }),
       });
-      inserted = ((await res.json()) as { inserted: number }).inserted;
     }
   } catch (err) {
     // Return 500 so Chainhooks retries rather than dropping the delivery.
@@ -288,13 +287,12 @@ legionRouter.post("/api/legion/chainhook", async (c) => {
     return c.json({ error: "Failed to persist events" }, 500);
   }
 
-  // Only purge when something actually changed. A redelivery that inserts
-  // nothing should not evict a warm cache entry.
-  if (inserted > 0 || removed > 0) {
+  // Purge on any non-empty delivery. Distinguishing a genuine change from a
+  // redelivery would cost a read per event (see recordEvents) to save a rebuild
+  // that the edge cache makes cheap anyway — the wrong trade.
+  if (applied.length > 0 || removed > 0) {
     edgeCacheDelete(c, ["/api/legion/state"]);
-  }
-
-  if (applied.length === 0 && rolled.length === 0) {
+  } else {
     // Silent no-op deliveries are how a payload-shape mismatch hides: the
     // service records a healthy 200 while nothing is ever indexed.
     logger?.warn?.("[legion] chainhook delivery parsed to zero events", {
@@ -305,17 +303,24 @@ legionRouter.post("/api/legion/chainhook", async (c) => {
 
   logger?.info?.("[legion] chainhook processed", {
     applied: applied.length,
-    inserted,
     removed,
   });
 
-  return c.json({ ok: true, inserted, removed, received: applied.length });
+  return c.json({ ok: true, removed, received: applied.length });
 });
 
 // ── GET /api/legion/state ──
 
 legionRouter.get("/api/legion/state", async (c) => {
-  const cached = await edgeCacheMatch(c);
+  // Canonical cache key, so a query-string probe (?x=random) or any variant
+  // resolves to the same cached entry instead of bypassing the cache and
+  // forcing a fresh DO + Hiro rebuild — the pattern PR #706 fixed for
+  // /api/correspondents. The default (no week) key is the naked path, which is
+  // also what the webhook purges; an explicit ?week= gets its own entry.
+  const week = c.req.query("week");
+  const cacheKeyPath = week ? `/api/legion/state~${week}` : "/api/legion/state";
+
+  const cached = await edgeCacheMatch(c, { cacheKeyPath });
   if (cached) return cached;
 
   const logger = c.get("logger");
@@ -342,14 +347,34 @@ legionRouter.get("/api/legion/state", async (c) => {
     // than whichever week today happens to fall in.
     const briefDate = c.req.query("week") ?? indexed.latest_brief_date;
 
-    const [tipHeight, params, pool, brief, meta, phase] = await Promise.all([
+    // Three reads, down from nine. `getParams` is cached in-isolate after its
+    // first call, so the steady state is really tip + brief. Phase is derived
+    // locally (see below); the title rides in on the propose event, so
+    // get-phase and get-brief-meta are gone.
+    const [tipHeight, params, pool, brief] = await Promise.all([
       getTipHeight(opts),
       getParams(opts),
       getPoolStats(opts),
       briefDate ? getBrief(briefDate, opts) : Promise.resolve(null),
-      briefDate ? getBriefMeta(briefDate, opts) : Promise.resolve(null),
-      briefDate ? getPhase(briefDate, opts) : Promise.resolve("none" as const),
     ]);
+
+    // Phase is arithmetic on values we already have, not a contract call:
+    // brief.status/voteEnd against the tip and the window sizes. Mirrors the
+    // contract's get-phase branch-for-branch.
+    const phase = deriveLegionPhase(
+      brief,
+      tipHeight,
+      params.vetoWindow,
+      params.concludeWindow
+    );
+
+    // Title/description arrive in the propose-brief event, already indexed —
+    // so pull them from the feed rather than paying a get-brief-meta read.
+    const proposeEvent = indexed.events.find(
+      (e) => e.event === "propose-brief" && e.brief_date === briefDate
+    );
+    const title = (proposeEvent?.data?.title as string) ?? "";
+    const description = (proposeEvent?.data?.description as string) ?? "";
 
     // Predicted only while the outcome is still undecided. Once the contract
     // has written a terminal status, `reason` is the truth and a prediction
@@ -374,8 +399,8 @@ legionRouter.get("/api/legion/state", async (c) => {
       brief: brief
         ? {
             brief_date: brief.briefDate,
-            title: meta?.title ?? "",
-            description: meta?.description ?? "",
+            title,
+            description,
             status: brief.status,
             reason: brief.reason,
             created_at_height: brief.createdAt,
@@ -408,13 +433,15 @@ legionRouter.get("/api/legion/state", async (c) => {
       indexed_through: indexed.watermark,
     };
 
-    // Short TTL, and the webhook purges on write — so a new event shows up
-    // immediately rather than waiting out the TTL. The TTL only bounds how
-    // stale the *height-derived* phase can get, which nothing can purge
-    // because no event fires when a window elapses.
-    c.header("Cache-Control", "public, max-age=5, s-maxage=10");
+    // The edge cache IS the cache layer — free, unlike caching in the DO.
+    // s-maxage=60 means a page load rebuilds (and reads Hiro) at most once a
+    // minute no matter how many visitors; the webhook purges this key on every
+    // new event, so a vote or contribution still shows immediately. The 60s
+    // only bounds how stale the height-derived phase/countdown can get, and the
+    // browser ticks the countdown locally in between.
+    c.header("Cache-Control", "public, max-age=15, s-maxage=60");
     const response = c.json(payload);
-    edgeCachePut(c, response);
+    edgeCachePut(c, response, { cacheKeyPath });
     return response;
   } catch (err) {
     logger?.error?.("[legion] failed to build state", { err: String(err) });

--- a/src/services/legion-chain.ts
+++ b/src/services/legion-chain.ts
@@ -185,36 +185,32 @@ export async function getBriefMeta(
 }
 
 /**
- * Lifecycle phase, straight from the contract.
+ * Lifecycle phase, derived locally from the tip.
  *
- * v2 exposes `get-phase`, so this is read rather than derived. Deriving it
- * locally would mean re-implementing window arithmetic that the contract
- * already owns, and any drift between the two would show users a phase the
- * contract disagrees with.
+ * The contract exposes `get-phase`, but calling it would be a Hiro read on
+ * every page load for something that is pure arithmetic on values we already
+ * hold: the brief's `status` and `voteEnd` (both in the brief record) against
+ * the current tip and the window sizes (from params). This mirrors the
+ * contract's `get-phase` branch-for-branch, so it cannot drift — the same
+ * inputs produce the same answer, without the round trip.
  */
-export async function getPhase(
-  briefDate: string,
-  opts: ChainReadOptions = {}
-): Promise<LegionPhase> {
-  const raw = await callReadOnly(
-    LEGION_GOV_CONTRACT,
-    "get-phase",
-    [encodeStringAscii(briefDate)],
-    opts
-  );
-  const phase = raw.type === "string" ? raw.value : "none";
-  return (VALID_PHASES.has(phase) ? phase : "none") as LegionPhase;
-}
+export function deriveLegionPhase(
+  brief: Pick<BriefRecord, "status" | "voteEnd"> | null,
+  tipHeight: number,
+  vetoWindow: number,
+  concludeWindow: number
+): LegionPhase {
+  if (!brief) return "none";
+  if (brief.status === 1) return "passed"; // BRIEF_STATUS.PASSED
+  if (brief.status === 2) return "failed"; // BRIEF_STATUS.FAILED
 
-const VALID_PHASES = new Set([
-  "none",
-  "voting",
-  "veto",
-  "concludable",
-  "lapsed",
-  "passed",
-  "failed",
-]);
+  const vetoEnd = brief.voteEnd + vetoWindow;
+  const concludeEnd = vetoEnd + concludeWindow;
+  if (tipHeight < brief.voteEnd) return "voting";
+  if (tipHeight < vetoEnd) return "veto";
+  if (tipHeight < concludeEnd) return "concludable";
+  return "lapsed";
+}
 
 export interface LegionParams {
   votingQuorum: number;
@@ -238,10 +234,19 @@ export interface LegionParams {
  * drift from the deployed code. Everything downstream takes these as input
  * rather than importing constants.
  */
+/**
+ * Governance parameters are immutable for a given contract, so the first read
+ * in a Worker isolate is cached in memory for the isolate's life. This is a
+ * free cache — no storage, no billing — and it means the common page load pays
+ * zero Hiro calls for parameters. Keyed by contract so a redeploy re-reads.
+ */
+let cachedParams: { contract: string; params: LegionParams } | null = null;
+
 export async function getParams(opts: ChainReadOptions = {}): Promise<LegionParams> {
+  if (cachedParams?.contract === LEGION_GOV_CONTRACT) return cachedParams.params;
   const raw = await callReadOnly(LEGION_GOV_CONTRACT, "get-params", [], opts);
   const num = (k: string) => asNumber(tupleField(raw, k));
-  return {
+  const params: LegionParams = {
     votingQuorum: num("votingQuorum"),
     votingThreshold: num("votingThreshold"),
     vetoQuorum: num("vetoQuorum"),
@@ -255,6 +260,8 @@ export async function getParams(opts: ChainReadOptions = {}): Promise<LegionPara
     concludeWindow: num("concludeWindow"),
     proposeInterval: num("proposeInterval"),
   };
+  cachedParams = { contract: LEGION_GOV_CONTRACT, params };
+  return params;
 }
 
 /** Pool-level scalars, fetched together since the page shows them as a unit. */


### PR DESCRIPTION
Two things: bring the Legion read path in line with `docs/cloudflare-cost-runbook.md`, and rebuild the page as a card.

## Cost — audited against the runbook

The read path was doing three things the runbook (#700/#704/#706/#725) warns against. Fixed:

| Fix | Anti-pattern it removes |
|---|---|
| Params cached in-isolate, phase derived locally, title from the propose event → **9 Hiro reads down to 3** | redundant reads |
| **Canonical edge-cache key** (`cacheKeyPath`) so `?x=random` can't bypass the cache | #706 exactly |
| **Removed the per-event `COUNT(*)`** in `recordEvents` | reads on the write path the runbook warns against |
| `s-maxage` 10 → 60, webhook still purges | fewer rebuilds; vote still shows instantly |
| Deleted the unused `legion_chain_state` table | a cron that never shipped |

**Result:** read path ≈ **52 bounded/indexed DO rows read, 0 DO writes** — inside the runbook's 50–500/invocation good zone. Write path reads **0** rows. The edge cache is the only cache layer, and it's free; a DO-side cache would have paid for what the CDN gives free.

## UI

- One **card** — proposal identity, vote bar, quorum + threshold as meters with the pass line marked. Dropped the prose paragraphs, block-height timeline, and verbose failure copy.
- Named the **News Legion**, tied to the product, with a four-step how-it-works strip (contribute → propose → vote → conclude) so the model reads in seconds.
- Countdown ticks client-side every second; the page polls only every 20s.

## Tests

508 pass. New coverage for `deriveLegionPhase` (mirrors the contract's `get-phase` at every boundary) and the payload parser. Verified the full page render against the live `/api/legion/state`.

## Not in this PR

- Activity-feed principals still render as hex (`1a3b05…`) rather than `ST…`. Needs a c32check encoder — flagged, deliberately separate.
- In-page action buttons (contribute / conclude) need wallet-connect; out of scope. CTAs stay as links for now.