### PR TITLE
fix(legion): refresh actor and brief_date on event re-delivery

### DIFF
--- a/src/objects/legion-do.ts
+++ b/src/objects/legion-do.ts
@@ -103,6 +103,8 @@ export class LegionDO implements DurableObject {
            ON CONFLICT(txid, event_index) DO UPDATE SET
              block_height = excluded.block_height,
              block_time   = excluded.block_time,
+             brief_date   = excluded.brief_date,
+             actor        = excluded.actor,
              payload      = excluded.payload`,
           e.txid,
           e.event_index,


### PR DESCRIPTION
Small follow-up to #893. `recordEvents`' `ON CONFLICT` updated only `payload`, so replaying an event through the new c32 decoder healed `data.who` (in the payload) but left the denormalised `actor`/`brief_date` columns stale. Include them in the update so a replay fully re-indexes a row — needed to heal the principals stored as hex before #893.

510 tests pass.